### PR TITLE
chore: Release v29.2.5 - Logging spam reduction and first public repo release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [29.2.5] - 2026-04-27
+
+### Changed
+- **First release in the new public repository** - Smart! is now published as source-available code on GitHub at https://github.com/majormer/SmartFoundations. The source is available for community transparency, code review, and pull request contributions. See LICENSE.md for the full source-available license terms.
+
+### Fixed
+- **A massive amount of logging spam removed** - Smart! was generating over 500,000 log entries during normal gameplay from per-frame input diagnostics, hologram construction events, recipe service activity, and child hologram spawning during grid placement. These high-frequency logs have been moved to verbose logging, eliminating the log flood while keeping diagnostics available for troubleshooting.
+- **Extend no longer runs post-build wiring during world load** - Loading a save could make Smart! run Extend's post-build wiring checks against ordinary factory buildings before you had used Extend at all. This produced confusing Extend chain-fix messages during login and did unnecessary work on restored buildings. Extend post-build wiring now only runs when there is actual pending Extend build state to process.
+- **Scaled Extend pump wiring now follows the cloned topology** - When extending refinery or pump setups with multiple cloned groups, cloned pumps now connect to the power pole cloned with their own group instead of all later pumps incorrectly wiring back to the first cloned pole.
+
+---
+
 ## [29.2.4] - 2026-04-26
 
 ### Fixed

--- a/SmartFoundations.uplugin
+++ b/SmartFoundations.uplugin
@@ -2,7 +2,7 @@
 	"AcceptsAnyRemoteVersion": true,
 	"FileVersion": 3,
 	"Version": 29,
-	"VersionName": "29.2.4",
+	"VersionName": "29.2.5",
 	"FriendlyName": "Smart!",
 	"Description": "Advanced hologram control for precision building - Completely rebuilt for Satisfactory 1.1+",
 	"Category": "Modding",
@@ -30,7 +30,7 @@
 			"SemVersion": "^3.11.3"
 		}
 	],
-	"SemVersion": "29.2.4",
+	"SemVersion": "29.2.5",
 	"GameVersion": ">=416835",
 	"LocalizationTargets": [
 		{

--- a/Source/SmartFoundations/Private/Features/Extend/SFExtendService.cpp
+++ b/Source/SmartFoundations/Private/Features/Extend/SFExtendService.cpp
@@ -2,7 +2,7 @@
 
 /**
  * SFExtendService Implementation
- * 
+ *
  * See SFExtendService.h for architecture overview and documentation.
  */
 
@@ -72,23 +72,23 @@ USFExtendService::USFExtendService()
 void USFExtendService::Initialize(USFSubsystem* InSubsystem)
 {
     Subsystem = InSubsystem;
-    
+
     // Create and initialize detection service
     DetectionService = NewObject<USFExtendDetectionService>(this);
     DetectionService->Initialize(InSubsystem);
-    
+
     // Create and initialize topology service
     TopologyService = NewObject<USFExtendTopologyService>(this);
     TopologyService->Initialize(InSubsystem, DetectionService);
-    
+
     // Create and initialize hologram service
     HologramService = NewObject<USFExtendHologramService>(this);
     HologramService->Initialize(InSubsystem, this);
-    
+
     // Create and initialize wiring service
     WiringService = NewObject<USFExtendWiringService>(this);
     WiringService->Initialize(InSubsystem, this);
-    
+
     UE_LOG(LogSmartFoundations, Log, TEXT("Smart!: SFExtendService initialized (with DetectionService, TopologyService, HologramService, and WiringService)"));
 }
 
@@ -108,10 +108,10 @@ void USFExtendService::ClearExtendState()
             CurrentExtendHologram->LockHologramPosition(false);
             UE_LOG(LogSmartFoundations, Log, TEXT("🔄 EXTEND: Unlocked CurrentExtendHologram"));
         }
-        
+
         // Restore the original hologram (cleans up swapped hologram tracking)
         RestoreOriginalHologram();
-        
+
         // Also unlock whatever the subsystem considers the active hologram (belt & suspenders)
         if (Subsystem.IsValid())
         {
@@ -120,14 +120,14 @@ void USFExtendService::ClearExtendState()
                 Hologram->LockHologramPosition(false);
             }
         }
-        
+
         // CRITICAL: Clear extend flags BEFORE restoring counters.
         // UpdateCounterState triggers OnScaledExtendStateChanged when IsExtendModeActive() is true,
         // which calls RefreshExtension → repositions and re-locks the hologram.
         // By clearing flags first, the counter restore won't trigger extend state changes.
         bHasValidTarget = false;
         bExtendCommitted = false;
-        
+
         // Now safe to restore pre-Extend counter snapshot
         if (bHasCounterSnapshot && Subsystem.IsValid())
         {
@@ -137,7 +137,7 @@ void USFExtendService::ClearExtendState()
             Subsystem->UpdateCounterState(PreExtendCounterSnapshot);
             bHasCounterSnapshot = false;
         }
-        
+
         ClearScaledExtendClones();  // Issue #265: Clean up scaled extend clones first
         ClearBeltPreviews();  // CRITICAL: Clean up child holograms before state reset
         ClearTopology();
@@ -150,35 +150,35 @@ void USFExtendService::ClearExtendState()
 void USFExtendService::Shutdown()
 {
     ClearExtendState();
-    
+
     // Shutdown wiring service
     if (WiringService)
     {
         WiringService->Shutdown();
         WiringService = nullptr;
     }
-    
+
     // Shutdown hologram service
     if (HologramService)
     {
         HologramService->Shutdown();
         HologramService = nullptr;
     }
-    
+
     // Shutdown topology service
     if (TopologyService)
     {
         TopologyService->Shutdown();
         TopologyService = nullptr;
     }
-    
+
     // Shutdown detection service
     if (DetectionService)
     {
         DetectionService->Shutdown();
         DetectionService = nullptr;
     }
-    
+
     Subsystem.Reset();
     UE_LOG(LogSmartFoundations, Log, TEXT("Smart!: SFExtendService shutdown"));
 }
@@ -206,20 +206,20 @@ void USFExtendService::CycleExtendDirection(int32 Delta)
     // Get valid directions - only cycle if there's more than one option
     TArray<ESFExtendDirection> ValidDirs = GetValidDirections();
     ESFExtendDirection CurrentDir = DetectionService->GetExtendDirection();
-    
+
     if (ValidDirs.Num() == 0)
     {
         UE_LOG(LogSmartFoundations, Warning, TEXT(" EXTEND: No valid directions available - both sides blocked"));
         return;
     }
-    
+
     if (ValidDirs.Num() == 1)
     {
         // Only one valid direction - can't cycle, but ensure we're using it
         if (CurrentDir != ValidDirs[0])
         {
             DetectionService->SetExtendDirection(ValidDirs[0]);
-            UE_LOG(LogSmartFoundations, VeryVerbose, TEXT(" EXTEND: Only one valid direction, using %s"), 
+            UE_LOG(LogSmartFoundations, VeryVerbose, TEXT(" EXTEND: Only one valid direction, using %s"),
                 ValidDirs[0] == ESFExtendDirection::Right ? TEXT("Right") : TEXT("Left"));
         }
         else
@@ -232,10 +232,10 @@ void USFExtendService::CycleExtendDirection(int32 Delta)
 
     // Toggle between Right and Left (only two valid directions for manifold alignment)
     // Forward/Backward would block input/output connectors
-    ESFExtendDirection NewDirection = (CurrentDir == ESFExtendDirection::Right) 
-        ? ESFExtendDirection::Left 
+    ESFExtendDirection NewDirection = (CurrentDir == ESFExtendDirection::Right)
+        ? ESFExtendDirection::Left
         : ESFExtendDirection::Right;
-    
+
     // Verify the new direction is valid
     if (!IsDirectionValid(NewDirection))
     {
@@ -243,17 +243,17 @@ void USFExtendService::CycleExtendDirection(int32 Delta)
             NewDirection == ESFExtendDirection::Right ? TEXT("Right") : TEXT("Left"));
         return;
     }
-    
+
     DetectionService->SetExtendDirection(NewDirection);
 
-    UE_LOG(LogSmartFoundations, VeryVerbose, TEXT(" EXTEND: Direction changed to %s"), 
+    UE_LOG(LogSmartFoundations, VeryVerbose, TEXT(" EXTEND: Direction changed to %s"),
         NewDirection == ESFExtendDirection::Right ? TEXT("Right") : TEXT("Left"));
 
     // Immediately refresh hologram position with new direction
     if (CurrentExtendHologram.IsValid())
     {
         RefreshExtension(CurrentExtendHologram.Get());
-        
+
         // CRITICAL: Recreate belt previews at new offset after direction change
         // CreateBeltPreviews clears ALL pending builds and costs at the start,
         // ensuring a fresh calculation from the base recipe.
@@ -267,7 +267,7 @@ FVector USFExtendService::GetDirectionOffset(const FVector& BuildingSize, const 
     // Buildings have input/output on Y axis, so sides are on X axis
     // This maintains manifold alignment - Y offset would block connectors
     FVector LocalOffset = FVector::ZeroVector;
-    
+
     ESFExtendDirection CurrentDir = DetectionService ? DetectionService->GetExtendDirection() : ESFExtendDirection::Right;
 
     switch (CurrentDir)
@@ -327,11 +327,11 @@ bool USFExtendService::IsDirectionValid(ESFExtendDirection Direction) const
     // Use a box overlap to check if there's a building at the target position
     // Use slightly smaller box to avoid false positives from adjacent buildings
     FVector HalfExtent = BuildingSize * 0.4f; // 80% of building size, centered
-    
+
     TArray<FOverlapResult> Overlaps;
     FCollisionQueryParams QueryParams;
     QueryParams.AddIgnoredActor(SourceBuilding);
-    
+
     // Check for factory buildings at target position
     bool bHasOverlap = World->OverlapMultiByChannel(
         Overlaps,
@@ -366,7 +366,7 @@ bool USFExtendService::IsDirectionValid(ESFExtendDirection Direction) const
 TArray<ESFExtendDirection> USFExtendService::GetValidDirections() const
 {
     TArray<ESFExtendDirection> ValidDirections;
-    
+
     if (IsDirectionValid(ESFExtendDirection::Right))
     {
         ValidDirections.Add(ESFExtendDirection::Right);
@@ -375,7 +375,7 @@ TArray<ESFExtendDirection> USFExtendService::GetValidDirections() const
     {
         ValidDirections.Add(ESFExtendDirection::Left);
     }
-    
+
     return ValidDirections;
 }
 
@@ -387,7 +387,7 @@ bool USFExtendService::WalkTopology(AFGBuildable* SourceBuilding)
     {
         return TopologyService->WalkTopology(SourceBuilding);
     }
-    
+
     UE_LOG(LogSmartFoundations, Warning, TEXT("Smart!: WalkTopology called but TopologyService not initialized"));
     return false;
 }
@@ -398,7 +398,7 @@ const FSFExtendTopology& USFExtendService::GetCurrentTopology() const
     {
         return TopologyService->GetCurrentTopology();
     }
-    
+
     // Return empty topology if service not initialized
     static FSFExtendTopology EmptyTopology;
     return EmptyTopology;
@@ -419,7 +419,7 @@ bool USFExtendService::IsValidExtendTarget(AFGBuildable* Building) const
     {
         return DetectionService->IsValidExtendTarget(Building);
     }
-    
+
     // Fallback if detection service not initialized
     if (!IsValid(Building))
     {
@@ -486,7 +486,7 @@ bool USFExtendService::TryExtendFromBuilding(AFGBuildable* HitBuilding, AFGHolog
             && SourceHologram->GetBuildClass()
             && HitBuilding->IsA(SourceHologram->GetBuildClass())
             && IsValidExtendTarget(HitBuilding);
-        
+
         if (!bStillValid)
         {
             if (bExtendCommitted)
@@ -514,13 +514,13 @@ bool USFExtendService::TryExtendFromBuilding(AFGBuildable* HitBuilding, AFGHolog
         {
             return false;
         }
-        
+
         UClass* HologramBuildClass = SourceHologram->GetBuildClass();
         if (!HologramBuildClass || !HitBuilding->IsA(HologramBuildClass))
         {
             return false;
         }
-        
+
         if (!IsValidExtendTarget(HitBuilding))
         {
             return false;
@@ -539,38 +539,38 @@ bool USFExtendService::TryExtendFromBuilding(AFGBuildable* HitBuilding, AFGHolog
         }
         return true;
     }
-    
+
     // Check if we're already extending from this building
     if (CurrentExtendTarget.IsValid() && CurrentExtendTarget.Get() == HitBuilding)
     {
         // Check if the hologram changed (build gun recreated it)
         bool bHologramChanged = !CurrentExtendHologram.IsValid() || CurrentExtendHologram.Get() != SourceHologram;
-        
+
         if (bHologramChanged)
         {
             // Hologram changed (likely after a build) - clean up and reset EXTEND state
             // User must re-aim at target to reactivate EXTEND
             UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("🔄 EXTEND: Hologram changed (build completed?) - resetting EXTEND state"));
-            
+
             // CRITICAL: Remember which building we just built from to prevent immediate re-activation
             // User must look away first before extending from the same building again
             LastBuiltFromBuilding = HitBuilding;
-            
+
             // CRITICAL: Destroy old children - they are NOT auto-destroyed with parent
             // because we don't add them via AddChild() (to prevent Construct crash)
             ClearBeltPreviews();
-            
+
             // Reset EXTEND state - don't automatically recreate belt previews
             // This ensures cleanup after a build
             CurrentExtendTarget.Reset();
             CurrentExtendHologram.Reset();
             bHasValidTarget = false;
-            
+
             // Don't return true here - let the code fall through to try re-activating
             // if the user is still pointing at a valid target on the NEXT frame
             return false;
         }
-        
+
         // Already set up, just refresh position
         static double LastRefreshLog = 0;
         double RefreshNow = FPlatformTime::Seconds();
@@ -579,7 +579,7 @@ bool USFExtendService::TryExtendFromBuilding(AFGBuildable* HitBuilding, AFGHolog
             UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("🔄 EXTEND: Already extending from %s, refreshing"), *HitBuilding->GetName());
             LastRefreshLog = RefreshNow;
         }
-        
+
         RefreshExtension(SourceHologram);
         return true;
     }
@@ -592,7 +592,7 @@ bool USFExtendService::TryExtendFromBuilding(AFGBuildable* HitBuilding, AFGHolog
         // This prevents stale preview holograms from appearing immediately after a build
         return false;
     }
-    
+
     // User is pointing at a different building - clear the cooldown
     if (LastBuiltFromBuilding.IsValid() && LastBuiltFromBuilding.Get() != HitBuilding)
     {
@@ -602,10 +602,10 @@ bool USFExtendService::TryExtendFromBuilding(AFGBuildable* HitBuilding, AFGHolog
 
     // New target - walk topology
     UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("🔄 EXTEND: Checks passed! Walking topology for %s"), *HitBuilding->GetName());
-    
+
     // NOTE: Orphaned pending builds will be cleared at the start of CreateBeltPreviews().
     // No need to clear here - the flow is: WalkTopology → CreateBeltPreviews (clears all → spawns new).
-    
+
     if (!WalkTopology(HitBuilding))
     {
         // Debug: Log topology walk failure
@@ -613,7 +613,7 @@ bool USFExtendService::TryExtendFromBuilding(AFGBuildable* HitBuilding, AFGHolog
         double Now = FPlatformTime::Seconds();
         if (Now - LastTopoLog > 2.0)
         {
-            UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("🔄 EXTEND: No valid topology found for %s (no belts/distributors connected?)"), 
+            UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("🔄 EXTEND: No valid topology found for %s (no belts/distributors connected?)"),
                 *HitBuilding->GetName());
             LastTopoLog = Now;
         }
@@ -623,7 +623,7 @@ bool USFExtendService::TryExtendFromBuilding(AFGBuildable* HitBuilding, AFGHolog
     CurrentExtendTarget = HitBuilding;
     bHasValidTarget = true;  // EXTEND is now active!
     bExtendCommitted = false;  // Not committed until first scale action (allows middle-click sampling)
-    
+
     // Snapshot the current grid counters so we can restore them when Extend deactivates.
     // This prevents normal scaling from inheriting Extend's counter values (X=3, spacing=200, etc.)
     if (!bHasCounterSnapshot && Subsystem.IsValid())
@@ -645,7 +645,7 @@ bool USFExtendService::TryExtendFromBuilding(AFGBuildable* HitBuilding, AFGHolog
         bHasValidTarget = false;
         return false;
     }
-    
+
     // If current direction is not valid, switch to a valid one
     ESFExtendDirection CurrentDir = DetectionService ? DetectionService->GetExtendDirection() : ESFExtendDirection::Right;
     if (!ValidDirs.Contains(CurrentDir))
@@ -659,7 +659,7 @@ bool USFExtendService::TryExtendFromBuilding(AFGBuildable* HitBuilding, AFGHolog
             CurrentDir == ESFExtendDirection::Right ? TEXT("Right") : TEXT("Left"));
     }
 
-    UE_LOG(LogSmartFoundations, Display, TEXT("🔄 EXTEND: ✅ ACTIVATED - pointing at %s (direction: %s, valid dirs: %d)"), 
+    UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("🔄 EXTEND: ✅ ACTIVATED - pointing at %s (direction: %s, valid dirs: %d)"),
         *HitBuilding->GetName(),
         CurrentDir == ESFExtendDirection::Right ? TEXT("Right") : TEXT("Left"),
         ValidDirs.Num());
@@ -676,7 +676,7 @@ bool USFExtendService::TryExtendFromBuilding(AFGBuildable* HitBuilding, AFGHolog
         ActiveHologram = SourceHologram;
         UE_LOG(LogSmartFoundations, Warning, TEXT("🔄 EXTEND: Hologram swap failed, using vanilla hologram"));
     }
-    
+
     // Track which hologram we've set up for EXTEND
     CurrentExtendHologram = ActiveHologram;
 
@@ -699,12 +699,12 @@ bool USFExtendService::TryExtendFromBuilding(AFGBuildable* HitBuilding, AFGHolog
 
     // Position the hologram at the offset location
     FVector NewLocation = SourceLocation + Offset;
-    
+
     // Use SetActorLocation directly - our custom hologram blocks SetHologramLocationAndRotation
     // from the build gun when EXTEND is active, so we can position freely
     ActiveHologram->SetActorLocation(NewLocation);
     ActiveHologram->SetActorRotation(SourceRotation);
-    
+
     // CRITICAL: Toggle lock to force validity recheck after repositioning
     // Without this, the hologram shows as invalid (red) because validity was cached at old position
     ActiveHologram->LockHologramPosition(false);
@@ -750,7 +750,7 @@ void USFExtendService::RefreshExtension(AFGHologram* SourceHologram, bool bForce
     {
         ActiveHologram = SourceHologram;
     }
-    
+
     if (!IsValid(ActiveHologram))
     {
         return;
@@ -769,7 +769,7 @@ void USFExtendService::RefreshExtension(AFGHologram* SourceHologram, bool bForce
 
     // Calculate offset based on current direction
     FVector Offset = GetDirectionOffset(BuildingSize, SourceRotation);
-    
+
     // Issue #265: Apply spacing, steps, and rotation to clone 1 (parent hologram) when extend is active
     FRotator Clone1Rotation = SourceRotation;  // Default: same rotation as source
     if (Subsystem.IsValid())
@@ -777,20 +777,20 @@ void USFExtendService::RefreshExtension(AFGHologram* SourceHologram, bool bForce
         const FSFCounterState& State = Subsystem->GetCounterState();
         ESFExtendDirection CurrentDir = DetectionService ? DetectionService->GetExtendDirection() : ESFExtendDirection::Right;
         float DirSign = (CurrentDir == ESFExtendDirection::Right) ? 1.0f : -1.0f;
-        
+
         bool bRotationActive = !FMath::IsNearlyZero(State.RotationZ);
-        
+
         if (bRotationActive)
         {
             // Arc/radial placement for clone 1 (CloneIndex=1)
             float ArcLength = BuildingSize.X + static_cast<float>(State.SpacingX);
             float StepRadians = FMath::Abs(FMath::DegreesToRadians(State.RotationZ));
             float Radius = (StepRadians > KINDA_SMALL_NUMBER) ? ArcLength / StepRadians : 0.0f;
-            
+
             float AngleDeg = State.RotationZ;  // CloneIndex=1 → 1 * RotationZ
             float AngleRad = FMath::DegreesToRadians(AngleDeg);
             float SignRotation = (State.RotationZ >= 0.0f) ? 1.0f : -1.0f;
-            
+
             // Arc position in local space — matches CalculateRotationOffset pattern:
             //   X = SignX * R * Sin(|θ|)              (direction determines forward/backward)
             //   Y = SignRotation * (R - R*Cos(|θ|))   (NO direction sign — canonical)
@@ -799,7 +799,7 @@ void USFExtendService::RefreshExtension(AFGHologram* SourceHologram, bool bForce
             ArcLocal.X = DirSign * Radius * FMath::Sin(FMath::Abs(AngleRad));
             ArcLocal.Y = SignRotation * (Radius - Radius * FMath::Cos(FMath::Abs(AngleRad)));
             ArcLocal.Z = static_cast<float>(State.StepsX);
-            
+
             Offset = SourceRotation.RotateVector(ArcLocal);
             Clone1Rotation = SourceRotation + FRotator(0.0f, AngleDeg * DirSign, 0.0f);
         }
@@ -814,7 +814,7 @@ void USFExtendService::RefreshExtension(AFGHologram* SourceHologram, bool bForce
 
     // Update hologram position
     FVector NewLocation = SourceLocation + Offset;
-    
+
     // CRITICAL: Do a line trace down to find the floor and create a valid hit result
     // Without this, the hologram's internal hit data is stale and CheckValidPlacement fails
     // with "Surface is too uneven" because it has no valid floor normal
@@ -824,25 +824,25 @@ void USFExtendService::RefreshExtension(AFGHologram* SourceHologram, bool bForce
     FCollisionQueryParams QueryParams;
     QueryParams.AddIgnoredActor(ActiveHologram);
     QueryParams.AddIgnoredActor(HitBuilding);
-    
+
     if (GetWorld()->LineTraceSingleByChannel(FloorHit, TraceStart, TraceEnd, ECC_Visibility, QueryParams))
     {
         // Found floor - call SetHologramLocationAndRotation with valid hit result
         // This updates the hologram's internal mIsValidHitResult and floor normal
         ActiveHologram->SetHologramLocationAndRotation(FloorHit);
     }
-    
+
     // CRITICAL: Ensure hologram stays locked
     if (!ActiveHologram->IsHologramLocked())
     {
         ActiveHologram->LockHologramPosition(true);
     }
-    
+
     // For our custom hologram, SetHologramLocationAndRotation is blocked when EXTEND is active
     // So we position directly with SetActorLocation - the build gun can't override because our override blocks it
     ActiveHologram->SetActorLocation(NewLocation);
     ActiveHologram->SetActorRotation(Clone1Rotation);
-    
+
     // Also update root component to ensure mesh moves
     if (USceneComponent* Root = ActiveHologram->GetRootComponent())
     {
@@ -850,10 +850,10 @@ void USFExtendService::RefreshExtension(AFGHologram* SourceHologram, bool bForce
         Root->SetWorldRotation(Clone1Rotation);
         Root->MarkRenderStateDirty();
     }
-    
+
     // Force hologram to be visible
     ActiveHologram->SetActorHiddenInGame(false);
-    
+
     // Force parent hologram to valid/invalid state based on scaled extend validation.
     // Our ASFFactoryHologram::CheckValidPlacement override skips vanilla's clearance
     // checks during extend mode, so no encroachment disqualifiers get added.
@@ -867,17 +867,17 @@ void USFExtendService::RefreshExtension(AFGHologram* SourceHologram, bool bForce
         ActiveHologram->ResetConstructDisqualifiers();
         ActiveHologram->SetPlacementMaterialState(EHologramMaterialState::HMS_OK);
     }
-    
+
     // CRITICAL: Force child holograms back to their intended positions every frame
     // The engine's parent hologram tick resets children to origin via SetHologramLocationAndRotation
     // We counteract this by forcing them back to where we want them
-    
+
     // Delegate basic position/rotation refresh to HologramService
     if (HologramService)
     {
         HologramService->RefreshChildPositions();
     }
-    
+
     // Additional material handling for Smart! hologram types
     for (AFGHologram* Child : BeltPreviewHolograms)
     {
@@ -897,12 +897,12 @@ void USFExtendService::RefreshExtension(AFGHologram* SourceHologram, bool bForce
             {
                 PipeChild->ForceApplyHologramMaterial();
             }
-            
+
             // Disable tick to prevent engine's CheckValidPlacement from overriding our material state
             Child->SetActorTickEnabled(false);
         }
     }
-    
+
     // Debug: Verify position (throttled)
     static double LastRefreshPosLog = 0;
     double Now = FPlatformTime::Seconds();
@@ -910,7 +910,7 @@ void USFExtendService::RefreshExtension(AFGHologram* SourceHologram, bool bForce
     {
         FVector ActualPos = ActiveHologram->GetActorLocation();
         FVector ActorScale = ActiveHologram->GetActorScale3D();
-        
+
         // Check mesh component positions and visibility
         TArray<UMeshComponent*> MeshComps;
         ActiveHologram->GetComponents(MeshComps);
@@ -920,7 +920,7 @@ void USFExtendService::RefreshExtension(AFGHologram* SourceHologram, bool bForce
         bool bHiddenInGame = true;
         int32 MatCount = 0;
         FString MatName = TEXT("none");
-        
+
         if (MeshComps.Num() > 0 && MeshComps[0])
         {
             MeshWorldPos = MeshComps[0]->GetComponentLocation();
@@ -933,14 +933,14 @@ void USFExtendService::RefreshExtension(AFGHologram* SourceHologram, bool bForce
                 MatName = MeshComps[0]->GetMaterial(0)->GetName();
             }
         }
-        
+
         UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("🔄 EXTEND: Pos=(%.0f,%.0f,%.0f) Scale=%.2f Visible=%d Hidden=%d Mat=%s"),
             MeshWorldPos.X, MeshWorldPos.Y, MeshWorldPos.Z,
             MeshScale.X,
             bCompVisible ? 1 : 0,
             bHiddenInGame ? 1 : 0,
             *MatName);
-        
+
         // Track child hologram positions and refresh belt materials
         for (int32 i = 0; i < BeltPreviewHolograms.Num(); ++i)
         {
@@ -954,18 +954,18 @@ void USFExtendService::RefreshExtension(AFGHologram* SourceHologram, bool bForce
                     // Force material state back to OK and re-apply to spline meshes
                     BeltChild->SetPlacementMaterialState(EHologramMaterialState::HMS_OK);
                     BeltChild->ForceApplyHologramMaterial();
-                    
+
                     // Ensure visibility
                     BeltChild->SetActorHiddenInGame(false);
                     TArray<USplineMeshComponent*> SplineMeshComps;
                     BeltChild->GetComponents<USplineMeshComponent>(SplineMeshComps);
-                    
+
                     // Log spline mesh state for debugging (only first belt, every 2 seconds)
                     static double LastBeltMeshLog = 0;
                     if (i == 1 && Now - LastBeltMeshLog > 2.0)  // Child[1] is first belt
                     {
                         LastBeltMeshLog = Now;
-                        UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("🎯 BELT REFRESH: %s has %d SplineMeshComponents"), 
+                        UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("🎯 BELT REFRESH: %s has %d SplineMeshComponents"),
                             *BeltChild->GetName(), SplineMeshComps.Num());
                         for (int32 SMIdx = 0; SMIdx < SplineMeshComps.Num() && SMIdx < 2; SMIdx++)
                         {
@@ -977,14 +977,14 @@ void USFExtendService::RefreshExtension(AFGHologram* SourceHologram, bool bForce
                                 *SMC->GetComponentLocation().ToString());
                         }
                     }
-                    
+
                     for (USplineMeshComponent* SMC : SplineMeshComps)
                     {
                         SMC->SetVisibility(true, true);
                         SMC->SetHiddenInGame(false);
                     }
                 }
-                
+
                 UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("🔄 EXTEND Child[%d]: Pos=%s Hidden=%d MatState=%d"),
                     i, *Child->GetActorLocation().ToString(),
                     Child->IsHidden() ? 1 : 0,
@@ -995,16 +995,16 @@ void USFExtendService::RefreshExtension(AFGHologram* SourceHologram, bool bForce
                 UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("🔄 EXTEND Child[%d]: INVALID/DESTROYED"), i);
             }
         }
-        
+
         LastRefreshPosLog = Now;
     }
 }
 
 void USFExtendService::CleanupExtension(AFGHologram* SourceHologram)
 {
-    UE_LOG(LogSmartFoundations, Log, TEXT("🔧 EXTEND: CleanupExtension called for %s"), 
+    UE_LOG(LogSmartFoundations, Log, TEXT("🔧 EXTEND: CleanupExtension called for %s"),
         SourceHologram ? *SourceHologram->GetName() : TEXT("nullptr"));
-    
+
     // Restore pre-Extend counter snapshot so normal scaling isn't polluted
     if (bHasCounterSnapshot && Subsystem.IsValid())
     {
@@ -1014,35 +1014,35 @@ void USFExtendService::CleanupExtension(AFGHologram* SourceHologram)
         Subsystem->UpdateCounterState(PreExtendCounterSnapshot);
         bHasCounterSnapshot = false;
     }
-    
+
     // Clear visual preview holograms (always)
     ClearScaledExtendClones();  // Issue #265: Clean up scaled extend clones
     ClearBeltPreviews();
-    
+
     // NOTE: Do NOT clear pending belt builds here!
     // When user BUILDS, OnActorSpawned defers belt construction to next tick.
     // CleanupExtension is called BEFORE that deferred tick executes.
     // BuildPendingBelts() will clear them after building.
     // If user CANCELS (no factory spawned), the pending builds will be orphaned
     // but harmless - they'll be cleared on next EXTEND activation.
-    
+
     // CRITICAL: Set LastBuiltFromBuilding BEFORE resetting CurrentExtendTarget
     // This prevents immediate re-activation if user is still pointing at the same building
     if (CurrentExtendTarget.IsValid())
     {
         LastBuiltFromBuilding = CurrentExtendTarget.Get();
-        UE_LOG(LogSmartFoundations, Log, TEXT("🔧 EXTEND: Set cooldown on %s to prevent immediate re-activation"), 
+        UE_LOG(LogSmartFoundations, Log, TEXT("🔧 EXTEND: Set cooldown on %s to prevent immediate re-activation"),
             *CurrentExtendTarget->GetName());
     }
-    
+
     CurrentExtendTarget.Reset();
     CurrentExtendHologram.Reset();
     ClearTopology();
-    
+
     // CRITICAL: Reset state flags so next build doesn't try to extend from same location
     bHasValidTarget = false;
     bExtendCommitted = false;
-    
+
     UE_LOG(LogSmartFoundations, Log, TEXT("🔧 EXTEND: State fully cleared (bHasValidTarget=false, pending belts preserved for deferred build)"));
 }
 
@@ -1052,23 +1052,23 @@ void USFExtendService::CheckAndPerformFinalCleanup()
     {
         return;
     }
-    
+
     UE_LOG(LogSmartFoundations, Log, TEXT("🔧 EXTEND: Performing final cleanup (build gun left build mode)"));
-    
+
     // Force destroy any remaining preview holograms
     ClearScaledExtendClones();  // Issue #265: Clean up scaled extend clones
     ClearBeltPreviews();
-    
+
     // Reset all state
     CurrentExtendTarget.Reset();
     CurrentExtendHologram.Reset();
     ClearTopology();
     bHasValidTarget = false;
     LastBuiltFromBuilding.Reset();
-    
+
     // Clear the flag
     bNeedsFinalCleanup = false;
-    
+
     UE_LOG(LogSmartFoundations, Log, TEXT("🔧 EXTEND: Final cleanup complete"));
 }
 
@@ -1080,26 +1080,26 @@ AFGBuildGun* USFExtendService::GetPlayerBuildGun() const
     {
         return nullptr;
     }
-    
+
     UWorld* World = Subsystem->GetWorld();
     if (!World)
     {
         return nullptr;
     }
-    
+
     // Get the local player controller
     APlayerController* PC = UGameplayStatics::GetPlayerController(World, 0);
     if (!PC)
     {
         return nullptr;
     }
-    
+
     AFGCharacterPlayer* Character = Cast<AFGCharacterPlayer>(PC->GetPawn());
     if (!Character)
     {
         return nullptr;
     }
-    
+
     // Get the build gun from the character's equipment
     // The build gun is stored as the active equipment when in build mode
     return Character->GetBuildGun();
@@ -1111,7 +1111,7 @@ UFGBuildGunStateBuild* USFExtendService::GetBuildGunBuildState(AFGBuildGun* Buil
     {
         return nullptr;
     }
-    
+
     // Get the build state from the build gun
     return Cast<UFGBuildGunStateBuild>(BuildGun->GetBuildGunStateFor(EBuildGunState::BGS_BUILD));
 }
@@ -1123,16 +1123,16 @@ ASFFactoryHologram* USFExtendService::SwapToSmartFactoryHologram(AFGHologram* Va
         UE_LOG(LogSmartFoundations, Warning, TEXT("🔄 EXTEND SWAP: Invalid vanilla hologram"));
         return nullptr;
     }
-    
+
     // Only swap factory holograms
     AFGFactoryHologram* FactoryHolo = Cast<AFGFactoryHologram>(VanillaHologram);
     if (!FactoryHolo)
     {
-        UE_LOG(LogSmartFoundations, Warning, TEXT("🔄 EXTEND SWAP: Not a factory hologram - %s"), 
+        UE_LOG(LogSmartFoundations, Warning, TEXT("🔄 EXTEND SWAP: Not a factory hologram - %s"),
             *VanillaHologram->GetClass()->GetName());
         return nullptr;
     }
-    
+
     // Get the build gun and its build state
     AFGBuildGun* BuildGun = GetPlayerBuildGun();
     if (!BuildGun)
@@ -1140,14 +1140,14 @@ ASFFactoryHologram* USFExtendService::SwapToSmartFactoryHologram(AFGHologram* Va
         UE_LOG(LogSmartFoundations, Warning, TEXT("🔄 EXTEND SWAP: Could not get build gun"));
         return nullptr;
     }
-    
+
     UFGBuildGunStateBuild* BuildState = GetBuildGunBuildState(BuildGun);
     if (!BuildState)
     {
         UE_LOG(LogSmartFoundations, Warning, TEXT("🔄 EXTEND SWAP: Could not get build state"));
         return nullptr;
     }
-    
+
     // Get world for spawning
     UWorld* World = VanillaHologram->GetWorld();
     if (!World)
@@ -1155,14 +1155,14 @@ ASFFactoryHologram* USFExtendService::SwapToSmartFactoryHologram(AFGHologram* Va
         UE_LOG(LogSmartFoundations, Warning, TEXT("🔄 EXTEND SWAP: No world"));
         return nullptr;
     }
-    
+
     // Verify the vanilla hologram has a build class
     if (!VanillaHologram->GetBuildClass())
     {
         UE_LOG(LogSmartFoundations, Error, TEXT("🔄 EXTEND SWAP: Vanilla hologram has no BuildClass"));
         return nullptr;
     }
-    
+
     // Use SpawnActorDeferred so we can initialize BEFORE BeginPlay is called
     ASFFactoryHologram* CustomHologram = World->SpawnActorDeferred<ASFFactoryHologram>(
         ASFFactoryHologram::StaticClass(),
@@ -1171,17 +1171,17 @@ ASFFactoryHologram* USFExtendService::SwapToSmartFactoryHologram(AFGHologram* Va
         nullptr,
         ESpawnActorCollisionHandlingMethod::AlwaysSpawn
     );
-    
+
     if (!CustomHologram)
     {
         UE_LOG(LogSmartFoundations, Error, TEXT("🔄 EXTEND SWAP: Failed to spawn deferred custom hologram"));
         return nullptr;
     }
-    
+
     // CRITICAL: Initialize from the vanilla hologram BEFORE BeginPlay
     // This copies mBuildClass, mRecipe, etc. which are required for BeginPlay
     CustomHologram->InitializeFromHologram(VanillaHologram);
-    
+
     // Copy mConstructionInstigator (private) via reflection — needed for build FX
     FProperty* InstigatorProp = AFGHologram::StaticClass()->FindPropertyByName(TEXT("mConstructionInstigator"));
     if (InstigatorProp)
@@ -1191,10 +1191,10 @@ ASFFactoryHologram* USFExtendService::SwapToSmartFactoryHologram(AFGHologram* Va
             InstigatorProp->ContainerPtrToValuePtr<void>(VanillaHologram)
         );
     }
-    
+
     // Now finish spawning - this will call BeginPlay with mBuildClass properly set
     CustomHologram->FinishSpawning(FTransform(VanillaHologram->GetActorRotation(), VanillaHologram->GetActorLocation()));
-    
+
     // The build state has mHologram as a UPROPERTY - use reflection to set it
     // This is the key: we replace the build gun's hologram pointer with our custom one
     FProperty* HologramProp = BuildState->GetClass()->FindPropertyByName(TEXT("mHologram"));
@@ -1218,16 +1218,16 @@ ASFFactoryHologram* USFExtendService::SwapToSmartFactoryHologram(AFGHologram* Va
         CustomHologram->Destroy();
         return nullptr;
     }
-    
+
     // Destroy the vanilla hologram
     VanillaHologram->Destroy();
-    
+
     // Track the swap (both locally and in HologramService for future migration)
     SwappedHologram = CustomHologram;
     bHasSwappedHologram = true;
-    
+
     UE_LOG(LogSmartFoundations, Log, TEXT("🔄 EXTEND SWAP: ✅ Successfully swapped to ASFFactoryHologram"));
-    
+
     return CustomHologram;
 }
 
@@ -1237,26 +1237,26 @@ void USFExtendService::RestoreOriginalHologram()
     {
         return;
     }
-    
+
     // We don't actually need to restore - the build gun will spawn a new hologram
     // when the recipe is re-selected or the state changes.
     // Just clean up our tracking.
-    
+
     if (SwappedHologram.IsValid())
     {
         // Unlock the hologram before cleanup
         SwappedHologram->LockHologramPosition(false);
     }
-    
+
     SwappedHologram.Reset();
     bHasSwappedHologram = false;
-    
+
     // Also restore in HologramService
     if (HologramService)
     {
         HologramService->RestoreOriginalHologram();
     }
-    
+
     UE_LOG(LogSmartFoundations, Log, TEXT("🔄 EXTEND SWAP: Hologram swap state cleared"));
 }
 
@@ -1280,11 +1280,11 @@ void USFExtendService::CreateBeltPreviews(AFGHologram* ParentHologram)
     {
         HologramService->SetCurrentParentHologram(ParentHologram);
         HologramService->CreateBeltPreviews(ParentHologram);
-        
+
         // Copy references for backwards compatibility with existing code
         StoredCloneTopology = HologramService->GetStoredCloneTopology();
         JsonSpawnedHolograms = HologramService->GetJsonSpawnedHolograms();
-        
+
         // Issue #288: Validate cloned power pole capacity for pump wiring. Runs
         // for the single-clone Extend preview; the scaled-extend path re-runs
         // this check at line ~6308 AND'd with lane validation.
@@ -1293,7 +1293,7 @@ void USFExtendService::CreateBeltPreviews(AFGHologram* ParentHologram)
         {
             CurrentExtendHologram->SetPlacementMaterialState(EHologramMaterialState::HMS_ERROR);
         }
-        
+
         // Issue #229: Populate power pole wiring data from cached topology
         PowerPoleWiringData.Empty();
         if (TopologyService && TopologyService->HasValidTopology())
@@ -1311,13 +1311,13 @@ void USFExtendService::CreateBeltPreviews(AFGHologram* ParentHologram)
                     WiringData.SourceFreeConnections = PowerNode.SourceFreeConnections;
                     WiringData.MaxConnections = PowerNode.MaxConnections;
                     PowerPoleWiringData.Add(CloneId, WiringData);
-                    
+
                     UE_LOG(LogSmartFoundations, Log, TEXT("⚡ EXTEND: Stored power pole wiring data for %s (source=%s, free=%d)"),
                         *CloneId, *PowerNode.PowerPole->GetName(), PowerNode.SourceFreeConnections);
                 }
             }
         }
-        
+
         // Copy tracked children for RefreshExtension
         BeltPreviewHolograms.Empty();
         for (AFGHologram* Child : HologramService->GetTrackedChildren())
@@ -1344,12 +1344,12 @@ void USFExtendService::ClearBeltPreviews()
         HologramService->SetCurrentParentHologram(CurrentExtendHologram.Get());
         HologramService->ClearBeltPreviews();
     }
-    
+
     // Clear local tracking (for backwards compatibility)
     BeltPreviewHolograms.Empty();
     ChildIntendedPositions.Empty();
     ChildIntendedRotations.Empty();
-    
+
     // Clear connection wiring maps
     ClearConnectionWiringMaps();
 }
@@ -1363,7 +1363,7 @@ void USFExtendService::ClearConnectionWiringMaps()
     LiftChainHologramMap.Empty();
     BeltChainDistributorMap.Empty();
     ManifoldBeltHolograms.Empty();
-    
+
     // Also clear built tracking maps (used by WireBuiltChildConnections)
     BuiltConveyorsByChain.Empty();
     BuiltDistributorsByChain.Empty();
@@ -1371,14 +1371,14 @@ void USFExtendService::ClearConnectionWiringMaps()
     BuiltPipesByChain.Empty();
     BuiltChainIsInputMap.Empty();
     BuiltPipeChainIsInputMap.Empty();
-    
+
     // Clear power pole wiring data (Issue #229)
     PowerPoleWiringData.Empty();
-    
+
     // Clear source distributor/junction maps (used by WireManifoldConnections)
     SourceDistributorsByChain.Empty();
     SourceJunctionsByChain.Empty();
-    
+
     // Clear distributor connector name map (used by Construct() to find correct output)
     DistributorConnectorNameByChain.Empty();
 }
@@ -1389,11 +1389,11 @@ UFGPipeConnectionComponentBase* USFExtendService::FindPipeConnectionByIndex(AFGH
     {
         return nullptr;
     }
-    
+
     // Get all pipe connection components on the hologram
     TArray<UFGPipeConnectionComponentBase*> PipeConnections;
     Hologram->GetComponents<UFGPipeConnectionComponentBase>(PipeConnections);
-    
+
     // Filter to pipe connections - accept both naming conventions:
     // - Pipes: "PipelineConnection0", "PipelineConnection1"
     // - Junctions: "Connection0", "Connection1", "Connection2", "Connection3"
@@ -1410,22 +1410,22 @@ UFGPipeConnectionComponentBase* USFExtendService::FindPipeConnectionByIndex(AFGH
             }
         }
     }
-    
+
     // Sort by name to ensure consistent ordering
     ValidConnections.Sort([](const UFGPipeConnectionComponentBase& A, const UFGPipeConnectionComponentBase& B)
     {
         return A.GetFName().ToString() < B.GetFName().ToString();
     });
-    
+
     UE_LOG(LogSmartFoundations, Verbose, TEXT("🔧 EXTEND Wire: FindPipeConnectionByIndex(%s, %d) - found %d valid connections"),
         *Hologram->GetName(), Index, ValidConnections.Num());
-    
+
     if (Index < ValidConnections.Num())
     {
         UE_LOG(LogSmartFoundations, Verbose, TEXT("🔧 EXTEND Wire:   Returning %s"), *ValidConnections[Index]->GetName());
         return ValidConnections[Index];
     }
-    
+
     return nullptr;
 }
 
@@ -1438,20 +1438,20 @@ void USFExtendService::WirePipeChainConnections(int32 ChainId, AFGHologram* Pare
         UE_LOG(LogSmartFoundations, Warning, TEXT("🔧 EXTEND Wire: No pipe holograms found for chain %d"), ChainId);
         return;
     }
-    
+
     // Get the junction hologram for this chain
     ASFPipelineJunctionChildHologram* JunctionHologram = nullptr;
     if (ASFPipelineJunctionChildHologram** JunctionPtr = PipeChainJunctionMap.Find(ChainId))
     {
         JunctionHologram = *JunctionPtr;
     }
-    
+
     UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("🔧 EXTEND Wire: Wiring chain %d (%s) with %d pipes, Junction=%s"),
         ChainId,
         bIsInputChain ? TEXT("INPUT") : TEXT("OUTPUT"),
         PipeHolograms->Num(),
         JunctionHologram ? *JunctionHologram->GetName() : TEXT("NONE"));
-    
+
     // Get parent factory hologram's pipe connections (for the first pipe in the chain)
     // The parent hologram represents the cloned factory
     TArray<UFGPipeConnectionComponentBase*> ParentPipeConnections;
@@ -1459,7 +1459,7 @@ void USFExtendService::WirePipeChainConnections(int32 ChainId, AFGHologram* Pare
     {
         ParentHologram->GetComponents<UFGPipeConnectionComponentBase>(ParentPipeConnections);
     }
-    
+
     // For each pipe in the chain, set its snapped connections
     // Flow direction determines endpoint connections:
     // OUTPUT chain: Factory.Output → Pipe[0].Conn0 → ... → Pipe[N].Conn1 → Junction.Input
@@ -1471,10 +1471,10 @@ void USFExtendService::WirePipeChainConnections(int32 ChainId, AFGHologram* Pare
         {
             continue;
         }
-        
+
         UFGPipeConnectionComponentBase* Conn0Target = nullptr;  // Connection0 target
         UFGPipeConnectionComponentBase* Conn1Target = nullptr;  // Connection1 target
-        
+
         // === FACTORY CONNECTION (first pipe, index 0) ===
         if (i == 0)
         {
@@ -1502,7 +1502,7 @@ void USFExtendService::WirePipeChainConnections(int32 ChainId, AFGHologram* Pare
                     i, *PipeHolo->GetName());
             }
         }
-        
+
         // === INTERNAL PIPE-TO-PIPE CONNECTIONS ===
         if (bIsInputChain)
         {
@@ -1518,7 +1518,7 @@ void USFExtendService::WirePipeChainConnections(int32 ChainId, AFGHologram* Pare
                         i, *PipeHolo->GetName(), i + 1, Conn0Target ? *Conn0Target->GetName() : TEXT("nullptr"));
                 }
             }
-            
+
             if (i > 0)
             {
                 // This pipe's Conn1 sends to previous pipe's Conn0
@@ -1545,7 +1545,7 @@ void USFExtendService::WirePipeChainConnections(int32 ChainId, AFGHologram* Pare
                         i, *PipeHolo->GetName(), i - 1, Conn0Target ? *Conn0Target->GetName() : TEXT("nullptr"));
                 }
             }
-            
+
             if (i < PipeHolograms->Num() - 1)
             {
                 // This pipe's Conn1 sends to next pipe's Conn0
@@ -1558,7 +1558,7 @@ void USFExtendService::WirePipeChainConnections(int32 ChainId, AFGHologram* Pare
                 }
             }
         }
-        
+
         // === JUNCTION CONNECTION (last pipe, index N-1) ===
         if (i == PipeHolograms->Num() - 1)
         {
@@ -1586,7 +1586,7 @@ void USFExtendService::WirePipeChainConnections(int32 ChainId, AFGHologram* Pare
                     i, *PipeHolo->GetName());
             }
         }
-        
+
         // Apply the snapped connections
         // CRITICAL: Both connections must be non-null to prevent vanilla from spawning child poles
         // If either is null, vanilla thinks that end is dangling and spawns a pole
@@ -1612,11 +1612,11 @@ UFGFactoryConnectionComponent* USFExtendService::FindFactoryConnectionByIndex(AF
     {
         return nullptr;
     }
-    
+
     // Get all factory connection components on the hologram
     TArray<UFGFactoryConnectionComponent*> FactoryConnections;
     Hologram->GetComponents<UFGFactoryConnectionComponent>(FactoryConnections);
-    
+
     // Filter to conveyor connections - accept "ConveyorAny" naming convention
     TArray<UFGFactoryConnectionComponent*> ValidConnections;
     for (UFGFactoryConnectionComponent* Conn : FactoryConnections)
@@ -1626,30 +1626,30 @@ UFGFactoryConnectionComponent* USFExtendService::FindFactoryConnectionByIndex(AF
             FString ConnName = Conn->GetFName().ToString();
             // Accept "ConveyorAny0", "ConveyorAny1" for belts
             // Also accept "Input0", "Output0" for distributors
-            if (ConnName.Contains(TEXT("ConveyorAny")) || 
-                ConnName.Contains(TEXT("Input")) || 
+            if (ConnName.Contains(TEXT("ConveyorAny")) ||
+                ConnName.Contains(TEXT("Input")) ||
                 ConnName.Contains(TEXT("Output")))
             {
                 ValidConnections.Add(Conn);
             }
         }
     }
-    
+
     // Sort by name to ensure consistent ordering
     ValidConnections.Sort([](const UFGFactoryConnectionComponent& A, const UFGFactoryConnectionComponent& B)
     {
         return A.GetFName().ToString() < B.GetFName().ToString();
     });
-    
+
     UE_LOG(LogSmartFoundations, Verbose, TEXT("🔧 EXTEND Wire: FindFactoryConnectionByIndex(%s, %d) - found %d valid connections"),
         *Hologram->GetName(), Index, ValidConnections.Num());
-    
+
     if (Index < ValidConnections.Num())
     {
         UE_LOG(LogSmartFoundations, Verbose, TEXT("🔧 EXTEND Wire:   Returning %s"), *ValidConnections[Index]->GetName());
         return ValidConnections[Index];
     }
-    
+
     return nullptr;
 }
 
@@ -1657,7 +1657,7 @@ void USFExtendService::WireBeltChainConnections(int32 ChainId, AFGHologram* Pare
 {
     UE_LOG(LogSmartFoundations, Warning, TEXT("🔌 WIRING CHAIN %d (%s) ============================"),
         ChainId, bIsInputChain ? TEXT("INPUT") : TEXT("OUTPUT"));
-    
+
     // Get the unified conveyor chain (belts + lifts) for this chain
     TMap<int32, AFGHologram*>* UnifiedChainPtr = UnifiedConveyorChainMap.Find(ChainId);
     if (!UnifiedChainPtr || UnifiedChainPtr->Num() == 0)
@@ -1665,16 +1665,16 @@ void USFExtendService::WireBeltChainConnections(int32 ChainId, AFGHologram* Pare
         UE_LOG(LogSmartFoundations, Warning, TEXT("🔌 WIRING: No conveyor holograms found for chain %d"), ChainId);
         return;
     }
-    
+
     TMap<int32, AFGHologram*>& UnifiedChain = *UnifiedChainPtr;
-    
+
     // Get the distributor hologram for this chain (if any)
     AFGHologram** DistributorPtr = BeltChainDistributorMap.Find(ChainId);
     AFGHologram* DistributorHologram = DistributorPtr ? *DistributorPtr : nullptr;
-    
+
     UE_LOG(LogSmartFoundations, Warning, TEXT("🔌 WIRING: Chain has %d elements, Distributor=%s"),
         UnifiedChain.Num(), DistributorHologram ? *DistributorHologram->GetName() : TEXT("NONE"));
-    
+
     // Get factory connections from parent factory hologram
     TArray<UFGFactoryConnectionComponent*> ParentFactoryConnections;
     if (ParentHologram)
@@ -1683,9 +1683,9 @@ void USFExtendService::WireBeltChainConnections(int32 ChainId, AFGHologram* Pare
         UE_LOG(LogSmartFoundations, Verbose, TEXT("🔧 EXTEND Wire: Parent %s has %d factory connections"),
             *ParentHologram->GetName(), ParentFactoryConnections.Num());
     }
-    
+
     // === UNIFIED CHAIN CONVENTION (after cloning fix) ===
-    // 
+    //
     // Both INPUT and OUTPUT chains now use the same index convention:
     //   Index 0 = SOURCE end (where items ENTER the chain)
     //   Index N-1 = DESTINATION end (where items EXIT the chain)
@@ -1701,7 +1701,7 @@ void USFExtendService::WireBeltChainConnections(int32 ChainId, AFGHologram* Pare
     //   - Index i: Conn0 receives from [i-1].Conn1, Conn1 sends to [i+1].Conn0
     //   - Index N-1: Conn1 sends to destination (distributor or factory)
     //
-    
+
     // Wire each belt in the chain (we only wire belts, lifts don't have snapped connections)
     for (auto& ChainPair : UnifiedChain)
     {
@@ -1710,7 +1710,7 @@ void USFExtendService::WireBeltChainConnections(int32 ChainId, AFGHologram* Pare
         {
             continue;
         }
-        
+
         // Only wire belt holograms (lifts don't have snapped connections)
         ASFConveyorBeltHologram* BeltHolo = Cast<ASFConveyorBeltHologram>(Hologram);
         if (!BeltHolo)
@@ -1718,7 +1718,7 @@ void USFExtendService::WireBeltChainConnections(int32 ChainId, AFGHologram* Pare
             UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("🔧 EXTEND Wire: Skipping non-belt hologram %s"), *Hologram->GetName());
             continue;
         }
-        
+
         // Get hologram data to determine chain position
         FSFHologramData* HoloData = USFHologramDataRegistry::GetData(BeltHolo);
         if (!HoloData)
@@ -1726,16 +1726,16 @@ void USFExtendService::WireBeltChainConnections(int32 ChainId, AFGHologram* Pare
             UE_LOG(LogSmartFoundations, Warning, TEXT("🔧 EXTEND Wire: Belt %s has no hologram data!"), *BeltHolo->GetName());
             continue;
         }
-        
+
         int32 ChainIndex = HoloData->ExtendChainIndex;
         int32 ChainLength = HoloData->ExtendChainLength;
-        
+
         UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("🔧 EXTEND Wire: Wiring belt %s at index %d/%d (%s)"),
             *BeltHolo->GetName(), ChainIndex, ChainLength, bIsInputChain ? TEXT("INPUT") : TEXT("OUTPUT"));
-        
+
         UFGFactoryConnectionComponent* Conn0Target = nullptr;
         UFGFactoryConnectionComponent* Conn1Target = nullptr;
-        
+
         // === SOURCE CONNECTION (first element, index 0) ===
         // Conn0 receives from the source of the chain
         if (ChainIndex == 0)
@@ -1762,11 +1762,11 @@ void USFExtendService::WireBeltChainConnections(int32 ChainId, AFGHologram* Pare
                 }
             }
         }
-        
+
         // === INTERNAL CONVEYOR-TO-CONVEYOR CONNECTIONS ===
         // Items flow forward through the chain: [i-1].Conn1 → [i].Conn0 → [i].Conn1 → [i+1].Conn0
         // This is the same for both INPUT and OUTPUT chains now!
-        
+
         if (ChainIndex > 0)
         {
             // This belt's Conn0 receives from previous conveyor's Conn1
@@ -1778,7 +1778,7 @@ void USFExtendService::WireBeltChainConnections(int32 ChainId, AFGHologram* Pare
                     ChainIndex, *BeltHolo->GetName(), ChainIndex - 1, *PrevHolo->GetName(), Conn0Target ? *Conn0Target->GetName() : TEXT("nullptr"));
             }
         }
-        
+
         if (ChainIndex < ChainLength - 1)
         {
             // This belt's Conn1 sends to next conveyor's Conn0
@@ -1790,7 +1790,7 @@ void USFExtendService::WireBeltChainConnections(int32 ChainId, AFGHologram* Pare
                     ChainIndex, *BeltHolo->GetName(), ChainIndex + 1, *NextHolo->GetName(), Conn1Target ? *Conn1Target->GetName() : TEXT("nullptr"));
             }
         }
-        
+
         // === DESTINATION CONNECTION (last element, index N-1) ===
         // Conn1 sends to the destination of the chain
         if (ChainIndex == ChainLength - 1)
@@ -1817,26 +1817,26 @@ void USFExtendService::WireBeltChainConnections(int32 ChainId, AFGHologram* Pare
                 }
             }
         }
-        
+
         // Apply snapped connections
         BeltHolo->SetSnappedConnections(Conn0Target, Conn1Target);
-        
+
         UE_LOG(LogSmartFoundations, Warning, TEXT("🔌 WIRING [%d/%d] %s:"),
             ChainIndex, ChainLength, *BeltHolo->GetName());
         UE_LOG(LogSmartFoundations, Warning, TEXT("🔌   Conn0 ← %s"),
-            Conn0Target ? *FString::Printf(TEXT("%s on %s"), *Conn0Target->GetName(), 
+            Conn0Target ? *FString::Printf(TEXT("%s on %s"), *Conn0Target->GetName(),
                 Conn0Target->GetOwner() ? *Conn0Target->GetOwner()->GetName() : TEXT("null")) : TEXT("NONE"));
         UE_LOG(LogSmartFoundations, Warning, TEXT("🔌   Conn1 → %s"),
-            Conn1Target ? *FString::Printf(TEXT("%s on %s"), *Conn1Target->GetName(), 
+            Conn1Target ? *FString::Printf(TEXT("%s on %s"), *Conn1Target->GetName(),
                 Conn1Target->GetOwner() ? *Conn1Target->GetOwner()->GetName() : TEXT("null")) : TEXT("NONE"));
-        
+
         if (!Conn0Target && !Conn1Target)
         {
             UE_LOG(LogSmartFoundations, Warning, TEXT("🔌 ⚠️ BOTH CONNECTIONS NULL for %s - will get isolated chain!"),
                 *BeltHolo->GetName());
         }
     }
-    
+
     UE_LOG(LogSmartFoundations, Warning, TEXT("🔌 WIRING CHAIN %d COMPLETE ============================"), ChainId);
 }
 
@@ -1845,7 +1845,7 @@ void USFExtendService::ProvideFloorHitResult(AFGHologram* Hologram, const FVecto
     // Create a synthetic hit result based on the parent hologram's valid floor
     // This is simpler than tracing - we just use the parent's floor position
     // The parent is already validated, so we know the floor is valid
-    
+
     FHitResult SyntheticHit;
     SyntheticHit.bBlockingHit = true;
     SyntheticHit.Location = Location;
@@ -1855,11 +1855,11 @@ void USFExtendService::ProvideFloorHitResult(AFGHologram* Hologram, const FVecto
     SyntheticHit.TraceStart = Location + FVector(0, 0, 100.0f);
     SyntheticHit.TraceEnd = Location - FVector(0, 0, 100.0f);
     SyntheticHit.Distance = 100.0f;
-    
+
     // Provide the synthetic hit result to the hologram
     Hologram->SetHologramLocationAndRotation(SyntheticHit);
-    
-    UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("EXTEND: Provided synthetic floor hit to hologram %s at %s"), 
+
+    UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("EXTEND: Provided synthetic floor hit to hologram %s at %s"),
         *Hologram->GetName(), *Location.ToString());
 }
 
@@ -1872,61 +1872,61 @@ void USFExtendService::ConnectAllChainElements(AFGBuildableFactory* NewFactory)
         ChainIsInputMap.Empty();
         return;
     }
-    
+
     if (BuiltChainElements.Num() == 0)
     {
         UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("🔧 EXTEND Phase 3.7: No chain elements to connect"));
         return;
     }
-    
+
     UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("🔧 EXTEND Phase 3.7: Connecting chain elements for %s (%d chains)"),
         *NewFactory->GetName(), BuiltChainElements.Num());
-    
+
     int32 TotalConnections = 0;
     int32 FailedConnections = 0;
-    
+
     // Process each chain
     for (auto& ChainPair : BuiltChainElements)
     {
         int32 ChainId = ChainPair.Key;
         TMap<int32, AFGBuildableConveyorBase*>& ElementsByIndex = ChainPair.Value;
         bool bIsInputChain = ChainIsInputMap.FindRef(ChainId);
-        
+
         // Sort chain indices
         TArray<int32> SortedIndices;
         ElementsByIndex.GetKeys(SortedIndices);
         SortedIndices.Sort();
-        
+
         UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("🔧 EXTEND Phase 3.7: Chain %d (%s) has %d elements at indices: %s"),
             ChainId, bIsInputChain ? TEXT("input") : TEXT("output"), SortedIndices.Num(),
             *FString::JoinBy(SortedIndices, TEXT(", "), [](int32 i) { return FString::FromInt(i); }));
-        
+
         // Connect consecutive elements
         for (int32 i = 0; i < SortedIndices.Num() - 1; i++)
         {
             int32 CurrentIndex = SortedIndices[i];
             int32 NextIndex = SortedIndices[i + 1];
-            
+
             AFGBuildableConveyorBase* Current = ElementsByIndex[CurrentIndex];
             AFGBuildableConveyorBase* Next = ElementsByIndex[NextIndex];
-            
+
             if (!Current || !Next)
             {
                 UE_LOG(LogSmartFoundations, Warning, TEXT("   ⚠️ Null element at index %d or %d"), CurrentIndex, NextIndex);
                 FailedConnections++;
                 continue;
             }
-            
+
             // Both belts and lifts inherit from AFGBuildableConveyorBase and have GetConnection0/1
             // Connection0 = INPUT (items flow in), Connection1 = OUTPUT (items flow out)
             // For input chains: items flow Distributor → Element[N-1] → ... → Element[0] → Factory
             //   So Element[i].Connection0 ← Element[i+1].Connection1
             // For output chains: items flow Factory → Element[0] → ... → Element[N-1] → Distributor
             //   So Element[i].Connection1 → Element[i+1].Connection0
-            
+
             UFGFactoryConnectionComponent* CurrentConn = nullptr;
             UFGFactoryConnectionComponent* NextConn = nullptr;
-            
+
             if (bIsInputChain)
             {
                 // Input chain: Current receives from Next
@@ -1939,7 +1939,7 @@ void USFExtendService::ConnectAllChainElements(AFGBuildableFactory* NewFactory)
                 CurrentConn = Current->GetConnection1();
                 NextConn = Next->GetConnection0();
             }
-            
+
             if (CurrentConn && NextConn && !CurrentConn->IsConnected() && !NextConn->IsConnected())
             {
                 CurrentConn->SetConnection(NextConn);
@@ -1958,23 +1958,23 @@ void USFExtendService::ConnectAllChainElements(AFGBuildableFactory* NewFactory)
                     NextConn ? NextConn->IsConnected() : -1);
             }
         }
-        
+
         // Connect first element (closest to factory) to factory
         if (SortedIndices.Num() > 0)
         {
             int32 FirstIndex = SortedIndices[0];
             AFGBuildableConveyorBase* FirstElement = ElementsByIndex[FirstIndex];
-            
+
             if (FirstElement)
             {
                 // Find appropriate factory connector
                 TArray<UFGFactoryConnectionComponent*> FactoryConnectors;
                 NewFactory->GetComponents<UFGFactoryConnectionComponent>(FactoryConnectors);
-                
-                EFactoryConnectionDirection NeededDirection = bIsInputChain 
-                    ? EFactoryConnectionDirection::FCD_INPUT 
+
+                EFactoryConnectionDirection NeededDirection = bIsInputChain
+                    ? EFactoryConnectionDirection::FCD_INPUT
                     : EFactoryConnectionDirection::FCD_OUTPUT;
-                
+
                 UFGFactoryConnectionComponent* FactoryConn = nullptr;
                 for (UFGFactoryConnectionComponent* Conn : FactoryConnectors)
                 {
@@ -1983,15 +1983,15 @@ void USFExtendService::ConnectAllChainElements(AFGBuildableFactory* NewFactory)
                     FactoryConn = Conn;
                     break;
                 }
-                
+
                 if (FactoryConn)
                 {
                     // For input chains: FirstElement.Connection1 (output) → Factory.Input
                     // For output chains: Factory.Output → FirstElement.Connection0 (input)
-                    UFGFactoryConnectionComponent* ElementConn = bIsInputChain 
-                        ? FirstElement->GetConnection1() 
+                    UFGFactoryConnectionComponent* ElementConn = bIsInputChain
+                        ? FirstElement->GetConnection1()
                         : FirstElement->GetConnection0();
-                    
+
                     if (ElementConn && !ElementConn->IsConnected())
                     {
                         ElementConn->SetConnection(FactoryConn);
@@ -2003,10 +2003,10 @@ void USFExtendService::ConnectAllChainElements(AFGBuildableFactory* NewFactory)
             }
         }
     }
-    
+
     UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("🔧 EXTEND Phase 3.7: Chain connections complete - %d succeeded, %d failed"),
         TotalConnections, FailedConnections);
-    
+
     // Clear the temporary storage
     BuiltChainElements.Empty();
     ChainIsInputMap.Empty();
@@ -2014,20 +2014,34 @@ void USFExtendService::ConnectAllChainElements(AFGBuildableFactory* NewFactory)
 
 // ==================== Phase 3.8: Wire Built Child Connections ====================
 
+bool USFExtendService::HasPendingPostBuildWiring() const
+{
+    return BuiltChainElements.Num() > 0 ||
+        BuiltConveyorsByChain.Num() > 0 ||
+        BuiltDistributorsByChain.Num() > 0 ||
+        BuiltJunctionsByChain.Num() > 0 ||
+        BuiltPipesByChain.Num() > 0 ||
+        JsonBuiltActors.Num() > 0 ||
+        JsonSpawnedHolograms.Num() > 0 ||
+        PowerPoleWiringData.Num() > 0 ||
+        ScaledExtendClones.Num() > 0 ||
+        (StoredCloneTopology.IsValid() && StoredCloneTopology->ChildHolograms.Num() > 0);
+}
+
 void USFExtendService::RegisterBuiltConveyor(int32 ChainId, int32 ChainIndex, AFGBuildableConveyorBase* BuiltConveyor, bool bIsInputChain)
 {
     if (!BuiltConveyor) return;
-    
+
     // Get or create the index map for this chain
     TMap<int32, AFGBuildableConveyorBase*>& ChainConveyors = BuiltConveyorsByChain.FindOrAdd(ChainId);
     ChainConveyors.Add(ChainIndex, BuiltConveyor);
-    
+
     // Track chain direction
     if (!BuiltChainIsInputMap.Contains(ChainId))
     {
         BuiltChainIsInputMap.Add(ChainId, bIsInputChain);
     }
-    
+
     UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("🔧 EXTEND: Registered built conveyor %s in chain %d at index %d (now %d conveyors, isInput=%d)"),
         *BuiltConveyor->GetName(), ChainId, ChainIndex, ChainConveyors.Num(), bIsInputChain);
 }
@@ -2049,9 +2063,9 @@ AFGBuildableConveyorBase* USFExtendService::GetBuiltConveyor(int32 ChainId, int3
 void USFExtendService::RegisterBuiltDistributor(int32 ChainId, AFGBuildable* BuiltDistributor)
 {
     if (!BuiltDistributor) return;
-    
+
     BuiltDistributorsByChain.Add(ChainId, BuiltDistributor);
-    
+
     UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("🔧 EXTEND: Registered built distributor %s for chain %d"),
         *BuiltDistributor->GetName(), ChainId);
 }
@@ -2078,9 +2092,9 @@ void USFExtendService::SetDistributorConnectorName(int32 ChainId, FName Connecto
 void USFExtendService::RegisterBuiltJunction(int32 ChainId, AFGBuildable* BuiltJunction)
 {
     if (!BuiltJunction) return;
-    
+
     BuiltJunctionsByChain.Add(ChainId, BuiltJunction);
-    
+
     UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("🔧 EXTEND: Registered built junction %s for pipe chain %d"),
         *BuiltJunction->GetName(), ChainId);
 }
@@ -2088,22 +2102,22 @@ void USFExtendService::RegisterBuiltJunction(int32 ChainId, AFGBuildable* BuiltJ
 void USFExtendService::RegisterBuiltPipe(int32 ChainId, int32 ChainIndex, AFGBuildablePipeline* BuiltPipe, bool bIsInputChain)
 {
     if (!BuiltPipe) return;
-    
+
     // Create chain entry if it doesn't exist
     if (!BuiltPipesByChain.Contains(ChainId))
     {
         BuiltPipesByChain.Add(ChainId, TMap<int32, AFGBuildablePipeline*>());
     }
-    
+
     // Add pipe to chain at index
     BuiltPipesByChain[ChainId].Add(ChainIndex, BuiltPipe);
-    
+
     // Track chain direction
     if (!BuiltPipeChainIsInputMap.Contains(ChainId))
     {
         BuiltPipeChainIsInputMap.Add(ChainId, bIsInputChain);
     }
-    
+
     UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("🔧 EXTEND: Registered built pipe %s for pipe chain %d, index %d (%s)"),
         *BuiltPipe->GetName(), ChainId, ChainIndex, bIsInputChain ? TEXT("INPUT") : TEXT("OUTPUT"));
 }
@@ -2313,8 +2327,8 @@ void USFExtendService::WireBuiltChildConnections(AFGBuildableFactory* NewFactory
         UE_LOG(LogSmartFoundations, Warning, TEXT("🔧 EXTEND Phase 3.8: WireBuiltChildConnections called with null factory"));
         return;
     }
-    
-    UE_LOG(LogSmartFoundations, Warning, TEXT("🔧 EXTEND Phase 3.8: WireBuiltChildConnections called for %s (StoredCloneTopology=%s, JsonBuiltActors=%d)"),
+
+    UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("🔧 EXTEND Phase 3.8: WireBuiltChildConnections called for %s (StoredCloneTopology=%s, JsonBuiltActors=%d)"),
         *NewFactory->GetName(),
         (StoredCloneTopology.IsValid() && StoredCloneTopology->ChildHolograms.Num() > 0) ? TEXT("VALID") : TEXT("INVALID"),
         JsonBuiltActors.Num());
@@ -2324,7 +2338,7 @@ void USFExtendService::WireBuiltChildConnections(AFGBuildableFactory* NewFactory
     // here (rather than at individual Construct() time) so the source → clone pairing has
     // the full topology available for lookup.
     CopyDistributorConfigurations();
-    
+
     int32 TotalConveyorChains = BuiltConveyorsByChain.Num();
     int32 TotalPipeChains = BuiltPipesByChain.Num();
 
@@ -2384,7 +2398,7 @@ void USFExtendService::WireBuiltChildConnections(AFGBuildableFactory* NewFactory
                 }
             }
         }
-        UE_LOG(LogSmartFoundations, Display, TEXT("🔧 EXTEND Phase 3.8a (#288): wired %d pipe-attachment endpoint(s) to neighbouring cloned pipes (JsonBuiltActors=%d)"),
+        UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("🔧 EXTEND Phase 3.8a (#288): wired %d pipe-attachment endpoint(s) to neighbouring cloned pipes (JsonBuiltActors=%d)"),
             AttachmentsWired, JsonBuiltActors.Num());
     }
 
@@ -2409,13 +2423,13 @@ void USFExtendService::WireBuiltChildConnections(AFGBuildableFactory* NewFactory
             {
                 AttachmentTotal++;
                 if (!Holo.ConnectedPowerPoleHologramId.IsEmpty()) AttachmentLinked++;
-                UE_LOG(LogSmartFoundations, Display,
+                UE_LOG(LogSmartFoundations, VeryVerbose,
                     TEXT("⚡ EXTEND Phase 3.8b (#288) inventory: %s class=%s PowerPoleClone=%s"),
                     *Holo.HologramId, *Holo.BuildClass,
                     Holo.ConnectedPowerPoleHologramId.IsEmpty() ? TEXT("<none>") : *Holo.ConnectedPowerPoleHologramId);
             }
         }
-        UE_LOG(LogSmartFoundations, Display,
+        UE_LOG(LogSmartFoundations, VeryVerbose,
             TEXT("⚡ EXTEND Phase 3.8b (#288) start: %d pipe_attachment(s), %d with pole linkage, JsonBuiltActors=%d"),
             AttachmentTotal, AttachmentLinked, JsonBuiltActors.Num());
 
@@ -2474,7 +2488,7 @@ void USFExtendService::WireBuiltChildConnections(AFGBuildableFactory* NewFactory
             if (NewWire->Connect(PumpPowerConn, PoleConn))
             {
                 ++PumpsWired;
-                UE_LOG(LogSmartFoundations, Display, TEXT("⚡ EXTEND Phase 3.8b (#288): wired pump %s → pole %s (pole now at %d/%d)"),
+                UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("⚡ EXTEND Phase 3.8b (#288): wired pump %s → pole %s (pole now at %d/%d)"),
                     *ClonePump->GetName(), *ClonePole->GetName(),
                     PoleConn->GetNumConnections(), PoleConn->GetMaxNumConnections());
             }
@@ -2487,12 +2501,12 @@ void USFExtendService::WireBuiltChildConnections(AFGBuildableFactory* NewFactory
             }
         }
 
-        UE_LOG(LogSmartFoundations, Display, TEXT("⚡ EXTEND Phase 3.8b (#288): pump power wiring complete — wired %d, skipped %d"),
+        UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("⚡ EXTEND Phase 3.8b (#288): pump power wiring complete — wired %d, skipped %d"),
             PumpsWired, PumpsSkipped);
     }
     else
     {
-        UE_LOG(LogSmartFoundations, Display, TEXT("⚡ EXTEND Phase 3.8b (#288): StoredCloneTopology invalid at pre-wire checkpoint — skipping pump power wiring"));
+        UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("⚡ EXTEND Phase 3.8b (#288): StoredCloneTopology invalid at pre-wire checkpoint — skipping pump power wiring"));
     }
 
     // ==================== PHASE 5/6: JSON-Based Wiring ====================
@@ -2522,10 +2536,10 @@ void USFExtendService::WireBuiltChildConnections(AFGBuildableFactory* NewFactory
 
     UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("🔧 EXTEND Phase 3.8: Wiring built child connections for %s (Conveyor chains: %d, Pipe chains: %d)"),
         *NewFactory->GetName(), TotalConveyorChains, TotalPipeChains);
-    
+
     int32 TotalConnections = 0;
     int32 FailedConnections = 0;
-    
+
     // ==================== CONVEYOR CHAIN WIRING ====================
     // HYBRID APPROACH:
     // - Conveyor-to-conveyor connections are handled by snapped connections at build time
@@ -2536,18 +2550,18 @@ void USFExtendService::WireBuiltChildConnections(AFGBuildableFactory* NewFactory
     // The snapped connections are set in SFConveyorBeltHologram::Construct() BEFORE
     // Super::Construct() is called, pointing to already-built conveyors.
     UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("🔧 EXTEND Phase 3.8: Wiring ENDPOINT connections only (conveyor↔conveyor handled by snapped connections)"));
-    
+
     for (auto& ChainPair : BuiltConveyorsByChain)
     {
         int32 ChainId = ChainPair.Key;
         TMap<int32, AFGBuildableConveyorBase*>& ConveyorsByIndex = ChainPair.Value;
         bool bIsInputChain = BuiltChainIsInputMap.FindRef(ChainId);
-        
+
         // Sort indices to get conveyors in order
         TArray<int32> SortedIndices;
         ConveyorsByIndex.GetKeys(SortedIndices);
         SortedIndices.Sort();
-        
+
         // Build ordered array of conveyors
         TArray<AFGBuildableConveyorBase*> OrderedConveyors;
         for (int32 Index : SortedIndices)
@@ -2557,11 +2571,11 @@ void USFExtendService::WireBuiltChildConnections(AFGBuildableFactory* NewFactory
                 OrderedConveyors.Add(Conveyor);
             }
         }
-        
+
         UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("🔧 EXTEND Phase 3.8: Processing conveyor chain %d with %d conveyors (%s), indices: %s"),
             ChainId, OrderedConveyors.Num(), bIsInputChain ? TEXT("INPUT") : TEXT("OUTPUT"),
             *FString::JoinBy(SortedIndices, TEXT(", "), [](int32 i) { return FString::FromInt(i); }));
-        
+
         // Connect consecutive conveyors in the chain
         // Note: Snapped connections create unified chains for lifts, but belts still need post-build wiring
         // to establish the actual connection (snapped connections don't work for belt-to-belt)
@@ -2569,13 +2583,13 @@ void USFExtendService::WireBuiltChildConnections(AFGBuildableFactory* NewFactory
         {
             AFGBuildableConveyorBase* Current = OrderedConveyors[i];
             AFGBuildableConveyorBase* Next = OrderedConveyors[i + 1];
-            
+
             if (!Current || !Next) continue;
-            
+
             // Connect Current.Connection1 (output) to Next.Connection0 (input)
             UFGFactoryConnectionComponent* CurrentConn1 = Current->GetConnection1();
             UFGFactoryConnectionComponent* NextConn0 = Next->GetConnection0();
-            
+
             if (CurrentConn1 && NextConn0 && !CurrentConn1->IsConnected() && !NextConn0->IsConnected())
             {
                 CurrentConn1->SetConnection(NextConn0);
@@ -2584,7 +2598,7 @@ void USFExtendService::WireBuiltChildConnections(AFGBuildableFactory* NewFactory
                     *Current->GetName(), *Next->GetName());
             }
         }
-        
+
         // === CHAIN INDEX CONVENTION (after INPUT chain reversal fix) ===
         //
         // Both INPUT and OUTPUT chains now use the SAME index convention:
@@ -2600,33 +2614,33 @@ void USFExtendService::WireBuiltChildConnections(AFGBuildableFactory* NewFactory
         //   - [N-1].Conn1 → Factory INPUT
         //
         // Items always flow: Conn0 → Conn1 through each conveyor
-        
+
         // Connect conveyor to factory
         if (OrderedConveyors.Num() > 0)
         {
             // INPUT: last conveyor (index N-1) connects to factory (destination)
             // OUTPUT: first conveyor (index 0) connects to factory (source)
             AFGBuildableConveyorBase* FactoryConveyor = bIsInputChain ? OrderedConveyors.Last() : OrderedConveyors[0];
-            
+
             // Find matching factory connector by proximity
             TArray<UFGFactoryConnectionComponent*> FactoryConnectors;
             NewFactory->GetComponents<UFGFactoryConnectionComponent>(FactoryConnectors);
-            
+
             // INPUT: conveyor's Conn1 (output) → Factory INPUT (items enter factory)
             // OUTPUT: conveyor's Conn0 (input) ← Factory OUTPUT (items leave factory)
             UFGFactoryConnectionComponent* ConveyorConn = bIsInputChain ? FactoryConveyor->GetConnection1() : FactoryConveyor->GetConnection0();
             EFactoryConnectionDirection NeededDirection = bIsInputChain ? EFactoryConnectionDirection::FCD_INPUT : EFactoryConnectionDirection::FCD_OUTPUT;
-            
+
             if (ConveyorConn && !ConveyorConn->IsConnected())
             {
                 UFGFactoryConnectionComponent* BestFactoryConn = nullptr;
                 float BestDistance = FLT_MAX;
-                
+
                 for (UFGFactoryConnectionComponent* FactoryConn : FactoryConnectors)
                 {
                     if (!FactoryConn || FactoryConn->IsConnected()) continue;
                     if (FactoryConn->GetDirection() != NeededDirection) continue;
-                    
+
                     float Distance = FVector::Dist(ConveyorConn->GetComponentLocation(), FactoryConn->GetComponentLocation());
                     if (Distance < BestDistance && Distance <= 350.0f)  // 350cm to handle edge cases at exactly 300cm
                     {
@@ -2634,7 +2648,7 @@ void USFExtendService::WireBuiltChildConnections(AFGBuildableFactory* NewFactory
                         BestFactoryConn = FactoryConn;
                     }
                 }
-                
+
                 if (BestFactoryConn)
                 {
                     ConveyorConn->SetConnection(BestFactoryConn);
@@ -2651,39 +2665,39 @@ void USFExtendService::WireBuiltChildConnections(AFGBuildableFactory* NewFactory
                 }
             }
         }
-        
+
         // Connect conveyor to distributor
         // INPUT: first conveyor (index 0) connects to distributor (source)
         // OUTPUT: last conveyor (index N-1) connects to distributor (destination)
         if (OrderedConveyors.Num() > 0)
         {
             AFGBuildableConveyorBase* DistributorConveyor = bIsInputChain ? OrderedConveyors[0] : OrderedConveyors.Last();
-            
+
             // Get the built distributor for this chain
             AFGBuildable** DistPtr = BuiltDistributorsByChain.Find(ChainId);
             if (DistPtr && *DistPtr)
             {
                 AFGBuildable* BuiltDistributor = *DistPtr;
-                
+
                 // Find matching distributor connector by proximity
                 TArray<UFGFactoryConnectionComponent*> DistConnectors;
                 BuiltDistributor->GetComponents<UFGFactoryConnectionComponent>(DistConnectors);
-                
+
                 // INPUT: conveyor's Conn0 (input) ← Distributor OUTPUT (items leave distributor/splitter)
                 // OUTPUT: conveyor's Conn1 (output) → Distributor INPUT (items enter distributor/merger)
                 UFGFactoryConnectionComponent* ConveyorConn = bIsInputChain ? DistributorConveyor->GetConnection0() : DistributorConveyor->GetConnection1();
                 EFactoryConnectionDirection NeededDirection = bIsInputChain ? EFactoryConnectionDirection::FCD_OUTPUT : EFactoryConnectionDirection::FCD_INPUT;
-                
+
                 if (ConveyorConn && !ConveyorConn->IsConnected())
                 {
                     UFGFactoryConnectionComponent* BestDistConn = nullptr;
                     float BestDistance = FLT_MAX;
-                    
+
                     for (UFGFactoryConnectionComponent* DistConn : DistConnectors)
                     {
                         if (!DistConn || DistConn->IsConnected()) continue;
                         if (DistConn->GetDirection() != NeededDirection) continue;
-                        
+
                         float Distance = FVector::Dist(ConveyorConn->GetComponentLocation(), DistConn->GetComponentLocation());
                         if (Distance < BestDistance && Distance <= 350.0f)  // 350cm to handle edge cases at exactly 300cm
                         {
@@ -2691,7 +2705,7 @@ void USFExtendService::WireBuiltChildConnections(AFGBuildableFactory* NewFactory
                             BestDistConn = DistConn;
                         }
                     }
-                    
+
                     if (BestDistConn)
                     {
                         ConveyorConn->SetConnection(BestDistConn);
@@ -2714,28 +2728,28 @@ void USFExtendService::WireBuiltChildConnections(AFGBuildableFactory* NewFactory
             }
         }
     }
-    
+
     // (Phases 3.8a and 3.8b formerly lived here — moved to before GenerateAndExecuteWiring above
     //  so that StoredCloneTopology and JsonBuiltActors are still populated when they run.)
 
     // ==================== PIPE CHAIN WIRING ====================
     // Process pipe chains similarly to belt chains
-    
+
     if (TotalPipeChains > 0)
     {
         UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("🔧 EXTEND Phase 3.8: Wiring %d pipe chains"), TotalPipeChains);
-        
+
         for (auto& PipeChainPair : BuiltPipesByChain)
         {
             int32 PipeChainId = PipeChainPair.Key;
             TMap<int32, AFGBuildablePipeline*>& PipesByIndex = PipeChainPair.Value;
             bool bIsInputChain = BuiltPipeChainIsInputMap.FindRef(PipeChainId);
-            
+
             // Sort indices to get pipes in order
             TArray<int32> SortedPipeIndices;
             PipesByIndex.GetKeys(SortedPipeIndices);
             SortedPipeIndices.Sort();
-            
+
             // Build ordered array of pipes
             TArray<AFGBuildablePipeline*> OrderedPipes;
             for (int32 Index : SortedPipeIndices)
@@ -2745,11 +2759,11 @@ void USFExtendService::WireBuiltChildConnections(AFGBuildableFactory* NewFactory
                     OrderedPipes.Add(Pipe);
                 }
             }
-            
+
             UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("🔧 EXTEND Phase 3.8: Processing pipe chain %d with %d pipes (%s), indices: %s"),
                 PipeChainId, OrderedPipes.Num(), bIsInputChain ? TEXT("INPUT") : TEXT("OUTPUT"),
                 *FString::JoinBy(SortedPipeIndices, TEXT(", "), [](int32 i) { return FString::FromInt(i); }));
-            
+
             // Connect consecutive pipes in the chain
             // Physical topology: Pipe[i].Conn1 meets Pipe[i+1].Conn0 at the same location
             // This is the same for both INPUT and OUTPUT chains (flow direction is handled by pumps)
@@ -2757,13 +2771,13 @@ void USFExtendService::WireBuiltChildConnections(AFGBuildableFactory* NewFactory
             {
                 AFGBuildablePipeline* CurrentPipe = OrderedPipes[i];
                 AFGBuildablePipeline* NextPipe = OrderedPipes[i + 1];
-                
+
                 if (!CurrentPipe || !NextPipe) continue;
-                
+
                 // Physical connection: CurrentPipe.Conn1 → NextPipe.Conn0
                 UFGPipeConnectionComponent* FromConn = CurrentPipe->GetPipeConnection1();
                 UFGPipeConnectionComponent* ToConn = NextPipe->GetPipeConnection0();
-                
+
                 if (FromConn && ToConn && !FromConn->IsConnected() && !ToConn->IsConnected())
                 {
                     FromConn->SetConnection(ToConn);
@@ -2780,12 +2794,12 @@ void USFExtendService::WireBuiltChildConnections(AFGBuildableFactory* NewFactory
                         ToConn ? ToConn->IsConnected() : -1);
                 }
             }
-            
+
             // Connect pipe to factory using SOURCE topology connector name (1:1 mapping)
             if (OrderedPipes.Num() > 0)
             {
                 AFGBuildablePipeline* FactoryPipe = OrderedPipes[0];  // First pipe is at factory end
-                
+
                 // Get the source factory connector name from topology
                 FName SourceFactoryConnectorName = NAME_None;
                 if (bIsInputChain && PipeChainId < GetCurrentTopology().PipeInputChains.Num())
@@ -2806,11 +2820,11 @@ void USFExtendService::WireBuiltChildConnections(AFGBuildableFactory* NewFactory
                         }
                     }
                 }
-                
+
                 // Find the clone factory connector with the SAME NAME as the source
                 TArray<UFGPipeConnectionComponent*> FactoryPipeConnectors;
                 NewFactory->GetComponents<UFGPipeConnectionComponent>(FactoryPipeConnectors);
-                
+
                 UFGPipeConnectionComponent* TargetFactoryConn = nullptr;
                 for (UFGPipeConnectionComponent* FactoryConn : FactoryPipeConnectors)
                 {
@@ -2820,11 +2834,11 @@ void USFExtendService::WireBuiltChildConnections(AFGBuildableFactory* NewFactory
                         break;
                     }
                 }
-                
+
                 UE_LOG(LogSmartFoundations, Log, TEXT("   🔍 Factory wiring: %s chain %d, Pipe=%s, TargetConnector=%s"),
                     bIsInputChain ? TEXT("INPUT") : TEXT("OUTPUT"), PipeChainId,
                     *FactoryPipe->GetName(), *SourceFactoryConnectorName.ToString());
-                
+
                 // Find which pipe connector (Conn0 or Conn1) is closest to the target factory connector
                 UFGPipeConnectionComponent* PipeConn = nullptr;
                 if (TargetFactoryConn)
@@ -2832,16 +2846,16 @@ void USFExtendService::WireBuiltChildConnections(AFGBuildableFactory* NewFactory
                     FVector TargetLoc = TargetFactoryConn->GetComponentLocation();
                     UFGPipeConnectionComponent* Conn0 = FactoryPipe->GetPipeConnection0();
                     UFGPipeConnectionComponent* Conn1 = FactoryPipe->GetPipeConnection1();
-                    
+
                     float Dist0 = Conn0 ? FVector::Dist(Conn0->GetComponentLocation(), TargetLoc) : FLT_MAX;
                     float Dist1 = Conn1 ? FVector::Dist(Conn1->GetComponentLocation(), TargetLoc) : FLT_MAX;
-                    
+
                     PipeConn = (Dist0 < Dist1) ? Conn0 : Conn1;
-                    
+
                     UE_LOG(LogSmartFoundations, Log, TEXT("   🔍 Pipe Conn0 dist=%.1f cm, Conn1 dist=%.1f cm, using %s"),
                         Dist0, Dist1, (Dist0 < Dist1) ? TEXT("Conn0") : TEXT("Conn1"));
                 }
-                
+
                 if (PipeConn && TargetFactoryConn && !PipeConn->IsConnected() && !TargetFactoryConn->IsConnected())
                 {
                     float Distance = FVector::Dist(PipeConn->GetComponentLocation(), TargetFactoryConn->GetComponentLocation());
@@ -2866,19 +2880,19 @@ void USFExtendService::WireBuiltChildConnections(AFGBuildableFactory* NewFactory
                         *TargetFactoryConn->GetName());
                 }
             }
-            
+
             // Connect pipe to junction using SOURCE topology to determine connector names
             // The source junction connector tells us which connector name to use on the clone
             if (OrderedPipes.Num() > 0)
             {
                 AFGBuildablePipeline* JunctionPipe = OrderedPipes.Last();  // Last pipe is at junction end
-                
+
                 // Get the CLONE junction for this chain
                 AFGBuildable** JunctionPtr = BuiltJunctionsByChain.Find(PipeChainId);
                 if (JunctionPtr && *JunctionPtr)
                 {
                     AFGBuildable* CloneJunction = *JunctionPtr;
-                    
+
                     // Get the source junction connector name from topology
                     FName SourceJunctionConnectorName = NAME_None;
                     if (bIsInputChain && PipeChainId < GetCurrentTopology().PipeInputChains.Num())
@@ -2900,11 +2914,11 @@ void USFExtendService::WireBuiltChildConnections(AFGBuildableFactory* NewFactory
                             }
                         }
                     }
-                    
+
                     // Find the clone junction connector with the SAME NAME as the source
                     TArray<UFGPipeConnectionComponent*> JunctionConnectors;
                     CloneJunction->GetComponents<UFGPipeConnectionComponent>(JunctionConnectors);
-                    
+
                     UFGPipeConnectionComponent* TargetJunctionConn = nullptr;
                     for (UFGPipeConnectionComponent* JunctionConn : JunctionConnectors)
                     {
@@ -2914,12 +2928,12 @@ void USFExtendService::WireBuiltChildConnections(AFGBuildableFactory* NewFactory
                             break;
                         }
                     }
-                    
+
                     UE_LOG(LogSmartFoundations, Log, TEXT("   🔍 Junction wiring: %s chain %d, Pipe=%s, Junction=%s (CLONE), TargetConnector=%s"),
                         bIsInputChain ? TEXT("INPUT") : TEXT("OUTPUT"), PipeChainId,
                         *JunctionPipe->GetName(), *CloneJunction->GetName(),
                         *SourceJunctionConnectorName.ToString());
-                    
+
                     // Find which pipe connector (Conn0 or Conn1) is closest to the target junction connector
                     UFGPipeConnectionComponent* PipeConn = nullptr;
                     if (TargetJunctionConn)
@@ -2927,18 +2941,18 @@ void USFExtendService::WireBuiltChildConnections(AFGBuildableFactory* NewFactory
                         FVector TargetLoc = TargetJunctionConn->GetComponentLocation();
                         UFGPipeConnectionComponent* Conn0 = JunctionPipe->GetPipeConnection0();
                         UFGPipeConnectionComponent* Conn1 = JunctionPipe->GetPipeConnection1();
-                        
+
                         float Dist0 = Conn0 ? FVector::Dist(Conn0->GetComponentLocation(), TargetLoc) : FLT_MAX;
                         float Dist1 = Conn1 ? FVector::Dist(Conn1->GetComponentLocation(), TargetLoc) : FLT_MAX;
-                        
+
                         PipeConn = (Dist0 < Dist1) ? Conn0 : Conn1;
-                        
+
                         UE_LOG(LogSmartFoundations, Log, TEXT("   🔍 Target junction connector %s @ (%.1f, %.1f, %.1f)"),
                             *SourceJunctionConnectorName.ToString(), TargetLoc.X, TargetLoc.Y, TargetLoc.Z);
                         UE_LOG(LogSmartFoundations, Log, TEXT("   🔍 Pipe Conn0 dist=%.1f cm, Conn1 dist=%.1f cm, using %s"),
                             Dist0, Dist1, (Dist0 < Dist1) ? TEXT("Conn0") : TEXT("Conn1"));
                     }
-                    
+
                     if (PipeConn && TargetJunctionConn && !PipeConn->IsConnected() && !TargetJunctionConn->IsConnected())
                     {
                         float Distance = FVector::Dist(PipeConn->GetComponentLocation(), TargetJunctionConn->GetComponentLocation());
@@ -2971,10 +2985,10 @@ void USFExtendService::WireBuiltChildConnections(AFGBuildableFactory* NewFactory
             }
         }
     }
-    
+
     UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("🔧 EXTEND Phase 3.8: Wiring complete - %d succeeded, %d failed"),
         TotalConnections, FailedConnections);
-    
+
     // Trigger pipe network rebuild for all connected pipes
     // This ensures the pipe subsystem recognizes the new connections we just made
     if (NewFactory)
@@ -2984,7 +2998,7 @@ void USFExtendService::WireBuiltChildConnections(AFGBuildableFactory* NewFactory
         if (PipeSubsystem)
         {
             TSet<int32> NetworksToRebuild;
-            
+
             // Collect all unique network IDs from built pipes
             for (auto& PipeChainPair : BuiltPipesByChain)
             {
@@ -3006,7 +3020,7 @@ void USFExtendService::WireBuiltChildConnections(AFGBuildableFactory* NewFactory
                     }
                 }
             }
-            
+
             // Mark all involved networks for rebuild
             for (int32 NetworkID : NetworksToRebuild)
             {
@@ -3016,7 +3030,7 @@ void USFExtendService::WireBuiltChildConnections(AFGBuildableFactory* NewFactory
                     Network->MarkForFullRebuild();
                 }
             }
-            
+
             if (NetworksToRebuild.Num() > 0)
             {
                 UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("🔧 EXTEND Phase 3.8: Marked %d pipe networks for rebuild"),
@@ -3024,7 +3038,7 @@ void USFExtendService::WireBuiltChildConnections(AFGBuildableFactory* NewFactory
             }
         }
     }
-    
+
     // ============================================================
     // CHAIN FIX: Delete built belts and respawn using SOURCE topology
     // ============================================================
@@ -3034,20 +3048,20 @@ void USFExtendService::WireBuiltChildConnections(AFGBuildableFactory* NewFactory
     // SOLUTION: Delete the fragmented belts and respawn them in FORWARD order
     // using the SOURCE topology data (which has correct lift configurations,
     // spline data, etc.) plus the offset to the clone position.
-    
-    UE_LOG(LogSmartFoundations, Warning, TEXT("🔧 EXTEND Chain Fix: Deleting fragmented belts and respawning from source topology..."));
-    
+
+    UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("🔧 EXTEND Chain Fix: Deleting fragmented belts and respawning from source topology..."));
+
     // Log topology info for debugging
-    UE_LOG(LogSmartFoundations, Warning, TEXT("🔧 EXTEND Chain Fix: Topology has %d input chains, %d output chains"),
+    UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("🔧 EXTEND Chain Fix: Topology has %d input chains, %d output chains"),
         GetCurrentTopology().InputChains.Num(), GetCurrentTopology().OutputChains.Num());
-    UE_LOG(LogSmartFoundations, Warning, TEXT("🔧 EXTEND Chain Fix: BuiltConveyorsByChain has %d chains:"), BuiltConveyorsByChain.Num());
+    UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("🔧 EXTEND Chain Fix: BuiltConveyorsByChain has %d chains:"), BuiltConveyorsByChain.Num());
     for (auto& DebugPair : BuiltConveyorsByChain)
     {
         bool bDebugIsInput = BuiltChainIsInputMap.FindRef(DebugPair.Key);
-        UE_LOG(LogSmartFoundations, Warning, TEXT("🔧 EXTEND Chain Fix:   ChainId=%d, IsInput=%d, ConveyorCount=%d"),
+        UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("🔧 EXTEND Chain Fix:   ChainId=%d, IsInput=%d, ConveyorCount=%d"),
             DebugPair.Key, bDebugIsInput ? 1 : 0, DebugPair.Value.Num());
     }
-    
+
     // Calculate offset from source to clone factory
     FVector CloneOffset = FVector::ZeroVector;
     if (GetCurrentTopology().SourceBuilding.IsValid() && NewFactory)
@@ -3057,16 +3071,16 @@ void USFExtendService::WireBuiltChildConnections(AFGBuildableFactory* NewFactory
     }
     else
     {
-        UE_LOG(LogSmartFoundations, Warning, TEXT("🔧 EXTEND Chain Fix: Cannot calculate offset - missing source or new factory!"));
+        UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("🔧 EXTEND Chain Fix: Cannot calculate offset - missing source or new factory!"));
     }
-    
+
     // Process each conveyor chain
     for (auto& ChainPair : BuiltConveyorsByChain)
     {
         int32 ChainId = ChainPair.Key;
         TMap<int32, AFGBuildableConveyorBase*>& ConveyorMap = ChainPair.Value;
         bool bIsInput = BuiltChainIsInputMap.FindRef(ChainId);
-        
+
         // Get the SOURCE chain from cached topology
         const FSFConnectionChainNode* SourceChain = nullptr;
         if (bIsInput && ChainId < GetCurrentTopology().InputChains.Num())
@@ -3082,28 +3096,28 @@ void USFExtendService::WireBuiltChildConnections(AFGBuildableFactory* NewFactory
                 SourceChain = &GetCurrentTopology().OutputChains[OutputChainIndex];
             }
         }
-        
+
         if (!SourceChain || SourceChain->Conveyors.Num() == 0)
         {
             UE_LOG(LogSmartFoundations, Warning, TEXT("🔧 EXTEND Chain %d: No source chain found in topology, skipping respawn"),
                 ChainId);
             continue;
         }
-        
+
         UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("🔧 EXTEND Chain %d (%s): Found %d source conveyors, %d built conveyors"),
-            ChainId, bIsInput ? TEXT("INPUT") : TEXT("OUTPUT"), 
+            ChainId, bIsInput ? TEXT("INPUT") : TEXT("OUTPUT"),
             SourceChain->Conveyors.Num(), ConveyorMap.Num());
-        
+
         // Collect endpoint connections before deletion (for first/last belt connections)
         // These are the external connections at each end of the chain
         TWeakObjectPtr<UFGFactoryConnectionComponent> FactoryEndConn;   // At topology[0] - factory side
         TWeakObjectPtr<UFGFactoryConnectionComponent> DistributorEndConn; // At topology[N-1] - distributor side
-        
+
         // Sort indices to find first and last
         TArray<int32> SortedIndices;
         ConveyorMap.GetKeys(SortedIndices);
         SortedIndices.Sort();
-        
+
         if (SortedIndices.Num() > 0)
         {
             // Get factory-end connection DIRECTLY from clone factory (not from belt)
@@ -3115,7 +3129,7 @@ void USFExtendService::WireBuiltChildConnections(AFGBuildableFactory* NewFactory
                 // For OUTPUT chains: factory OUTPUT feeds into belt chain
                 TArray<UFGFactoryConnectionComponent*> FactoryConnections;
                 NewFactory->GetComponents<UFGFactoryConnectionComponent>(FactoryConnections);
-                
+
                 // Find the correct factory connector based on chain type and source topology
                 // The source chain has a SourceConnector that we need to match by name
                 FName SourceConnectorName = NAME_None;
@@ -3123,20 +3137,20 @@ void USFExtendService::WireBuiltChildConnections(AFGBuildableFactory* NewFactory
                 {
                     SourceConnectorName = SourceChain->SourceConnector->GetFName();
                 }
-                
+
                 for (UFGFactoryConnectionComponent* FactoryConn : FactoryConnections)
                 {
                     if (!FactoryConn) continue;
-                    
+
                     // For INPUT chains: need INPUT connector (factory receives FROM belt chain)
                     // For OUTPUT chains: need OUTPUT connector (factory feeds INTO belt chain)
                     bool bWantInput = bIsInput;
                     bool bIsInput_Conn = (FactoryConn->GetDirection() == EFactoryConnectionDirection::FCD_INPUT);
-                    
+
                     // Match by name if we have source connector name, otherwise match by direction
                     // NOTE: Don't check IsConnected() - factory may be connected to old belt we're about to delete
                     bool bNameMatch = (SourceConnectorName == NAME_None) || (FactoryConn->GetFName() == SourceConnectorName);
-                    
+
                     if (bWantInput == bIsInput_Conn && bNameMatch)
                     {
                         FactoryEndConn = FactoryConn;
@@ -3146,29 +3160,29 @@ void USFExtendService::WireBuiltChildConnections(AFGBuildableFactory* NewFactory
                     }
                 }
             }
-            
+
             // Get distributor-end connection DIRECTLY from clone distributor (not from belt)
             // Belt connections may not have been established due to fragmented chains
             AFGBuildable** CloneDistributorPtr = BuiltDistributorsByChain.Find(ChainId);
             if (CloneDistributorPtr && *CloneDistributorPtr)
             {
                 AFGBuildable* CloneDistributor = *CloneDistributorPtr;
-                
+
                 // Get the connector that should connect to the belt chain
                 // For INPUT chains (splitter): use an OUTPUT connector to feed into belts
                 // For OUTPUT chains (merger): use an INPUT connector to receive from belts
                 TArray<UFGFactoryConnectionComponent*> Connections;
                 CloneDistributor->GetComponents<UFGFactoryConnectionComponent>(Connections);
-                
+
                 for (UFGFactoryConnectionComponent* DistConn : Connections)
                 {
                     if (!DistConn) continue;
-                    
+
                     // For INPUT chains: need OUTPUT connector (splitter feeds INTO belt chain)
                     // For OUTPUT chains: need INPUT connector (merger receives FROM belt chain)
                     bool bWantOutput = bIsInput;
                     bool bIsOutput = (DistConn->GetDirection() == EFactoryConnectionDirection::FCD_OUTPUT);
-                    
+
                     if (bWantOutput == bIsOutput && !DistConn->IsConnected())
                     {
                         DistributorEndConn = DistConn;
@@ -3179,16 +3193,16 @@ void USFExtendService::WireBuiltChildConnections(AFGBuildableFactory* NewFactory
                 }
             }
         }
-        
+
         UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("🔧 EXTEND Chain %d: Endpoints - FactoryEnd=%s, DistributorEnd=%s"),
             ChainId,
             FactoryEndConn.IsValid() ? *FactoryEndConn->GetName() : TEXT("NULL"),
             DistributorEndConn.IsValid() ? *DistributorEndConn->GetName() : TEXT("NULL"));
-        
+
         // Delete all fragmented conveyors (belts and lifts)
         UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("🔧 EXTEND Chain %d: Deleting %d fragmented conveyors..."),
             ChainId, SortedIndices.Num());
-        
+
         for (int32 Index : SortedIndices)
         {
             AFGBuildableConveyorBase* Conveyor = ConveyorMap[Index];
@@ -3203,7 +3217,7 @@ void USFExtendService::WireBuiltChildConnections(AFGBuildableFactory* NewFactory
             }
         }
         ConveyorMap.Empty();
-        
+
         // Respawn conveyors using SOURCE topology data
         // For INPUT chains: items flow Splitter → Factory, so spawn in REVERSE order (N-1 → 0)
         //   because topology[0] is at factory, topology[N-1] is at splitter
@@ -3212,13 +3226,13 @@ void USFExtendService::WireBuiltChildConnections(AFGBuildableFactory* NewFactory
         UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("🔧 EXTEND Chain %d (%s): Respawning %d conveyors (order: %s)..."),
             ChainId, bIsInput ? TEXT("INPUT") : TEXT("OUTPUT"), SourceChain->Conveyors.Num(),
             bIsInput ? TEXT("REVERSE N→0") : TEXT("FORWARD 0→N"));
-        
+
         UWorld* World = GetWorld();
         if (!World) continue;
-        
+
         AFGBuildableConveyorBase* PreviousConveyor = nullptr;
         int32 NumSourceConveyors = SourceChain->Conveyors.Num();
-        
+
         for (int32 iter = 0; iter < NumSourceConveyors; iter++)
         {
             // For INPUT chains, iterate in reverse; for OUTPUT chains, iterate forward
@@ -3229,13 +3243,13 @@ void USFExtendService::WireBuiltChildConnections(AFGBuildableFactory* NewFactory
                 UE_LOG(LogSmartFoundations, Warning, TEXT("🔧 EXTEND   [%d] Source conveyor is null, skipping"), i);
                 continue;
             }
-            
+
             AFGBuildableConveyorBase* NewConveyor = nullptr;
-            
+
             // Check if source is a lift or belt
             AFGBuildableConveyorLift* SourceLift = Cast<AFGBuildableConveyorLift>(SourceConveyor);
             AFGBuildableConveyorBelt* SourceBelt = Cast<AFGBuildableConveyorBelt>(SourceConveyor);
-            
+
             if (SourceLift)
             {
                 // Spawn lift at clone location using same approach as belts
@@ -3243,16 +3257,16 @@ void USFExtendService::WireBuiltChildConnections(AFGBuildableFactory* NewFactory
                 FVector CloneLocation = SourceLocation + CloneOffset;
                 FTransform CloneTransform = SourceLift->GetActorTransform();
                 CloneTransform.SetLocation(CloneLocation);
-                
+
                 // mTopTransform is LOCAL (relative to actor), so it stays the same
                 FTransform SourceTopTransform = SourceLift->GetTopTransform();
-                
+
                 UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("🔧 EXTEND   [%d] Spawning lift:"), i);
                 UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("🔧 EXTEND     Source: %s at %s, Height=%.1f"),
                     *SourceLift->GetName(), *SourceLocation.ToString(), SourceLift->GetHeight());
                 UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("🔧 EXTEND     Clone location: %s"), *CloneLocation.ToString());
                 UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("🔧 EXTEND     Source TopTransform: %s (LOCAL)"), *SourceTopTransform.ToString());
-                
+
                 // Spawn at clone transform
                 AFGBuildableConveyorLift* NewLift = World->SpawnActorDeferred<AFGBuildableConveyorLift>(
                     SourceLift->GetClass(),
@@ -3260,7 +3274,7 @@ void USFExtendService::WireBuiltChildConnections(AFGBuildableFactory* NewFactory
                     nullptr,
                     nullptr,
                     ESpawnActorCollisionHandlingMethod::AlwaysSpawn);
-                
+
                 if (NewLift)
                 {
                     // Set mTopTransform via reflection BEFORE FinishSpawning (it's private)
@@ -3275,7 +3289,7 @@ void USFExtendService::WireBuiltChildConnections(AFGBuildableFactory* NewFactory
                             UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("🔧 EXTEND     Set mTopTransform via reflection"));
                         }
                     }
-                    
+
                     // Set snapped connections BEFORE FinishSpawning so chain actor registers correctly
                     // mSnappedConnectionComponents[0] = Conn0 partner, [1] = Conn1 partner
                     FProperty* SnappedConnProp = NewLift->GetClass()->FindPropertyByName(TEXT("mSnappedConnectionComponents"));
@@ -3286,15 +3300,15 @@ void USFExtendService::WireBuiltChildConnections(AFGBuildableFactory* NewFactory
                         if (ArrayPtr && ArrayProp)
                         {
                             FScriptArrayHelper ArrayHelper(ArrayProp, ArrayPtr);
-                            
+
                             // Resize array to 2 if needed (it starts empty)
                             if (ArrayHelper.Num() < 2)
                             {
                                 ArrayHelper.Resize(2);
                             }
-                            
+
                             UFGFactoryConnectionComponent** Conn0Ptr = (UFGFactoryConnectionComponent**)ArrayHelper.GetRawPtr(0);
-                            
+
                             // Conn0 partner (previous conveyor's Conn1 or endpoint)
                             if (PreviousConveyor)
                             {
@@ -3313,13 +3327,13 @@ void USFExtendService::WireBuiltChildConnections(AFGBuildableFactory* NewFactory
                             }
                         }
                     }
-                    
+
                     UGameplayStatics::FinishSpawningActor(NewLift, CloneTransform);
                     NewLift->SetupConnections();
-                    
+
                     UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("🔧 EXTEND   [%d] Spawned lift %s at %s, Height=%.1f"),
                         i, *NewLift->GetName(), *NewLift->GetActorLocation().ToString(), NewLift->GetHeight());
-                    
+
                     // Also set connections via SetConnection for immediate effect
                     if (PreviousConveyor)
                     {
@@ -3351,7 +3365,7 @@ void USFExtendService::WireBuiltChildConnections(AFGBuildableFactory* NewFactory
                                 *FactoryEndConn->GetName());
                         }
                     }
-                    
+
                     NewConveyor = NewLift;
                 }
                 else
@@ -3371,14 +3385,14 @@ void USFExtendService::WireBuiltChildConnections(AFGBuildableFactory* NewFactory
                     ClonePoint.Location += CloneOffset;
                     CloneSplineData.Add(ClonePoint);
                 }
-                
+
                 FVector SourceLocation = SourceBelt->GetActorLocation();
                 FVector CloneLocation = SourceLocation + CloneOffset;
-                
+
                 UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("🔧 EXTEND   [%d] Respawning belt:"), i);
-                UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("🔧 EXTEND     Source: %s at %s"), 
+                UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("🔧 EXTEND     Source: %s at %s"),
                     *SourceBelt->GetName(), *SourceLocation.ToString());
-                
+
                 // Spawn belt at source transform, then use Respline with offset spline data
                 AFGBuildableConveyorBelt* NewBelt = World->SpawnActorDeferred<AFGBuildableConveyorBelt>(
                     SourceBelt->GetClass(),
@@ -3386,7 +3400,7 @@ void USFExtendService::WireBuiltChildConnections(AFGBuildableFactory* NewFactory
                     nullptr,
                     nullptr,
                     ESpawnActorCollisionHandlingMethod::AlwaysSpawn);
-                
+
                 if (NewBelt)
                 {
                     // Set snapped connections BEFORE FinishSpawning so chain actor registers correctly
@@ -3399,15 +3413,15 @@ void USFExtendService::WireBuiltChildConnections(AFGBuildableFactory* NewFactory
                         if (ArrayPtr && ArrayProp)
                         {
                             FScriptArrayHelper ArrayHelper(ArrayProp, ArrayPtr);
-                            
+
                             // Resize array to 2 if needed (it starts empty)
                             if (ArrayHelper.Num() < 2)
                             {
                                 ArrayHelper.Resize(2);
                             }
-                            
+
                             UFGFactoryConnectionComponent** Conn0Ptr = (UFGFactoryConnectionComponent**)ArrayHelper.GetRawPtr(0);
-                            
+
                             if (PreviousConveyor)
                             {
                                 *Conn0Ptr = PreviousConveyor->GetConnection1();
@@ -3425,9 +3439,9 @@ void USFExtendService::WireBuiltChildConnections(AFGBuildableFactory* NewFactory
                             }
                         }
                     }
-                    
+
                     UGameplayStatics::FinishSpawningActor(NewBelt, SourceBelt->GetActorTransform());
-                    
+
                     // Apply offset spline data using Respline
                     if (CloneSplineData.Num() >= 2)
                     {
@@ -3437,10 +3451,10 @@ void USFExtendService::WireBuiltChildConnections(AFGBuildableFactory* NewFactory
                             NewBelt = ResplinedBelt;
                         }
                     }
-                    
+
                     UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("🔧 EXTEND   [%d] Respawned belt %s -> %s at %s"),
                         i, *SourceBelt->GetName(), *NewBelt->GetName(), *NewBelt->GetActorLocation().ToString());
-                    
+
                     // Also set connections via SetConnection for immediate effect
                     if (PreviousConveyor)
                     {
@@ -3472,7 +3486,7 @@ void USFExtendService::WireBuiltChildConnections(AFGBuildableFactory* NewFactory
                                 *FactoryEndConn->GetName());
                         }
                     }
-                    
+
                     NewBelt->OnBuildEffectFinished();
 
                     // NOTE: Don't call AddConveyor here - the belt chain is still being built.
@@ -3487,7 +3501,7 @@ void USFExtendService::WireBuiltChildConnections(AFGBuildableFactory* NewFactory
             {
                 // Register the new conveyor
                 ConveyorMap.Add(i, NewConveyor);
-                
+
                 // Connect last spawned conveyor's Conn1 to endpoint
                 // For INPUT chains (reverse): last spawned is at factory end → connect to FactoryEndConn
                 // For OUTPUT chains (forward): last spawned is at distributor end → connect to DistributorEndConn
@@ -3507,15 +3521,15 @@ void USFExtendService::WireBuiltChildConnections(AFGBuildableFactory* NewFactory
                             *DistributorEndConn->GetName());
                     }
                 }
-                
+
                 UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("🔧 EXTEND   [%d] Chain=%s"),
                     i,
                     NewConveyor->GetConveyorChainActor() ? *NewConveyor->GetConveyorChainActor()->GetName() : TEXT("NULL"));
-                
+
                 PreviousConveyor = NewConveyor;
             }
         }
-        
+
         // Log final chain state
         TSet<AFGConveyorChainActor*> FinalChains;
         for (auto& ConveyorPair : ConveyorMap)
@@ -3529,11 +3543,11 @@ void USFExtendService::WireBuiltChildConnections(AFGBuildableFactory* NewFactory
                 }
             }
         }
-        
+
         UE_LOG(LogSmartFoundations, Warning, TEXT("🔧 EXTEND Chain %d: Respawn complete - %d conveyors now have %d chain actor(s)"),
             ChainId, ConveyorMap.Num(), FinalChains.Num());
     }
-    
+
     // CRITICAL: Clear tracking maps after wiring to prevent duplicate wiring attempts
     // The deferred timer fires for EVERY factory built (including junctions), so without
     // clearing these maps, subsequent calls would try to re-wire already-connected elements
@@ -3543,7 +3557,7 @@ void USFExtendService::WireBuiltChildConnections(AFGBuildableFactory* NewFactory
     BuiltPipesByChain.Empty();
     BuiltChainIsInputMap.Empty();
     BuiltPipeChainIsInputMap.Empty();
-    
+
     // Also clear source tracking maps (used for pipe junction connections)
     SourceDistributorsByChain.Empty();
     SourceJunctionsByChain.Empty();
@@ -3558,57 +3572,57 @@ void USFExtendService::WireManifoldConnections(AFGBuildableFactory* SourceFactor
         UE_LOG(LogSmartFoundations, Warning, TEXT("🔧 EXTEND Manifold: Invalid factory pointers"));
         return;
     }
-    
+
     UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("🔧 EXTEND Manifold: Wiring manifold connections between %s and %s"),
         *SourceFactory->GetName(), *CloneFactory->GetName());
-    
+
     int32 BeltManifolds = 0;
     int32 PipeManifolds = 0;
-    
+
     // Wire belt/lift manifold connections (distributor → distributor)
     for (auto& ChainPair : SourceDistributorsByChain)
     {
         int32 ChainId = ChainPair.Key;
         AFGBuildable* SourceDistributor = ChainPair.Value;
         AFGBuildable** CloneDistPtr = BuiltDistributorsByChain.Find(ChainId);
-        
+
         if (!SourceDistributor || !CloneDistPtr || !*CloneDistPtr)
         {
             UE_LOG(LogSmartFoundations, Warning, TEXT("   ⚠️ Missing distributor for chain %d"), ChainId);
             continue;
         }
-        
+
         AFGBuildable* CloneDistributor = *CloneDistPtr;
         bool bIsInputChain = BuiltChainIsInputMap.FindRef(ChainId);
-        
+
         // Get connectors from both distributors
         TArray<UFGFactoryConnectionComponent*> SourceConnectors, CloneConnectors;
         SourceDistributor->GetComponents<UFGFactoryConnectionComponent>(SourceConnectors);
         CloneDistributor->GetComponents<UFGFactoryConnectionComponent>(CloneConnectors);
-        
+
         // For INPUT chains (splitters): Source OUTPUT → Clone INPUT
         // For OUTPUT chains (mergers): Clone OUTPUT → Source INPUT
         EFactoryConnectionDirection FromDir = bIsInputChain ? EFactoryConnectionDirection::FCD_OUTPUT : EFactoryConnectionDirection::FCD_OUTPUT;
         EFactoryConnectionDirection ToDir = bIsInputChain ? EFactoryConnectionDirection::FCD_INPUT : EFactoryConnectionDirection::FCD_INPUT;
-        
+
         TArray<UFGFactoryConnectionComponent*>& FromConnectors = bIsInputChain ? SourceConnectors : CloneConnectors;
         TArray<UFGFactoryConnectionComponent*>& ToConnectors = bIsInputChain ? CloneConnectors : SourceConnectors;
         AFGBuildable* FromDistributor = bIsInputChain ? SourceDistributor : CloneDistributor;
         AFGBuildable* ToDistributor = bIsInputChain ? CloneDistributor : SourceDistributor;
-        
+
         // Find best pair: unconnected, correct direction, shortest distance
         UFGFactoryConnectionComponent* BestFrom = nullptr;
         UFGFactoryConnectionComponent* BestTo = nullptr;
         float BestDistance = FLT_MAX;
-        
+
         for (UFGFactoryConnectionComponent* From : FromConnectors)
         {
             if (!From || From->IsConnected() || From->GetDirection() != FromDir) continue;
-            
+
             for (UFGFactoryConnectionComponent* To : ToConnectors)
             {
                 if (!To || To->IsConnected() || To->GetDirection() != ToDir) continue;
-                
+
                 float Distance = FVector::Dist(From->GetComponentLocation(), To->GetComponentLocation());
                 if (Distance < BestDistance)
                 {
@@ -3618,7 +3632,7 @@ void USFExtendService::WireManifoldConnections(AFGBuildableFactory* SourceFactor
                 }
             }
         }
-        
+
         if (BestFrom && BestTo)
         {
             if (CreateManifoldBelt(BestFrom, BestTo))
@@ -3634,47 +3648,47 @@ void USFExtendService::WireManifoldConnections(AFGBuildableFactory* SourceFactor
             UE_LOG(LogSmartFoundations, Warning, TEXT("   ⚠️ No available connectors for manifold on chain %d"), ChainId);
         }
     }
-    
+
     // Wire pipe manifold connections (junction → junction)
     for (auto& ChainPair : SourceJunctionsByChain)
     {
         int32 ChainId = ChainPair.Key;
         AFGBuildable* SourceJunction = ChainPair.Value;
         AFGBuildable** CloneJunctionPtr = BuiltJunctionsByChain.Find(ChainId);
-        
+
         if (!SourceJunction || !CloneJunctionPtr || !*CloneJunctionPtr)
         {
             UE_LOG(LogSmartFoundations, Warning, TEXT("   ⚠️ Missing junction for pipe chain %d"), ChainId);
             continue;
         }
-        
+
         AFGBuildable* CloneJunction = *CloneJunctionPtr;
         bool bIsInputChain = BuiltPipeChainIsInputMap.FindRef(ChainId);
-        
+
         // Get pipe connectors from both junctions
         TArray<UFGPipeConnectionComponentBase*> SourceConnectors, CloneConnectors;
         SourceJunction->GetComponents<UFGPipeConnectionComponentBase>(SourceConnectors);
         CloneJunction->GetComponents<UFGPipeConnectionComponentBase>(CloneConnectors);
-        
+
         // For junctions, direction is ANY - find the pair that faces each other
         TArray<UFGPipeConnectionComponentBase*>& FromConnectors = bIsInputChain ? SourceConnectors : CloneConnectors;
         TArray<UFGPipeConnectionComponentBase*>& ToConnectors = bIsInputChain ? CloneConnectors : SourceConnectors;
         AFGBuildable* FromJunction = bIsInputChain ? SourceJunction : CloneJunction;
         AFGBuildable* ToJunction = bIsInputChain ? CloneJunction : SourceJunction;
-        
+
         // Find best pair: unconnected, shortest distance
         UFGPipeConnectionComponentBase* BestFrom = nullptr;
         UFGPipeConnectionComponentBase* BestTo = nullptr;
         float BestDistance = FLT_MAX;
-        
+
         for (UFGPipeConnectionComponentBase* From : FromConnectors)
         {
             if (!From || From->IsConnected()) continue;
-            
+
             for (UFGPipeConnectionComponentBase* To : ToConnectors)
             {
                 if (!To || To->IsConnected()) continue;
-                
+
                 float Distance = FVector::Dist(From->GetComponentLocation(), To->GetComponentLocation());
                 if (Distance < BestDistance)
                 {
@@ -3684,7 +3698,7 @@ void USFExtendService::WireManifoldConnections(AFGBuildableFactory* SourceFactor
                 }
             }
         }
-        
+
         if (BestFrom && BestTo)
         {
             if (CreateManifoldPipe(BestFrom, BestTo))
@@ -3700,10 +3714,10 @@ void USFExtendService::WireManifoldConnections(AFGBuildableFactory* SourceFactor
             UE_LOG(LogSmartFoundations, Warning, TEXT("   ⚠️ No available connectors for pipe manifold on chain %d"), ChainId);
         }
     }
-    
+
     UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("🔧 EXTEND Manifold: Created %d belt manifolds, %d pipe manifolds"),
         BeltManifolds, PipeManifolds);
-    
+
     // Clear source tracking maps after manifold wiring
     SourceDistributorsByChain.Empty();
     SourceJunctionsByChain.Empty();
@@ -3716,24 +3730,24 @@ void USFExtendService::WireManifoldPipe(AFGBuildablePipeline* BuiltPipe, UFGPipe
         UE_LOG(LogSmartFoundations, Warning, TEXT("🔧 EXTEND Manifold Pipe Wire: Invalid parameters"));
         return;
     }
-    
+
     // Get the pipe's two connectors
     UFGPipeConnectionComponentBase* PipeConn0 = BuiltPipe->GetPipeConnection0();
     UFGPipeConnectionComponentBase* PipeConn1 = BuiltPipe->GetPipeConnection1();
-    
+
     if (!PipeConn0 || !PipeConn1)
     {
         UE_LOG(LogSmartFoundations, Warning, TEXT("🔧 EXTEND Manifold Pipe Wire: Pipe %s missing connectors"), *BuiltPipe->GetName());
         return;
     }
-    
+
     // Find which pipe connector is closer to source junction
     float Dist0ToSource = FVector::Dist(PipeConn0->GetComponentLocation(), SourceConnector->GetComponentLocation());
     float Dist1ToSource = FVector::Dist(PipeConn1->GetComponentLocation(), SourceConnector->GetComponentLocation());
-    
+
     UFGPipeConnectionComponentBase* PipeToSource = (Dist0ToSource < Dist1ToSource) ? PipeConn0 : PipeConn1;
     UFGPipeConnectionComponentBase* PipeToClone = (Dist0ToSource < Dist1ToSource) ? PipeConn1 : PipeConn0;
-    
+
     // Wire pipe to source junction
     if (!PipeToSource->IsConnected() && !SourceConnector->IsConnected())
     {
@@ -3747,7 +3761,7 @@ void USFExtendService::WireManifoldPipe(AFGBuildablePipeline* BuiltPipe, UFGPipe
         UE_LOG(LogSmartFoundations, Warning, TEXT("🔧 EXTEND Manifold Pipe Wire: Source connection failed (PipeConnected=%d, SourceConnected=%d)"),
             PipeToSource->IsConnected(), SourceConnector->IsConnected());
     }
-    
+
     // Find clone junction from BuiltJunctionsByChain
     AFGBuildable** CloneJunctionPtr = BuiltJunctionsByChain.Find(CloneChainId);
     if (!CloneJunctionPtr || !*CloneJunctionPtr)
@@ -3755,13 +3769,13 @@ void USFExtendService::WireManifoldPipe(AFGBuildablePipeline* BuiltPipe, UFGPipe
         UE_LOG(LogSmartFoundations, Warning, TEXT("🔧 EXTEND Manifold Pipe Wire: Clone junction not found for chain %d"), CloneChainId);
         return;
     }
-    
+
     AFGBuildable* CloneJunction = *CloneJunctionPtr;
-    
+
     // Get clone junction's connectors
     TArray<UFGPipeConnectionComponentBase*> CloneConnectors;
     CloneJunction->GetComponents<UFGPipeConnectionComponentBase>(CloneConnectors);
-    
+
     // ============================================================
     // OPPOSING CONNECTOR APPROACH FOR PIPE MANIFOLD WIRING
     // ============================================================
@@ -3770,33 +3784,33 @@ void USFExtendService::WireManifoldPipe(AFGBuildablePipeline* BuiltPipe, UFGPipe
     // This matches the spawning logic where we selected the source connector
     // facing toward the clone, and used the same relative position on clone.
     // ============================================================
-    
+
     FVector CloneLocation = CloneJunction->GetActorLocation();
     FVector SourceLocation = SourceConnector->GetOwner()->GetActorLocation();
     FVector DirectionToSource = (SourceLocation - CloneLocation).GetSafeNormal();
-    
+
     UFGPipeConnectionComponentBase* BestCloneConnector = nullptr;
     float BestAlignment = -FLT_MAX;
-    
+
     for (UFGPipeConnectionComponentBase* CloneConn : CloneConnectors)
     {
         if (!CloneConn || CloneConn->IsConnected()) continue;
-        
+
         // Find the connector whose position (relative to junction center) best faces toward source
         FVector ConnPos = CloneConn->GetComponentLocation();
         FVector DirFromCenter = (ConnPos - CloneLocation).GetSafeNormal();
         float Alignment = FVector::DotProduct(DirFromCenter, DirectionToSource);
-        
+
         if (Alignment > BestAlignment)
         {
             BestAlignment = Alignment;
             BestCloneConnector = CloneConn;
         }
     }
-    
+
     UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("🔧 EXTEND Manifold Pipe Wire: Clone connector selection - BestAlignment=%.2f"),
         BestAlignment);
-    
+
     if (BestCloneConnector && !PipeToClone->IsConnected())
     {
         PipeToClone->SetConnection(BestCloneConnector);
@@ -3810,10 +3824,10 @@ void USFExtendService::WireManifoldPipe(AFGBuildablePipeline* BuiltPipe, UFGPipe
         UE_LOG(LogSmartFoundations, Warning, TEXT("🔧 EXTEND Manifold Pipe Wire: Clone connection failed (NoCloneConnector=%d, PipeConnected=%d)"),
             BestCloneConnector == nullptr, PipeToClone->IsConnected());
     }
-    
+
     UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("🔧 EXTEND Manifold Pipe Wire: ✅ Wired manifold pipe %s between source and clone junctions"),
         *BuiltPipe->GetName());
-    
+
     // Merge pipe networks to ensure fluid can flow
     // Cast to UFGPipeConnectionComponent to access GetPipeNetworkID()
     UFGPipeConnectionComponent* NetworkConn0 = Cast<UFGPipeConnectionComponent>(PipeConn0);
@@ -3828,7 +3842,7 @@ void USFExtendService::WireManifoldPipe(AFGBuildablePipeline* BuiltPipe, UFGPipe
             int32 Network1 = NetworkConn1->GetPipeNetworkID();
             UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("🔧 EXTEND Manifold Pipe Wire: Network IDs - Conn0=%d, Conn1=%d"),
                 Network0, Network1);
-            
+
             if (Network0 != Network1 && Network0 != INDEX_NONE && Network1 != INDEX_NONE)
             {
                 AFGPipeNetwork* Net0 = PipeSubsystem->FindPipeNetwork(Network0);
@@ -3872,34 +3886,34 @@ void USFExtendService::WireManifoldBelt(AFGBuildableConveyorBelt* BuiltBelt, UFG
         UE_LOG(LogSmartFoundations, Warning, TEXT("🔧 EXTEND Manifold Belt Wire: Invalid parameters"));
         return;
     }
-    
+
     // Get the belt's two connectors
     UFGFactoryConnectionComponent* BeltConn0 = BuiltBelt->GetConnection0();
     UFGFactoryConnectionComponent* BeltConn1 = BuiltBelt->GetConnection1();
-    
+
     if (!BeltConn0 || !BeltConn1)
     {
         UE_LOG(LogSmartFoundations, Warning, TEXT("🔧 EXTEND Manifold Belt Wire: Belt %s missing connectors"), *BuiltBelt->GetName());
         return;
     }
-    
+
     // Determine flow direction based on SourceConnector direction
     EFactoryConnectionDirection SourceDir = SourceConnector->GetDirection();
     bool bSourceIsOutput = (SourceDir == EFactoryConnectionDirection::FCD_OUTPUT);
-    
+
     // For SPLITTERS (INPUT chain): Source OUTPUT → Belt → Clone INPUT
     //   - SourceConnector is OUTPUT
     //   - Belt Conn0 (INPUT) connects to Source OUTPUT
     //   - Belt Conn1 (OUTPUT) connects to Clone INPUT
     //
-    // For MERGERS (OUTPUT chain): Clone OUTPUT → Belt → Source INPUT  
+    // For MERGERS (OUTPUT chain): Clone OUTPUT → Belt → Source INPUT
     //   - SourceConnector is INPUT (on source merger, receives from belt)
     //   - Belt Conn0 (INPUT) connects to Clone OUTPUT
     //   - Belt Conn1 (OUTPUT) connects to Source INPUT
-    
+
     UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("🔧 EXTEND Manifold Belt Wire: SourceConnector=%s, Dir=%d, bSourceIsOutput=%d"),
         *SourceConnector->GetName(), (int32)SourceDir, bSourceIsOutput);
-    
+
     // Find clone distributor from BuiltDistributorsByChain
     AFGBuildable** CloneDistributorPtr = BuiltDistributorsByChain.Find(CloneChainId);
     if (!CloneDistributorPtr || !*CloneDistributorPtr)
@@ -3907,17 +3921,17 @@ void USFExtendService::WireManifoldBelt(AFGBuildableConveyorBelt* BuiltBelt, UFG
         UE_LOG(LogSmartFoundations, Warning, TEXT("🔧 EXTEND Manifold Belt Wire: Clone distributor not found for chain %d"), CloneChainId);
         return;
     }
-    
+
     AFGBuildable* CloneDistributor = *CloneDistributorPtr;
-    
+
     // Get clone distributor's connectors
     TArray<UFGFactoryConnectionComponent*> CloneConnectors;
     CloneDistributor->GetComponents<UFGFactoryConnectionComponent>(CloneConnectors);
-    
+
     // Assign belt connectors based on flow direction
     UFGFactoryConnectionComponent* BeltToSource = nullptr;
     UFGFactoryConnectionComponent* BeltToClone = nullptr;
-    
+
     if (bSourceIsOutput)
     {
         // SPLITTER: Source OUTPUT → Belt Conn0 → Belt Conn1 → Clone INPUT
@@ -3930,7 +3944,7 @@ void USFExtendService::WireManifoldBelt(AFGBuildableConveyorBelt* BuiltBelt, UFG
         BeltToSource = BeltConn1;  // Belt sends to source
         BeltToClone = BeltConn0;   // Belt receives from clone
     }
-    
+
     // Wire belt to source distributor
     if (!BeltToSource->IsConnected() && !SourceConnector->IsConnected())
     {
@@ -3951,44 +3965,44 @@ void USFExtendService::WireManifoldBelt(AFGBuildableConveyorBelt* BuiltBelt, UFG
         UE_LOG(LogSmartFoundations, Warning, TEXT("🔧 EXTEND Manifold Belt Wire: Source connection failed (BeltConnected=%d, SourceConnected=%d)"),
             BeltToSource->IsConnected(), SourceConnector->IsConnected());
     }
-    
+
     // For clone connector direction:
     // - SPLITTER: Clone needs INPUT (to receive from belt)
     // - MERGER: Clone needs OUTPUT (to send to belt)
-    EFactoryConnectionDirection NeededDir = bSourceIsOutput 
+    EFactoryConnectionDirection NeededDir = bSourceIsOutput
         ? EFactoryConnectionDirection::FCD_INPUT   // Splitter: clone receives
         : EFactoryConnectionDirection::FCD_OUTPUT; // Merger: clone sends
-    
+
     // Find the closest available connector on the clone distributor
     FVector BeltCloneEndPos = BeltToClone->GetComponentLocation();
-    
+
     UFGFactoryConnectionComponent* BestCloneConnector = nullptr;
     float BestDistance = FLT_MAX;
-    
+
     for (UFGFactoryConnectionComponent* CloneConn : CloneConnectors)
     {
         if (!CloneConn || CloneConn->IsConnected()) continue;
-        
+
         // Check direction compatibility
         EFactoryConnectionDirection CloneDir = CloneConn->GetDirection();
         if (CloneDir != NeededDir && CloneDir != EFactoryConnectionDirection::FCD_ANY)
         {
             continue;
         }
-        
+
         // Find closest matching connector to belt's clone end
         float Distance = FVector::Dist(CloneConn->GetComponentLocation(), BeltCloneEndPos);
-        
+
         if (Distance < BestDistance)
         {
             BestDistance = Distance;
             BestCloneConnector = CloneConn;
         }
     }
-    
+
     UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("🔧 EXTEND Manifold Belt Wire: Clone connector selection - NeededDir=%d, BestDistance=%.2f"),
         (int32)NeededDir, BestDistance);
-    
+
     if (BestCloneConnector && !BeltToClone->IsConnected())
     {
         if (BeltToClone->CanConnectTo(BestCloneConnector))
@@ -4009,10 +4023,10 @@ void USFExtendService::WireManifoldBelt(AFGBuildableConveyorBelt* BuiltBelt, UFG
         UE_LOG(LogSmartFoundations, Warning, TEXT("🔧 EXTEND Manifold Belt Wire: Clone connection failed (NoCloneConnector=%d, BeltConnected=%d, NeededDir=%d)"),
             BestCloneConnector == nullptr, BeltToClone->IsConnected(), (int32)NeededDir);
     }
-    
+
     UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("🔧 EXTEND Manifold Belt Wire: ✅ Wired manifold belt %s between source and clone distributors"),
         *BuiltBelt->GetName());
-    
+
     // ============================================================
     // DIAGNOSTIC: Log chain state of manifold belt and connected belts
     // ============================================================
@@ -4023,7 +4037,7 @@ void USFExtendService::WireManifoldBelt(AFGBuildableConveyorBelt* BuiltBelt, UFG
             *BuiltBelt->GetName(),
             ManifoldChain ? *ManifoldChain->GetName() : TEXT("NULL"),
             ManifoldBucketID);
-        
+
         // Log source distributor connections
         AFGBuildable* SrcDist = SourceConnector->GetOuterBuildable();
         if (SrcDist)
@@ -4041,13 +4055,13 @@ void USFExtendService::WireManifoldBelt(AFGBuildableConveyorBelt* BuiltBelt, UFG
                     UFGFactoryConnectionComponent* Other = Conn->GetConnection();
                     AActor* OtherOwner = Other ? Other->GetOwner() : nullptr;
                     ConnectedTo = OtherOwner ? OtherOwner->GetName() : TEXT("(unknown)");
-                    
+
                     AFGBuildableConveyorBase* OtherBelt = Cast<AFGBuildableConveyorBase>(OtherOwner);
                     if (OtherBelt)
                     {
                         AFGConveyorChainActor* OtherChain = OtherBelt->GetConveyorChainActor();
                         int32 OtherBucket = OtherBelt->GetConveyorBucketID();
-                        ChainInfo = FString::Printf(TEXT(" [Chain=%s, Bucket=%d]"), 
+                        ChainInfo = FString::Printf(TEXT(" [Chain=%s, Bucket=%d]"),
                             OtherChain ? *OtherChain->GetName() : TEXT("NULL"), OtherBucket);
                     }
                 }
@@ -4055,7 +4069,7 @@ void USFExtendService::WireManifoldBelt(AFGBuildableConveyorBelt* BuiltBelt, UFG
                     *Conn->GetName(), (int32)Conn->GetDirection(), *ConnectedTo, *ChainInfo);
             }
         }
-        
+
         // Log clone distributor connections
         UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("🔧 EXTEND Chain Diag: Clone distributor %s has %d connectors:"), *CloneDistributor->GetName(), CloneConnectors.Num());
         for (UFGFactoryConnectionComponent* Conn : CloneConnectors)
@@ -4068,13 +4082,13 @@ void USFExtendService::WireManifoldBelt(AFGBuildableConveyorBelt* BuiltBelt, UFG
                 UFGFactoryConnectionComponent* Other = Conn->GetConnection();
                 AActor* OtherOwner = Other ? Other->GetOwner() : nullptr;
                 ConnectedTo = OtherOwner ? OtherOwner->GetName() : TEXT("(unknown)");
-                
+
                 AFGBuildableConveyorBase* OtherBelt = Cast<AFGBuildableConveyorBase>(OtherOwner);
                 if (OtherBelt)
                 {
                     AFGConveyorChainActor* OtherChain = OtherBelt->GetConveyorChainActor();
                     int32 OtherBucket = OtherBelt->GetConveyorBucketID();
-                    ChainInfo = FString::Printf(TEXT(" [Chain=%s, Bucket=%d]"), 
+                    ChainInfo = FString::Printf(TEXT(" [Chain=%s, Bucket=%d]"),
                         OtherChain ? *OtherChain->GetName() : TEXT("NULL"), OtherBucket);
                 }
             }
@@ -4082,13 +4096,13 @@ void USFExtendService::WireManifoldBelt(AFGBuildableConveyorBelt* BuiltBelt, UFG
                 *Conn->GetName(), (int32)Conn->GetDirection(), *ConnectedTo, *ChainInfo);
         }
     }
-    
+
     // ============================================================
     // CHAIN INTEGRATION NOTE
     // ============================================================
     // The manifold belt was built without connections, so it has no chain actor.
     // After wiring, it has BucketID (registered with subsystem) but ChainActor=NULL.
-    // 
+    //
     // We CANNOT destroy chain actors during the build process because:
     // 1. Immediate destruction crashes during parallel factory tick
     // 2. Deferred destruction still crashes because items flow before rebuild
@@ -4097,7 +4111,7 @@ void USFExtendService::WireManifoldBelt(AFGBuildableConveyorBelt* BuiltBelt, UFG
     // TODO: Find a proper way to integrate the manifold belt into the chain system,
     // possibly by calling AFGBuildableSubsystem::MigrateConveyorGroupToChainActor
     // or by building the belt with connections already set.
-    
+
     UE_LOG(LogSmartFoundations, Warning, TEXT("🔧 EXTEND Manifold Belt Wire: Manifold belt %s has ChainActor=%s, BucketID=%d - chain integration pending"),
         *BuiltBelt->GetName(),
         BuiltBelt->GetConveyorChainActor() ? *BuiltBelt->GetConveyorChainActor()->GetName() : TEXT("NULL"),
@@ -4110,13 +4124,13 @@ bool USFExtendService::CreateManifoldBelt(UFGFactoryConnectionComponent* FromCon
     {
         return false;
     }
-    
+
     UWorld* World = GetWorld();
     if (!World)
     {
         return false;
     }
-    
+
     // Get belt tier from auto-connect settings (highest unlocked)
     int32 BeltTier = 5;  // Default to Mk5
     if (USFSubsystem* SmartSubsystem = USFSubsystem::Get(World))
@@ -4124,9 +4138,9 @@ bool USFExtendService::CreateManifoldBelt(UFGFactoryConnectionComponent* FromCon
         AFGPlayerController* PC = World->GetFirstPlayerController<AFGPlayerController>();
         BeltTier = SmartSubsystem->GetHighestUnlockedBeltTier(PC);
     }
-    
+
     // Load belt class
-    FString BeltPath = FString::Printf(TEXT("/Game/FactoryGame/Buildable/Factory/ConveyorBeltMk%d/Build_ConveyorBeltMk%d.Build_ConveyorBeltMk%d_C"), 
+    FString BeltPath = FString::Printf(TEXT("/Game/FactoryGame/Buildable/Factory/ConveyorBeltMk%d/Build_ConveyorBeltMk%d.Build_ConveyorBeltMk%d_C"),
         BeltTier, BeltTier, BeltTier);
     UClass* BeltClass = LoadObject<UClass>(nullptr, *BeltPath);
     if (!BeltClass)
@@ -4134,13 +4148,13 @@ bool USFExtendService::CreateManifoldBelt(UFGFactoryConnectionComponent* FromCon
         UE_LOG(LogSmartFoundations, Warning, TEXT("   ⚠️ Failed to load belt class: %s"), *BeltPath);
         return false;
     }
-    
+
     // Calculate spline points for the belt
     FVector StartPos = FromConnector->GetComponentLocation();
     FVector EndPos = ToConnector->GetComponentLocation();
     FVector StartForward = FromConnector->GetForwardVector();
     FVector EndForward = -ToConnector->GetForwardVector();  // Negate for facing inward
-    
+
     // Create spline data (simple 2-point belt)
     TArray<FSplinePointData> SplineData;
     FSplinePointData StartPoint;
@@ -4148,31 +4162,31 @@ bool USFExtendService::CreateManifoldBelt(UFGFactoryConnectionComponent* FromCon
     StartPoint.ArriveTangent = StartForward * 100.0f;
     StartPoint.LeaveTangent = StartForward * 100.0f;
     SplineData.Add(StartPoint);
-    
+
     FSplinePointData EndPoint;
     EndPoint.Location = EndPos;
     EndPoint.ArriveTangent = EndForward * 100.0f;
     EndPoint.LeaveTangent = EndForward * 100.0f;
     SplineData.Add(EndPoint);
-    
+
     // Spawn belt
     FActorSpawnParameters SpawnParams;
     SpawnParams.SpawnCollisionHandlingOverride = ESpawnActorCollisionHandlingMethod::AlwaysSpawn;
-    
+
     AFGBuildableConveyorBelt* Belt = World->SpawnActor<AFGBuildableConveyorBelt>(BeltClass, StartPos, FRotator::ZeroRotator, SpawnParams);
     if (!Belt)
     {
         UE_LOG(LogSmartFoundations, Warning, TEXT("   ⚠️ Failed to spawn manifold belt"));
         return false;
     }
-    
+
     // Set spline data
     TArray<FSplinePointData>* MutableSpline = Belt->GetMutableSplinePointData();
     if (MutableSpline)
     {
         *MutableSpline = SplineData;
     }
-    
+
     // Respline the belt to apply the spline data
     AFGBuildableConveyorBelt* ResplinedBelt = AFGBuildableConveyorBelt::Respline(Belt, SplineData);
     if (ResplinedBelt)
@@ -4217,18 +4231,18 @@ bool USFExtendService::CreateManifoldPipe(UFGPipeConnectionComponentBase* FromCo
     {
         return false;
     }
-    
+
     UWorld* World = GetWorld();
     if (!World)
     {
         return false;
     }
-    
+
     // Get pipe tier from auto-connect settings (use Mk2 by default for now)
     int32 PipeTier = 2;  // Default to Mk2
-    
+
     // Load pipe class
-    FString PipePath = FString::Printf(TEXT("/Game/FactoryGame/Buildable/Factory/PipelineMk%d/Build_PipelineMK%d.Build_PipelineMK%d_C"), 
+    FString PipePath = FString::Printf(TEXT("/Game/FactoryGame/Buildable/Factory/PipelineMk%d/Build_PipelineMK%d.Build_PipelineMK%d_C"),
         PipeTier, PipeTier, PipeTier);
     UClass* PipeClass = LoadObject<UClass>(nullptr, *PipePath);
     if (!PipeClass)
@@ -4236,13 +4250,13 @@ bool USFExtendService::CreateManifoldPipe(UFGPipeConnectionComponentBase* FromCo
         UE_LOG(LogSmartFoundations, Warning, TEXT("   ⚠️ Failed to load pipe class: %s"), *PipePath);
         return false;
     }
-    
+
     // Calculate spline points for the pipe
     FVector StartPos = FromConnector->GetComponentLocation();
     FVector EndPos = ToConnector->GetComponentLocation();
     FVector StartForward = FromConnector->GetForwardVector();
     FVector EndForward = -ToConnector->GetForwardVector();
-    
+
     // Create spline data (simple 2-point pipe)
     TArray<FSplinePointData> SplineData;
     FSplinePointData StartPoint;
@@ -4250,24 +4264,24 @@ bool USFExtendService::CreateManifoldPipe(UFGPipeConnectionComponentBase* FromCo
     StartPoint.ArriveTangent = StartForward * 100.0f;
     StartPoint.LeaveTangent = StartForward * 100.0f;
     SplineData.Add(StartPoint);
-    
+
     FSplinePointData EndPoint;
     EndPoint.Location = EndPos;
     EndPoint.ArriveTangent = EndForward * 100.0f;
     EndPoint.LeaveTangent = EndForward * 100.0f;
     SplineData.Add(EndPoint);
-    
+
     // Spawn pipe with DEFERRED construction (same technique as BuildExtendPipeAndReturn)
     FActorSpawnParameters SpawnParams;
     SpawnParams.bDeferConstruction = true;
-    
+
     AFGBuildablePipeline* Pipe = World->SpawnActor<AFGBuildablePipeline>(PipeClass, StartPos, FRotator::ZeroRotator, SpawnParams);
     if (!Pipe)
     {
         UE_LOG(LogSmartFoundations, Warning, TEXT("   ⚠️ Failed to spawn manifold pipe"));
         return false;
     }
-    
+
     // Apply spline data BEFORE FinishSpawning
     TArray<FSplinePointData>* MutableSpline = Pipe->GetMutableSplinePointData();
     if (!MutableSpline)
@@ -4277,20 +4291,20 @@ bool USFExtendService::CreateManifoldPipe(UFGPipeConnectionComponentBase* FromCo
         return false;
     }
     *MutableSpline = SplineData;
-    
+
     // Finish spawning and signal build complete
     Pipe->FinishSpawning(FTransform(FRotator::ZeroRotator, StartPos));
     Pipe->OnBuildEffectFinished();
-    
+
     // Connect the pipe
     UFGPipeConnectionComponent* PipeConn0 = Pipe->GetPipeConnection0();
     UFGPipeConnectionComponent* PipeConn1 = Pipe->GetPipeConnection1();
-    
+
     if (PipeConn0 && PipeConn1)
     {
         PipeConn0->SetConnection(Cast<UFGPipeConnectionComponent>(FromConnector));
         PipeConn1->SetConnection(Cast<UFGPipeConnectionComponent>(ToConnector));
-        
+
         // Merge pipe networks
         AFGPipeSubsystem* PipeSubsystem = AFGPipeSubsystem::Get(World);
         if (PipeSubsystem)
@@ -4309,7 +4323,7 @@ bool USFExtendService::CreateManifoldPipe(UFGPipeConnectionComponentBase* FromCo
             }
         }
     }
-    
+
     UE_LOG(LogSmartFoundations, Log, TEXT("   🔧 Created manifold pipe Mk%d between junctions"), PipeTier);
     return true;
 }
@@ -4330,13 +4344,13 @@ FSFBuildableSnapshot USFExtendService::CaptureNearbyBuildables(float Radius)
     FSFBuildableSnapshot Snapshot;
     Snapshot.CaptureRadius = Radius;
     Snapshot.CaptureTime = FDateTime::Now();
-    
+
     if (!Subsystem.IsValid())
     {
         UE_LOG(LogSmartFoundations, Warning, TEXT("📊 DIAG: Cannot capture - no subsystem"));
         return Snapshot;
     }
-    
+
     // Get player location
     APlayerController* PC = Subsystem->GetWorld()->GetFirstPlayerController();
     if (!PC || !PC->GetPawn())
@@ -4344,9 +4358,9 @@ FSFBuildableSnapshot USFExtendService::CaptureNearbyBuildables(float Radius)
         UE_LOG(LogSmartFoundations, Warning, TEXT("📊 DIAG: Cannot capture - no player"));
         return Snapshot;
     }
-    
+
     FVector PlayerLocation = PC->GetPawn()->GetActorLocation();
-    
+
     // ==================== Build EXTEND Topology Lookup ====================
     // Maps buildable actor -> (Role, ChainId, ChainIndex)
     struct FExtendTopologyInfo {
@@ -4355,7 +4369,7 @@ FSFBuildableSnapshot USFExtendService::CaptureNearbyBuildables(float Radius)
         int32 ChainIndex = -1;
     };
     TMap<AActor*, FExtendTopologyInfo> TopologyLookup;
-    
+
     // Add source factory
     if (CurrentExtendTarget.IsValid())
     {
@@ -4363,12 +4377,12 @@ FSFBuildableSnapshot USFExtendService::CaptureNearbyBuildables(float Radius)
         Info.Role = TEXT("SourceFactory");
         TopologyLookup.Add(CurrentExtendTarget.Get(), Info);
     }
-    
+
     // Add input belt chain members (conveyors = belts + lifts, poles, and distributors)
     for (int32 ChainIdx = 0; ChainIdx < GetCurrentTopology().InputChains.Num(); ++ChainIdx)
     {
         const FSFConnectionChainNode& Chain = GetCurrentTopology().InputChains[ChainIdx];
-        
+
         // Add distributor (splitter) at chain end
         if (Chain.Distributor.IsValid())
         {
@@ -4377,7 +4391,7 @@ FSFBuildableSnapshot USFExtendService::CaptureNearbyBuildables(float Radius)
             Info.ChainId = ChainIdx;
             TopologyLookup.Add(Chain.Distributor.Get(), Info);
         }
-        
+
         // Add all conveyors (belts and lifts) in chain
         for (int32 ConvIdx = 0; ConvIdx < Chain.Conveyors.Num(); ++ConvIdx)
         {
@@ -4392,7 +4406,7 @@ FSFBuildableSnapshot USFExtendService::CaptureNearbyBuildables(float Radius)
                 TopologyLookup.Add(Conv, Info);
             }
         }
-        
+
         // Add all support poles in chain (future cloning candidate)
         for (int32 PoleIdx = 0; PoleIdx < Chain.SupportPoles.Num(); ++PoleIdx)
         {
@@ -4406,12 +4420,12 @@ FSFBuildableSnapshot USFExtendService::CaptureNearbyBuildables(float Radius)
             }
         }
     }
-    
+
     // Add output belt chain members
     for (int32 ChainIdx = 0; ChainIdx < GetCurrentTopology().OutputChains.Num(); ++ChainIdx)
     {
         const FSFConnectionChainNode& Chain = GetCurrentTopology().OutputChains[ChainIdx];
-        
+
         // Add distributor (merger) at chain end
         if (Chain.Distributor.IsValid())
         {
@@ -4420,7 +4434,7 @@ FSFBuildableSnapshot USFExtendService::CaptureNearbyBuildables(float Radius)
             Info.ChainId = ChainIdx;
             TopologyLookup.Add(Chain.Distributor.Get(), Info);
         }
-        
+
         // Add all conveyors (belts and lifts) in chain
         for (int32 ConvIdx = 0; ConvIdx < Chain.Conveyors.Num(); ++ConvIdx)
         {
@@ -4434,7 +4448,7 @@ FSFBuildableSnapshot USFExtendService::CaptureNearbyBuildables(float Radius)
                 TopologyLookup.Add(Conv, Info);
             }
         }
-        
+
         // Add all support poles in chain
         for (int32 PoleIdx = 0; PoleIdx < Chain.SupportPoles.Num(); ++PoleIdx)
         {
@@ -4448,12 +4462,12 @@ FSFBuildableSnapshot USFExtendService::CaptureNearbyBuildables(float Radius)
             }
         }
     }
-    
+
     // Add input pipe chain members
     for (int32 ChainIdx = 0; ChainIdx < GetCurrentTopology().PipeInputChains.Num(); ++ChainIdx)
     {
         const FSFPipeConnectionChainNode& Chain = GetCurrentTopology().PipeInputChains[ChainIdx];
-        
+
         // Add junction at chain end
         if (Chain.Junction.IsValid())
         {
@@ -4462,7 +4476,7 @@ FSFBuildableSnapshot USFExtendService::CaptureNearbyBuildables(float Radius)
             Info.ChainId = ChainIdx;
             TopologyLookup.Add(Chain.Junction.Get(), Info);
         }
-        
+
         // Add all pipes in chain
         for (int32 PipeIdx = 0; PipeIdx < Chain.Pipelines.Num(); ++PipeIdx)
         {
@@ -4475,7 +4489,7 @@ FSFBuildableSnapshot USFExtendService::CaptureNearbyBuildables(float Radius)
                 TopologyLookup.Add(Chain.Pipelines[PipeIdx].Get(), Info);
             }
         }
-        
+
         // Add all support poles (pipe supports) in chain
         for (int32 PoleIdx = 0; PoleIdx < Chain.SupportPoles.Num(); ++PoleIdx)
         {
@@ -4489,12 +4503,12 @@ FSFBuildableSnapshot USFExtendService::CaptureNearbyBuildables(float Radius)
             }
         }
     }
-    
+
     // Add output pipe chain members
     for (int32 ChainIdx = 0; ChainIdx < GetCurrentTopology().PipeOutputChains.Num(); ++ChainIdx)
     {
         const FSFPipeConnectionChainNode& Chain = GetCurrentTopology().PipeOutputChains[ChainIdx];
-        
+
         // Add junction at chain end
         if (Chain.Junction.IsValid())
         {
@@ -4503,7 +4517,7 @@ FSFBuildableSnapshot USFExtendService::CaptureNearbyBuildables(float Radius)
             Info.ChainId = ChainIdx;
             TopologyLookup.Add(Chain.Junction.Get(), Info);
         }
-        
+
         // Add all pipes in chain
         for (int32 PipeIdx = 0; PipeIdx < Chain.Pipelines.Num(); ++PipeIdx)
         {
@@ -4516,7 +4530,7 @@ FSFBuildableSnapshot USFExtendService::CaptureNearbyBuildables(float Radius)
                 TopologyLookup.Add(Chain.Pipelines[PipeIdx].Get(), Info);
             }
         }
-        
+
         // Add all support poles (pipe supports) in chain
         for (int32 PoleIdx = 0; PoleIdx < Chain.SupportPoles.Num(); ++PoleIdx)
         {
@@ -4530,51 +4544,51 @@ FSFBuildableSnapshot USFExtendService::CaptureNearbyBuildables(float Radius)
             }
         }
     }
-    
+
     UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("📊 DIAG: Built topology lookup with %d members"), TopologyLookup.Num());
     Snapshot.CaptureLocation = PlayerLocation;
-    
+
     // Find all buildables in radius
     TArray<AActor*> FoundActors;
     UGameplayStatics::GetAllActorsOfClass(Subsystem->GetWorld(), AFGBuildable::StaticClass(), FoundActors);
-    
+
     for (AActor* Actor : FoundActors)
     {
         AFGBuildable* Buildable = Cast<AFGBuildable>(Actor);
         if (!Buildable) continue;
-        
+
         float Distance = FVector::Dist(PlayerLocation, Buildable->GetActorLocation());
         if (Distance > Radius) continue;
-        
+
         FSFCapturedBuildable Captured;
-        
+
         // === Identity ===
         Captured.Name = Buildable->GetName();
         Captured.ClassName = Buildable->GetClass()->GetName();
-        
+
         // === Transform ===
         Captured.Location = Buildable->GetActorLocation();
         Captured.Rotation = Buildable->GetActorRotation();
         Captured.Scale = Buildable->GetActorScale3D();
-        
+
         // Get bounds
         FVector Origin, BoxExtent;
         Buildable->GetActorBounds(false, Origin, BoxExtent);
         Captured.BoundsMin = Origin - BoxExtent;
         Captured.BoundsMax = Origin + BoxExtent;
-        
+
         // === State ===
         Captured.bIsHidden = Buildable->IsHidden();
         Captured.bIsPendingKill = !IsValid(Buildable);
         Captured.bHasBegunPlay = Buildable->HasActorBegunPlay();
-        
+
         // === Capture Factory Connections ===
         TArray<UFGFactoryConnectionComponent*> FactoryConns;
         Buildable->GetComponents<UFGFactoryConnectionComponent>(FactoryConns);
         for (UFGFactoryConnectionComponent* Conn : FactoryConns)
         {
             if (!Conn) continue;
-            
+
             FSFCapturedConnection CapturedConn;
             CapturedConn.ConnectorName = Conn->GetName();
             CapturedConn.ConnectorClass = Conn->GetClass()->GetName();
@@ -4582,7 +4596,7 @@ FSFBuildableSnapshot USFExtendService::CaptureNearbyBuildables(float Radius)
             CapturedConn.WorldRotation = Conn->GetComponentRotation();
             CapturedConn.Direction = (int32)Conn->GetDirection();
             CapturedConn.bIsConnected = Conn->IsConnected();
-            
+
             if (Conn->IsConnected())
             {
                 UFGFactoryConnectionComponent* OtherConn = Conn->GetConnection();
@@ -4592,17 +4606,17 @@ FSFBuildableSnapshot USFExtendService::CaptureNearbyBuildables(float Radius)
                     CapturedConn.ConnectedToConnector = OtherConn->GetName();
                 }
             }
-            
+
             Captured.FactoryConnections.Add(CapturedConn);
         }
-        
+
         // === Capture Pipe Connections ===
         TArray<UFGPipeConnectionComponent*> PipeConns;
         Buildable->GetComponents<UFGPipeConnectionComponent>(PipeConns);
         for (UFGPipeConnectionComponent* Conn : PipeConns)
         {
             if (!Conn) continue;
-            
+
             FSFCapturedConnection CapturedConn;
             CapturedConn.ConnectorName = Conn->GetName();
             CapturedConn.ConnectorClass = Conn->GetClass()->GetName();
@@ -4610,7 +4624,7 @@ FSFBuildableSnapshot USFExtendService::CaptureNearbyBuildables(float Radius)
             CapturedConn.WorldRotation = Conn->GetComponentRotation();
             CapturedConn.Direction = (int32)Conn->GetPipeConnectionType();
             CapturedConn.bIsConnected = Conn->IsConnected();
-            
+
             if (Conn->IsConnected())
             {
                 UFGPipeConnectionComponentBase* OtherConnBase = Conn->GetConnection();
@@ -4620,22 +4634,22 @@ FSFBuildableSnapshot USFExtendService::CaptureNearbyBuildables(float Radius)
                     CapturedConn.ConnectedToConnector = OtherConnBase->GetName();
                 }
             }
-            
+
             Captured.PipeConnections.Add(CapturedConn);
         }
-        
+
         // === Categorize and gather type-specific data ===
         if (AFGBuildableConveyorBelt* Belt = Cast<AFGBuildableConveyorBelt>(Buildable))
         {
             Captured.Category = TEXT("Belt");
             Captured.BeltSpeed = Belt->GetSpeed();
-            
+
             // Get spline data
             if (USplineComponent* Spline = Belt->GetSplineComponent())
             {
                 Captured.SplineLength = Spline->GetSplineLength();
                 Captured.SplinePointCount = Spline->GetNumberOfSplinePoints();
-                
+
                 for (int32 i = 0; i < Spline->GetNumberOfSplinePoints(); ++i)
                 {
                     FSFCapturedSplinePoint Point;
@@ -4654,7 +4668,7 @@ FSFBuildableSnapshot USFExtendService::CaptureNearbyBuildables(float Radius)
             Captured.Category = TEXT("Lift");
             Captured.LiftHeight = Lift->GetHeight();
             Captured.bLiftIsReversed = Lift->GetIsReversed();
-            
+
             // Get connection locations
             TArray<UFGFactoryConnectionComponent*> LiftConns;
             Lift->GetComponents<UFGFactoryConnectionComponent>(LiftConns);
@@ -4677,13 +4691,13 @@ FSFBuildableSnapshot USFExtendService::CaptureNearbyBuildables(float Radius)
         else if (AFGBuildablePipeline* Pipe = Cast<AFGBuildablePipeline>(Buildable))
         {
             Captured.Category = TEXT("Pipe");
-            
+
             // Get spline data
             if (USplineComponent* Spline = Pipe->GetSplineComponent())
             {
                 Captured.SplineLength = Spline->GetSplineLength();
                 Captured.SplinePointCount = Spline->GetNumberOfSplinePoints();
-                
+
                 for (int32 i = 0; i < Spline->GetNumberOfSplinePoints(); ++i)
                 {
                     FSFCapturedSplinePoint Point;
@@ -4709,7 +4723,7 @@ FSFBuildableSnapshot USFExtendService::CaptureNearbyBuildables(float Radius)
         {
             Captured.Category = TEXT("Other");
         }
-        
+
         // === Check if this buildable is part of EXTEND topology ===
         if (FExtendTopologyInfo* TopoInfo = TopologyLookup.Find(Buildable))
         {
@@ -4718,14 +4732,14 @@ FSFBuildableSnapshot USFExtendService::CaptureNearbyBuildables(float Radius)
             Captured.ExtendChainId = TopoInfo->ChainId;
             Captured.ExtendChainIndex = TopoInfo->ChainIndex;
         }
-        
+
         Snapshot.Buildables.Add(Captured);
-        
+
         // Update category count
         int32& Count = Snapshot.CountByCategory.FindOrAdd(Captured.Category);
         Count++;
     }
-    
+
     return Snapshot;
 }
 
@@ -4740,36 +4754,36 @@ void USFExtendService::CapturePreviewSnapshot()
     {
         // Capture with RadarPulse (200m = 20000cm)
         FSFRadarPulseSnapshot PulseSnapshot = RadarPulse->CaptureSnapshot(20000.0f, TEXT("EXTEND_PRE"));
-        
+
         // Flag EXTEND source objects
         RadarPulse->FlagExtendSourceObjects(PulseSnapshot, GetCurrentTopology(), CurrentExtendTarget.Get());
-        
+
         // Cache for later comparison
         RadarPulse->CacheSnapshot(TEXT("EXTEND_PRE"), PulseSnapshot);
-        
+
         // Log the snapshot with EXTEND source details
         // RadarPulse->LogFlaggedObjects(PulseSnapshot, TEXT("ExtendSource"), true);  // DISABLED: Too verbose (~2000 lines)
-        
+
         bHasPreviewSnapshot = true;
         UE_LOG(LogSmartFoundations, Log, TEXT("📡 RadarPulse: EXTEND preview snapshot captured (%d objects, %d EXTEND sources)"),
             PulseSnapshot.TotalObjects, PulseSnapshot.ExtendSourceCount);
         return;
     }
     */
-    
+
     // Fallback to legacy capture if RadarPulse unavailable
     PreviewSnapshot = CaptureNearbyBuildables(15000.0f);  // 150m
     bHasPreviewSnapshot = true;
-    
-    UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("📊 DIAG: Captured PREVIEW snapshot - %d buildables within 150m"), 
+
+    UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("📊 DIAG: Captured PREVIEW snapshot - %d buildables within 150m"),
         PreviewSnapshot.Buildables.Num());
-    
+
     // Log summary by category
     for (const auto& Pair : PreviewSnapshot.CountByCategory)
     {
         UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("📊 DIAG:   %s: %d"), *Pair.Key, Pair.Value);
     }
-    
+
     // === Log EXTEND Source Topology Summary ===
     int32 SourceCount = 0;
     TMap<FString, int32> SourceByRole;
@@ -4782,7 +4796,7 @@ void USFExtendService::CapturePreviewSnapshot()
             Count++;
         }
     }
-    
+
     if (SourceCount > 0)
     {
         // DISABLED: Source topology box logging - generates ~30+ lines per Extend
@@ -4792,42 +4806,42 @@ void USFExtendService::CapturePreviewSnapshot()
         UE_LOG(LogSmartFoundations, Display, TEXT("╔═══════════════════════════════════════════════════════════════════╗"));
         UE_LOG(LogSmartFoundations, Display, TEXT("║           EXTEND SOURCE TOPOLOGY (%d members)                      ║"), SourceCount);
         UE_LOG(LogSmartFoundations, Display, TEXT("╠═══════════════════════════════════════════════════════════════════╣"));
-        
+
         for (const auto& Pair : SourceByRole)
         {
             UE_LOG(LogSmartFoundations, Display, TEXT("║   %-20s: %3d                                       ║"), *Pair.Key, Pair.Value);
         }
-        
+
         UE_LOG(LogSmartFoundations, Display, TEXT("╚═══════════════════════════════════════════════════════════════════╝"));
         */
-        
+
         // DISABLED: Detailed source topology logging generates ~1500 lines per Extend
         // Re-enable for debugging by uncommenting the block below
         /*
         // Log full details of SOURCE topology members
         UE_LOG(LogSmartFoundations, Display, TEXT(""));
         UE_LOG(LogSmartFoundations, Display, TEXT("📊 EXTEND SOURCE DETAILS:"));
-        
+
         for (const FSFCapturedBuildable& B : PreviewSnapshot.Buildables)
         {
             if (B.bIsExtendSource)
             {
                 UE_LOG(LogSmartFoundations, Display, TEXT(""));
                 UE_LOG(LogSmartFoundations, Display, TEXT("┌─────────────────────────────────────────────────────────────────────"));
-                UE_LOG(LogSmartFoundations, Display, TEXT("│ ★ %s [%s] - Chain %d, Index %d"), 
+                UE_LOG(LogSmartFoundations, Display, TEXT("│ ★ %s [%s] - Chain %d, Index %d"),
                     *B.ExtendRole, *B.Name, B.ExtendChainId, B.ExtendChainIndex);
                 UE_LOG(LogSmartFoundations, Display, TEXT("├─────────────────────────────────────────────────────────────────────"));
                 UE_LOG(LogSmartFoundations, Display, TEXT("│ Category: %s | Class: %s"), *B.Category, *B.ClassName);
                 UE_LOG(LogSmartFoundations, Display, TEXT("│ Location: X=%.3f Y=%.3f Z=%.3f"), B.Location.X, B.Location.Y, B.Location.Z);
                 UE_LOG(LogSmartFoundations, Display, TEXT("│ Rotation: P=%.3f Y=%.3f R=%.3f"), B.Rotation.Pitch, B.Rotation.Yaw, B.Rotation.Roll);
-                
+
                 // Belt-specific data
                 if (B.Category == TEXT("Belt"))
                 {
                     UE_LOG(LogSmartFoundations, Display, TEXT("│ ═══ BELT DATA ═══"));
-                    UE_LOG(LogSmartFoundations, Display, TEXT("│ Speed: %.1f | SplineLength: %.1fcm | SplinePoints: %d"), 
+                    UE_LOG(LogSmartFoundations, Display, TEXT("│ Speed: %.1f | SplineLength: %.1fcm | SplinePoints: %d"),
                         B.BeltSpeed, B.SplineLength, B.SplinePointCount);
-                    
+
                     for (const FSFCapturedSplinePoint& SP : B.SplinePoints)
                     {
                         UE_LOG(LogSmartFoundations, Display, TEXT("│   [Point %d] World=(%.1f,%.1f,%.1f)"),
@@ -4837,7 +4851,7 @@ void USFExtendService::CapturePreviewSnapshot()
                             SP.LeaveTangent.X, SP.LeaveTangent.Y, SP.LeaveTangent.Z);
                     }
                 }
-                
+
                 // Lift-specific data
                 if (B.Category == TEXT("Lift"))
                 {
@@ -4847,27 +4861,27 @@ void USFExtendService::CapturePreviewSnapshot()
                         B.LiftBottomLocation.X, B.LiftBottomLocation.Y, B.LiftBottomLocation.Z,
                         B.LiftTopLocation.X, B.LiftTopLocation.Y, B.LiftTopLocation.Z);
                 }
-                
+
                 // Pipe-specific data
                 if (B.Category == TEXT("Pipe"))
                 {
                     UE_LOG(LogSmartFoundations, Display, TEXT("│ ═══ PIPE DATA ═══"));
                     UE_LOG(LogSmartFoundations, Display, TEXT("│ SplineLength: %.1fcm | SplinePoints: %d"), B.SplineLength, B.SplinePointCount);
-                    
+
                     for (const FSFCapturedSplinePoint& SP : B.SplinePoints)
                     {
                         UE_LOG(LogSmartFoundations, Display, TEXT("│   [Point %d] World=(%.1f,%.1f,%.1f)"),
                             SP.Index, SP.WorldLocation.X, SP.WorldLocation.Y, SP.WorldLocation.Z);
                     }
                 }
-                
+
                 // Factory connections
                 if (B.FactoryConnections.Num() > 0)
                 {
                     UE_LOG(LogSmartFoundations, Display, TEXT("│ ═══ FACTORY CONNECTIONS (%d) ═══"), B.FactoryConnections.Num());
                     for (const FSFCapturedConnection& Conn : B.FactoryConnections)
                     {
-                        FString ConnStatus = Conn.bIsConnected 
+                        FString ConnStatus = Conn.bIsConnected
                             ? FString::Printf(TEXT("-> %s.%s"), *Conn.ConnectedToActor, *Conn.ConnectedToConnector)
                             : TEXT("(not connected)");
                         UE_LOG(LogSmartFoundations, Display, TEXT("│   %s [Dir=%d] @ (%.1f,%.1f,%.1f) %s"),
@@ -4876,14 +4890,14 @@ void USFExtendService::CapturePreviewSnapshot()
                             *ConnStatus);
                     }
                 }
-                
+
                 // Pipe connections
                 if (B.PipeConnections.Num() > 0)
                 {
                     UE_LOG(LogSmartFoundations, Display, TEXT("│ ═══ PIPE CONNECTIONS (%d) ═══"), B.PipeConnections.Num());
                     for (const FSFCapturedConnection& Conn : B.PipeConnections)
                     {
-                        FString ConnStatus = Conn.bIsConnected 
+                        FString ConnStatus = Conn.bIsConnected
                             ? FString::Printf(TEXT("-> %s.%s"), *Conn.ConnectedToActor, *Conn.ConnectedToConnector)
                             : TEXT("(not connected)");
                         UE_LOG(LogSmartFoundations, Display, TEXT("│   %s [Type=%d] @ (%.1f,%.1f,%.1f) %s"),
@@ -4892,7 +4906,7 @@ void USFExtendService::CapturePreviewSnapshot()
                             *ConnStatus);
                     }
                 }
-                
+
                 UE_LOG(LogSmartFoundations, Display, TEXT("└─────────────────────────────────────────────────────────────────────"));
             }
         }
@@ -4907,7 +4921,7 @@ void USFExtendService::CapturePostBuildSnapshotAndLogDiff()
         UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("📊 DIAG: No preview snapshot to compare against"));
         return;
     }
-    
+
     // DISABLED: RadarPulse generates too much log output (~1400 lines per Extend)
     // Re-enable for debugging by uncommenting the block below
     /*
@@ -4917,7 +4931,7 @@ void USFExtendService::CapturePostBuildSnapshotAndLogDiff()
     {
         // Capture POST snapshot (200m = 20000cm)
         FSFRadarPulseSnapshot PostSnapshot = RadarPulse->CaptureSnapshot(20000.0f, TEXT("EXTEND_POST"));
-        
+
         // Get the PRE snapshot from cache
         FSFRadarPulseSnapshot PreSnapshot;
         if (RadarPulse->GetCachedSnapshot(TEXT("EXTEND_PRE"), PreSnapshot))
@@ -4925,7 +4939,7 @@ void USFExtendService::CapturePostBuildSnapshotAndLogDiff()
             // Compare and log the diff
             FSFSnapshotDiff Diff = RadarPulse->CompareSnapshots(PreSnapshot, PostSnapshot);
             RadarPulse->LogDiff(Diff, true);  // Verbose output
-            
+
             UE_LOG(LogSmartFoundations, Log, TEXT("📡 RadarPulse: EXTEND build diff - %d new, %d removed, %d modified"),
                 Diff.NewObjects.Num(), Diff.RemovedObjects.Num(), Diff.ModifiedObjects.Num());
         }
@@ -4934,22 +4948,22 @@ void USFExtendService::CapturePostBuildSnapshotAndLogDiff()
             // No PRE snapshot cached, just log the POST snapshot
             RadarPulse->LogSnapshot(PostSnapshot, true);
         }
-        
+
         // Clear cache
         RadarPulse->ClearCache(TEXT("EXTEND_PRE"));
         bHasPreviewSnapshot = false;
         return;
     }
     */
-    
+
     // Fallback to legacy capture if RadarPulse unavailable
     FSFBuildableSnapshot PostBuildSnapshot = CaptureNearbyBuildables(15000.0f);  // 150m
-    
-    UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("📊 DIAG: Captured POST-BUILD snapshot - %d buildables within 150m"), 
+
+    UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("📊 DIAG: Captured POST-BUILD snapshot - %d buildables within 150m"),
         PostBuildSnapshot.Buildables.Num());
-    
+
     LogSnapshotDiff(PreviewSnapshot, PostBuildSnapshot);
-    
+
     // Clear the preview snapshot
     bHasPreviewSnapshot = false;
     PreviewSnapshot = FSFBuildableSnapshot();
@@ -4964,23 +4978,23 @@ void USFExtendService::LogSnapshotDiff(const FSFBuildableSnapshot& Before, const
     UE_LOG(LogSmartFoundations, Display, TEXT("╔═══════════════════════════════════════════════════════════════════╗"));
     UE_LOG(LogSmartFoundations, Display, TEXT("║               EXTEND DIAGNOSTIC: BUILD DIFF SUMMARY               ║"));
     UE_LOG(LogSmartFoundations, Display, TEXT("╠═══════════════════════════════════════════════════════════════════╣"));
-    UE_LOG(LogSmartFoundations, Display, TEXT("║ Capture Radius: 150m | Before: %4d buildables | After: %4d        ║"), 
+    UE_LOG(LogSmartFoundations, Display, TEXT("║ Capture Radius: 150m | Before: %4d buildables | After: %4d        ║"),
         Before.Buildables.Num(), After.Buildables.Num());
     UE_LOG(LogSmartFoundations, Display, TEXT("╠═══════════════════════════════════════════════════════════════════╣"));
-    
+
     // Build set of existing names for quick lookup
     TSet<FString> BeforeNames;
     for (const FSFCapturedBuildable& B : Before.Buildables)
     {
         BeforeNames.Add(B.Name);
     }
-    
+
     TSet<FString> AfterNames;
     for (const FSFCapturedBuildable& A : After.Buildables)
     {
         AfterNames.Add(A.Name);
     }
-    
+
     // Find new buildables (in After but not in Before)
     TArray<FSFCapturedBuildable> NewBuildables;
     for (const FSFCapturedBuildable& A : After.Buildables)
@@ -4990,7 +5004,7 @@ void USFExtendService::LogSnapshotDiff(const FSFBuildableSnapshot& Before, const
             NewBuildables.Add(A);
         }
     }
-    
+
     // Find removed buildables (in Before but not in After)
     TArray<FSFCapturedBuildable> RemovedBuildables;
     for (const FSFCapturedBuildable& B : Before.Buildables)
@@ -5000,7 +5014,7 @@ void USFExtendService::LogSnapshotDiff(const FSFBuildableSnapshot& Before, const
             RemovedBuildables.Add(B);
         }
     }
-    
+
     // Count new by category
     TMap<FString, int32> NewByCategory;
     for (const FSFCapturedBuildable& N : NewBuildables)
@@ -5008,7 +5022,7 @@ void USFExtendService::LogSnapshotDiff(const FSFBuildableSnapshot& Before, const
         int32& Count = NewByCategory.FindOrAdd(N.Category);
         Count++;
     }
-    
+
     // Count removed by category
     TMap<FString, int32> RemovedByCategory;
     for (const FSFCapturedBuildable& R : RemovedBuildables)
@@ -5016,16 +5030,16 @@ void USFExtendService::LogSnapshotDiff(const FSFBuildableSnapshot& Before, const
         int32& Count = RemovedByCategory.FindOrAdd(R.Category);
         Count++;
     }
-    
+
     // Log category summary
     UE_LOG(LogSmartFoundations, Display, TEXT("║ Category        │ Before │ After  │ New    │ Removed │ Delta   ║"));
     UE_LOG(LogSmartFoundations, Display, TEXT("╟─────────────────┼────────┼────────┼────────┼─────────┼─────────╢"));
-    
+
     // Collect all categories
     TSet<FString> AllCategories;
     for (const auto& Pair : Before.CountByCategory) AllCategories.Add(Pair.Key);
     for (const auto& Pair : After.CountByCategory) AllCategories.Add(Pair.Key);
-    
+
     for (const FString& Category : AllCategories)
     {
         int32 BeforeCount = Before.CountByCategory.Contains(Category) ? Before.CountByCategory[Category] : 0;
@@ -5033,21 +5047,21 @@ void USFExtendService::LogSnapshotDiff(const FSFBuildableSnapshot& Before, const
         int32 NewCount = NewByCategory.Contains(Category) ? NewByCategory[Category] : 0;
         int32 RemovedCount = RemovedByCategory.Contains(Category) ? RemovedByCategory[Category] : 0;
         int32 Delta = AfterCount - BeforeCount;
-        
+
         FString DeltaStr = Delta > 0 ? FString::Printf(TEXT("+%d"), Delta) : FString::Printf(TEXT("%d"), Delta);
-        
-        UE_LOG(LogSmartFoundations, Display, TEXT("║ %-15s │ %6d │ %6d │ %6d │ %7d │ %7s ║"), 
+
+        UE_LOG(LogSmartFoundations, Display, TEXT("║ %-15s │ %6d │ %6d │ %6d │ %7d │ %7s ║"),
             *Category, BeforeCount, AfterCount, NewCount, RemovedCount, *DeltaStr);
     }
-    
+
     UE_LOG(LogSmartFoundations, Display, TEXT("╠═══════════════════════════════════════════════════════════════════╣"));
-    UE_LOG(LogSmartFoundations, Display, TEXT("║ TOTAL           │ %6d │ %6d │ %6d │ %7d │ %+7d ║"), 
-        Before.Buildables.Num(), After.Buildables.Num(), 
+    UE_LOG(LogSmartFoundations, Display, TEXT("║ TOTAL           │ %6d │ %6d │ %6d │ %7d │ %+7d ║"),
+        Before.Buildables.Num(), After.Buildables.Num(),
         NewBuildables.Num(), RemovedBuildables.Num(),
         After.Buildables.Num() - Before.Buildables.Num());
     UE_LOG(LogSmartFoundations, Display, TEXT("╚═══════════════════════════════════════════════════════════════════╝"));
     */
-    
+
     // DISABLED: Detailed buildable enumeration generates ~1000 lines per Extend
     // Re-enable for debugging by uncommenting the block below
     /*
@@ -5058,54 +5072,54 @@ void USFExtendService::LogSnapshotDiff(const FSFBuildableSnapshot& Before, const
         UE_LOG(LogSmartFoundations, Display, TEXT("╔═══════════════════════════════════════════════════════════════════╗"));
         UE_LOG(LogSmartFoundations, Display, TEXT("║            FULL ENUMERATION: NEW BUILDABLES (%d total)            ║"), NewBuildables.Num());
         UE_LOG(LogSmartFoundations, Display, TEXT("╚═══════════════════════════════════════════════════════════════════╝"));
-        
+
         for (int32 i = 0; i < NewBuildables.Num(); ++i)
         {
             const FSFCapturedBuildable& N = NewBuildables[i];
-            
+
             UE_LOG(LogSmartFoundations, Display, TEXT(""));
             UE_LOG(LogSmartFoundations, Display, TEXT("┌─────────────────────────────────────────────────────────────────────"));
-            
+
             // Show EXTEND source badge prominently
             if (N.bIsExtendSource)
             {
                 UE_LOG(LogSmartFoundations, Display, TEXT("│ [%d] ★ EXTEND SOURCE ★ %s"), i, *N.Name);
-                UE_LOG(LogSmartFoundations, Display, TEXT("│     Role: %s | Chain: %d | Index: %d"), 
+                UE_LOG(LogSmartFoundations, Display, TEXT("│     Role: %s | Chain: %d | Index: %d"),
                     *N.ExtendRole, N.ExtendChainId, N.ExtendChainIndex);
             }
             else
             {
                 UE_LOG(LogSmartFoundations, Display, TEXT("│ [%d] %s"), i, *N.Name);
             }
-            
+
             UE_LOG(LogSmartFoundations, Display, TEXT("├─────────────────────────────────────────────────────────────────────"));
             UE_LOG(LogSmartFoundations, Display, TEXT("│ Category: %s | Class: %s"), *N.Category, *N.ClassName);
             UE_LOG(LogSmartFoundations, Display, TEXT("│ Location: X=%.3f Y=%.3f Z=%.3f"), N.Location.X, N.Location.Y, N.Location.Z);
             UE_LOG(LogSmartFoundations, Display, TEXT("│ Rotation: P=%.3f Y=%.3f R=%.3f"), N.Rotation.Pitch, N.Rotation.Yaw, N.Rotation.Roll);
             UE_LOG(LogSmartFoundations, Display, TEXT("│ Scale: X=%.3f Y=%.3f Z=%.3f"), N.Scale.X, N.Scale.Y, N.Scale.Z);
-            UE_LOG(LogSmartFoundations, Display, TEXT("│ Bounds: Min=(%.1f,%.1f,%.1f) Max=(%.1f,%.1f,%.1f)"), 
+            UE_LOG(LogSmartFoundations, Display, TEXT("│ Bounds: Min=(%.1f,%.1f,%.1f) Max=(%.1f,%.1f,%.1f)"),
                 N.BoundsMin.X, N.BoundsMin.Y, N.BoundsMin.Z, N.BoundsMax.X, N.BoundsMax.Y, N.BoundsMax.Z);
-            UE_LOG(LogSmartFoundations, Display, TEXT("│ State: Hidden=%d PendingKill=%d BegunPlay=%d"), 
+            UE_LOG(LogSmartFoundations, Display, TEXT("│ State: Hidden=%d PendingKill=%d BegunPlay=%d"),
                 N.bIsHidden, N.bIsPendingKill, N.bHasBegunPlay);
-            
+
             // Belt-specific data
             if (N.Category == TEXT("Belt"))
             {
                 UE_LOG(LogSmartFoundations, Display, TEXT("│ ═══ BELT DATA ═══"));
-                UE_LOG(LogSmartFoundations, Display, TEXT("│ Speed: %.1f | SplineLength: %.1fcm | SplinePoints: %d"), 
+                UE_LOG(LogSmartFoundations, Display, TEXT("│ Speed: %.1f | SplineLength: %.1fcm | SplinePoints: %d"),
                     N.BeltSpeed, N.SplineLength, N.SplinePointCount);
-                
+
                 for (const FSFCapturedSplinePoint& SP : N.SplinePoints)
                 {
                     UE_LOG(LogSmartFoundations, Display, TEXT("│   [Point %d] Local=(%.1f,%.1f,%.1f) World=(%.1f,%.1f,%.1f)"),
-                        SP.Index, SP.Location.X, SP.Location.Y, SP.Location.Z, 
+                        SP.Index, SP.Location.X, SP.Location.Y, SP.Location.Z,
                         SP.WorldLocation.X, SP.WorldLocation.Y, SP.WorldLocation.Z);
                     UE_LOG(LogSmartFoundations, Display, TEXT("│             Arrive=(%.1f,%.1f,%.1f) Leave=(%.1f,%.1f,%.1f)"),
                         SP.ArriveTangent.X, SP.ArriveTangent.Y, SP.ArriveTangent.Z,
                         SP.LeaveTangent.X, SP.LeaveTangent.Y, SP.LeaveTangent.Z);
                 }
             }
-            
+
             // Lift-specific data
             if (N.Category == TEXT("Lift"))
             {
@@ -5115,28 +5129,28 @@ void USFExtendService::LogSnapshotDiff(const FSFBuildableSnapshot& Before, const
                     N.LiftBottomLocation.X, N.LiftBottomLocation.Y, N.LiftBottomLocation.Z,
                     N.LiftTopLocation.X, N.LiftTopLocation.Y, N.LiftTopLocation.Z);
             }
-            
+
             // Pipe-specific data
             if (N.Category == TEXT("Pipe"))
             {
                 UE_LOG(LogSmartFoundations, Display, TEXT("│ ═══ PIPE DATA ═══"));
                 UE_LOG(LogSmartFoundations, Display, TEXT("│ SplineLength: %.1fcm | SplinePoints: %d"), N.SplineLength, N.SplinePointCount);
-                
+
                 for (const FSFCapturedSplinePoint& SP : N.SplinePoints)
                 {
                     UE_LOG(LogSmartFoundations, Display, TEXT("│   [Point %d] Local=(%.1f,%.1f,%.1f) World=(%.1f,%.1f,%.1f)"),
-                        SP.Index, SP.Location.X, SP.Location.Y, SP.Location.Z, 
+                        SP.Index, SP.Location.X, SP.Location.Y, SP.Location.Z,
                         SP.WorldLocation.X, SP.WorldLocation.Y, SP.WorldLocation.Z);
                 }
             }
-            
+
             // Factory connections
             if (N.FactoryConnections.Num() > 0)
             {
                 UE_LOG(LogSmartFoundations, Display, TEXT("│ ═══ FACTORY CONNECTIONS (%d) ═══"), N.FactoryConnections.Num());
                 for (const FSFCapturedConnection& Conn : N.FactoryConnections)
                 {
-                    FString ConnStatus = Conn.bIsConnected 
+                    FString ConnStatus = Conn.bIsConnected
                         ? FString::Printf(TEXT("-> %s.%s"), *Conn.ConnectedToActor, *Conn.ConnectedToConnector)
                         : TEXT("(not connected)");
                     UE_LOG(LogSmartFoundations, Display, TEXT("│   %s [Dir=%d] @ (%.1f,%.1f,%.1f) %s"),
@@ -5145,14 +5159,14 @@ void USFExtendService::LogSnapshotDiff(const FSFBuildableSnapshot& Before, const
                         *ConnStatus);
                 }
             }
-            
+
             // Pipe connections
             if (N.PipeConnections.Num() > 0)
             {
                 UE_LOG(LogSmartFoundations, Display, TEXT("│ ═══ PIPE CONNECTIONS (%d) ═══"), N.PipeConnections.Num());
                 for (const FSFCapturedConnection& Conn : N.PipeConnections)
                 {
-                    FString ConnStatus = Conn.bIsConnected 
+                    FString ConnStatus = Conn.bIsConnected
                         ? FString::Printf(TEXT("-> %s.%s"), *Conn.ConnectedToActor, *Conn.ConnectedToConnector)
                         : TEXT("(not connected)");
                     UE_LOG(LogSmartFoundations, Display, TEXT("│   %s [Type=%d] @ (%.1f,%.1f,%.1f) %s"),
@@ -5161,11 +5175,11 @@ void USFExtendService::LogSnapshotDiff(const FSFBuildableSnapshot& Before, const
                         *ConnStatus);
                 }
             }
-            
+
             UE_LOG(LogSmartFoundations, Display, TEXT("└─────────────────────────────────────────────────────────────────────"));
         }
     }
-    
+
     // Log FULL details of removed buildables
     if (RemovedBuildables.Num() > 0)
     {
@@ -5173,7 +5187,7 @@ void USFExtendService::LogSnapshotDiff(const FSFBuildableSnapshot& Before, const
         UE_LOG(LogSmartFoundations, Warning, TEXT("╔═══════════════════════════════════════════════════════════════════╗"));
         UE_LOG(LogSmartFoundations, Warning, TEXT("║          FULL ENUMERATION: REMOVED BUILDABLES (%d total)          ║"), RemovedBuildables.Num());
         UE_LOG(LogSmartFoundations, Warning, TEXT("╚═══════════════════════════════════════════════════════════════════╝"));
-        
+
         for (int32 i = 0; i < RemovedBuildables.Num(); ++i)
         {
             const FSFCapturedBuildable& R = RemovedBuildables[i];
@@ -5193,30 +5207,30 @@ int32 USFExtendService::GenerateAndExecuteWiring(AFGBuildableFactory* NewFactory
         UE_LOG(LogSmartFoundations, Warning, TEXT("🔌 EXTEND Phase 5/6: GenerateAndExecuteWiring called with null factory"));
         return 0;
     }
-    
+
     // Check if we have stored clone topology from JSON spawning
     if (!StoredCloneTopology.IsValid() || StoredCloneTopology->ChildHolograms.Num() == 0)
     {
         UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("🔌 EXTEND Phase 5/6: No stored clone topology - skipping JSON wiring"));
         return 0;
     }
-    
+
     UE_LOG(LogSmartFoundations, Log, TEXT("🔌 EXTEND Phase 5/6: Generating wiring manifest from %d child holograms, %d registered built actors"),
         StoredCloneTopology->ChildHolograms.Num(), JsonBuiltActors.Num());
-    
+
     // Build clone_id -> buildable mapping from JsonBuiltActors (populated during Construct())
     // Holograms are destroyed after Construct(), so we can't use JsonSpawnedHolograms here
     TMap<FString, AActor*> CloneIdToBuildable;
-    
+
     // Add parent factory
     CloneIdToBuildable.Add(TEXT("parent"), NewFactory);
-    
+
     // Copy all registered built actors
     for (const auto& Pair : JsonBuiltActors)
     {
         const FString& CloneId = Pair.Key;
         AActor* BuiltActor = Pair.Value;
-        
+
         if (IsValid(BuiltActor))
         {
             CloneIdToBuildable.Add(CloneId, BuiltActor);
@@ -5228,7 +5242,7 @@ int32 USFExtendService::GenerateAndExecuteWiring(AFGBuildableFactory* NewFactory
             UE_LOG(LogSmartFoundations, Warning, TEXT("🔌 EXTEND Phase 5/6: Registered actor for %s is no longer valid"), *CloneId);
         }
     }
-    
+
     // Pre-resolve "source:" targets from topology into CloneIdToBuildable.
     // Clone 1's lane segments have "source:ActorName" targets pointing to the SOURCE
     // building's distributors (real world actors, not clones). Without this, Generate()
@@ -5251,20 +5265,20 @@ int32 USFExtendService::GenerateAndExecuteWiring(AFGBuildableFactory* NewFactory
                     }
                 }
             };
-            
+
             ResolveSourceTarget(Holo.CloneConnections.ConveyorAny0.Target);
             ResolveSourceTarget(Holo.CloneConnections.ConveyorAny1.Target);
         }
     }
-    
+
     UE_LOG(LogSmartFoundations, Log, TEXT("🔌 EXTEND Phase 5/6: Mapped %d buildables (including parent + source targets)"), CloneIdToBuildable.Num());
-    
+
     // Generate wiring manifest
     FSFWiringManifest WiringManifest = FSFWiringManifest::Generate(
         *StoredCloneTopology,
         CloneIdToBuildable,
         NewFactory);
-    
+
     // Resolve source buildable targets for lane segments connecting to source junctions
     // These have bIsSourceBuildable=true and need resolution via GetSourceBuildableByName
     for (FSFWiringConnection& PipeConn : WiringManifest.PipeConnections)
@@ -5292,31 +5306,31 @@ int32 USFExtendService::GenerateAndExecuteWiring(AFGBuildableFactory* NewFactory
             }
         }
     }
-    
+
     // Save manifest for debugging
     FString LogDir = FPaths::ProjectLogDir();
     WiringManifest.SaveToFile(LogDir / TEXT("WiringManifest.json"));
-    
+
     UE_LOG(LogSmartFoundations, Log, TEXT("🔌 EXTEND Phase 5/6: Generated manifest - %d belt connections, %d pipe connections"),
         WiringManifest.BeltConnections.Num(), WiringManifest.PipeConnections.Num());
-    
+
     // Execute all wiring in single tick
     int32 WiredCount = WiringManifest.ExecuteWiring(GetWorld());
-    
+
     UE_LOG(LogSmartFoundations, Log, TEXT("🔌 EXTEND Phase 5/6: Wiring complete - %d connections established"), WiredCount);
-    
+
     // Create chain actors for wired belts (prevents crash in Factory_UpdateRadioactivity)
     // Pass JsonBuiltActors to include lane segments that were wired in ConfigureComponents
     int32 ChainsCreated = WiringManifest.CreateChainActors(GetWorld(), JsonBuiltActors);
-    
+
     UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("🔌 EXTEND Phase 5/6: Chain actors created - %d chains"), ChainsCreated);
-    
+
     // Rebuild pipe networks to ensure fluid flow between source and clone manifolds
     // Pass JsonBuiltActors to include lane segment pipes that were wired in ConfigureComponents
     int32 NetworksRebuilt = WiringManifest.RebuildPipeNetworks(GetWorld(), JsonBuiltActors);
-    
+
     UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("🔌 EXTEND Phase 5/6: Pipe networks rebuilt - %d networks"), NetworksRebuilt);
-    
+
     // ==================== Lift ↔ Passthrough Linking (Issue #260) ====================
     // Built lifts need mSnappedPassthroughs set so they render as half-height
     // when connected to floor holes. Uses world search (TActorIterator) to find
@@ -5331,16 +5345,16 @@ int32 USFExtendService::GenerateAndExecuteWiring(AFGBuildableFactory* NewFactory
                 BuiltLifts.AddUnique(Lift);
             }
         }
-        
+
         UE_LOG(LogSmartFoundations, Warning, TEXT("🔗 PASSTHROUGH LINK: Found %d built lifts in JsonBuiltActors (%d total entries)"),
             BuiltLifts.Num(), JsonBuiltActors.Num());
-        
+
         if (BuiltLifts.Num() > 0)
         {
             // Step 2: Collect ALL passthroughs in the world near the build area (via TActorIterator)
             TArray<AFGBuildablePassthrough*> NearbyPassthroughs;
             FVector BuildCenter = NewFactory ? NewFactory->GetActorLocation() : FVector::ZeroVector;
-            
+
             for (TActorIterator<AFGBuildablePassthrough> It(GetWorld()); It; ++It)
             {
                 AFGBuildablePassthrough* PT = *It;
@@ -5349,42 +5363,42 @@ int32 USFExtendService::GenerateAndExecuteWiring(AFGBuildableFactory* NewFactory
                     NearbyPassthroughs.Add(PT);
                 }
             }
-            
+
             UE_LOG(LogSmartFoundations, Warning, TEXT("🔗 PASSTHROUGH LINK: Found %d passthroughs within 100m of factory at %s"),
                 NearbyPassthroughs.Num(), *BuildCenter.ToString());
-            
+
             // Step 3: Get reflection property
             FProperty* SnappedProp = AFGBuildableConveyorLift::StaticClass()->FindPropertyByName(TEXT("mSnappedPassthroughs"));
             UE_LOG(LogSmartFoundations, Warning, TEXT("🔗 PASSTHROUGH LINK: mSnappedPassthroughs property %s"),
                 SnappedProp ? TEXT("FOUND") : TEXT("NOT FOUND"));
-            
+
             // Step 4: For each lift, find closest passthrough at bottom or top position
             int32 LinkedCount = 0;
             const float SnapDistance = 100.0f; // 1m tolerance
-            
+
             for (AFGBuildableConveyorLift* Lift : BuiltLifts)
             {
                 if (!IsValid(Lift) || !SnappedProp) continue;
-                
+
                 FVector LiftLoc = Lift->GetActorLocation();
                 FTransform TopXform = Lift->GetTopTransform();
                 FVector LiftTop = Lift->GetActorTransform().TransformPosition(TopXform.GetTranslation());
-                
+
                 UE_LOG(LogSmartFoundations, Warning, TEXT("🔗 PASSTHROUGH LINK: Lift %s bottom=(%s) top=(%s)"),
                     *Lift->GetName(), *LiftLoc.ToString(), *LiftTop.ToString());
-                
+
                 AFGBuildablePassthrough* BottomPT = nullptr;
                 AFGBuildablePassthrough* TopPT = nullptr;
                 float BestBottomDist = SnapDistance;
                 float BestTopDist = SnapDistance;
-                
+
                 for (AFGBuildablePassthrough* PT : NearbyPassthroughs)
                 {
                     FVector PTLoc = PT->GetActorLocation();
-                    
+
                     float DistBottom = FVector::Dist(PTLoc, LiftLoc);
                     float DistTop = FVector::Dist(PTLoc, LiftTop);
-                    
+
                     if (DistBottom < BestBottomDist)
                     {
                         BestBottomDist = DistBottom;
@@ -5396,17 +5410,17 @@ int32 USFExtendService::GenerateAndExecuteWiring(AFGBuildableFactory* NewFactory
                         TopPT = PT;
                     }
                 }
-                
+
                 if (BottomPT || TopPT)
                 {
                     // Use reflection to access private mSnappedPassthroughs
-                    TArray<AFGBuildablePassthrough*>* PassthroughArray = 
+                    TArray<AFGBuildablePassthrough*>* PassthroughArray =
                         SnappedProp->ContainerPtrToValuePtr<TArray<AFGBuildablePassthrough*>>(Lift);
-                    
+
                     if (PassthroughArray)
                     {
                         if (PassthroughArray->Num() < 2) PassthroughArray->SetNum(2);
-                        
+
                         if (BottomPT)
                         {
                             (*PassthroughArray)[0] = BottomPT;
@@ -5421,7 +5435,7 @@ int32 USFExtendService::GenerateAndExecuteWiring(AFGBuildableFactory* NewFactory
                             UE_LOG(LogSmartFoundations, Warning, TEXT("🔗   → top=%s (dist=%.1f)"),
                                 *TopPT->GetName(), BestTopDist);
                         }
-                        
+
                         // Trigger mesh rebuild via OnRep
                         UFunction* OnRepFunc = Lift->FindFunction(TEXT("OnRep_SnappedPassthroughs"));
                         if (OnRepFunc)
@@ -5433,7 +5447,7 @@ int32 USFExtendService::GenerateAndExecuteWiring(AFGBuildableFactory* NewFactory
                         {
                             UE_LOG(LogSmartFoundations, Warning, TEXT("🔗   → OnRep_SnappedPassthroughs NOT FOUND as UFunction"));
                         }
-                        
+
                         LinkedCount++;
                     }
                     else
@@ -5446,12 +5460,12 @@ int32 USFExtendService::GenerateAndExecuteWiring(AFGBuildableFactory* NewFactory
                     UE_LOG(LogSmartFoundations, Warning, TEXT("🔗   → no passthrough within %.0fcm"), SnapDistance);
                 }
             }
-            
+
             UE_LOG(LogSmartFoundations, Warning, TEXT("🔗 PASSTHROUGH LINK: Linked %d/%d lifts to passthroughs"),
                 LinkedCount, BuiltLifts.Num());
         }
     }
-    
+
     // ==================== Pipe ↔ Passthrough Linking ====================
     // Built pipes through floor holes need SetTopSnappedConnection/SetBottomSnappedConnection
     // called on the passthrough with the pipe's connection. Same pattern as lift linking above.
@@ -5466,44 +5480,44 @@ int32 USFExtendService::GenerateAndExecuteWiring(AFGBuildableFactory* NewFactory
                 BuiltPipes.AddUnique(Pipe);
             }
         }
-        
+
         if (BuiltPipes.Num() > 0)
         {
             // Collect nearby pipe passthroughs
             TArray<AFGBuildablePassthrough*> NearbyPipePassthroughs;
             FVector PipeBuildCenter = NewFactory ? NewFactory->GetActorLocation() : FVector::ZeroVector;
-            
+
             for (TActorIterator<AFGBuildablePassthrough> It(GetWorld()); It; ++It)
             {
                 AFGBuildablePassthrough* PT = *It;
                 if (!IsValid(PT)) continue;
-                
+
                 // Only pipe floor holes (class name contains "Pipe")
                 FString PTClassName = PT->GetClass()->GetFName().ToString();
                 if (!PTClassName.Contains(TEXT("Pipe"))) continue;
-                
+
                 if (FVector::Dist(PT->GetActorLocation(), PipeBuildCenter) < 10000.0f)
                 {
                     NearbyPipePassthroughs.Add(PT);
                 }
             }
-            
+
             int32 PipeLinkedCount = 0;
             const float PipeSnapDist = 100.0f; // 1m XY tolerance
-            
+
             for (AFGBuildablePipeline* Pipe : BuiltPipes)
             {
                 if (!IsValid(Pipe)) continue;
-                
+
                 // Check both endpoints of the pipe
                 UFGPipeConnectionComponentBase* PipeConn0 = Pipe->GetPipeConnection0();
                 UFGPipeConnectionComponentBase* PipeConn1 = Pipe->GetPipeConnection1();
-                
+
                 for (AFGBuildablePassthrough* PT : NearbyPipePassthroughs)
                 {
                     FVector PTLoc = PT->GetActorLocation();
                     float PTZ = PTLoc.Z;
-                    
+
                     // Check Conn0 against this passthrough
                     if (PipeConn0)
                     {
@@ -5525,7 +5539,7 @@ int32 USFExtendService::GenerateAndExecuteWiring(AFGBuildableFactory* NewFactory
                             }
                         }
                     }
-                    
+
                     // Check Conn1 against this passthrough
                     if (PipeConn1)
                     {
@@ -5549,7 +5563,7 @@ int32 USFExtendService::GenerateAndExecuteWiring(AFGBuildableFactory* NewFactory
                     }
                 }
             }
-            
+
             if (PipeLinkedCount > 0)
             {
                 UE_LOG(LogSmartFoundations, Log, TEXT("🔗 PIPE PASSTHROUGH LINK: Linked %d pipe connections to %d pipe floor holes"),
@@ -5557,7 +5571,7 @@ int32 USFExtendService::GenerateAndExecuteWiring(AFGBuildableFactory* NewFactory
             }
         }
     }
-    
+
     // VERIFICATION: Log chain actor status for all built conveyors
     UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("⛓️ VERIFY CHAINS: Checking %d built actors for chain actor status"), JsonBuiltActors.Num());
     int32 ValidChains = 0;
@@ -5582,17 +5596,17 @@ int32 USFExtendService::GenerateAndExecuteWiring(AFGBuildableFactory* NewFactory
         }
     }
     UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("⛓️ VERIFY CHAINS: %d valid, %d NULL (crash risk if NULL > 0)"), ValidChains, NullChains);
-    
+
     // ==================== Power Pole Wiring (Issue #229) ====================
     // Wire built power poles: clone factory ↔ clone pole, and source pole ↔ clone pole
     int32 PowerWiredCount = 0;
     UClass* WireClass = LoadClass<AFGBuildableWire>(nullptr, TEXT("/Game/FactoryGame/Buildable/Factory/PowerLine/Build_PowerLine.Build_PowerLine_C"));
-    
+
     for (const auto& WiringPair : PowerPoleWiringData)
     {
         const FString& CloneId = WiringPair.Key;
         const FSFSourcePoleWiringData& SourceData = WiringPair.Value;
-        
+
         // Find the built clone pole
         AActor* const* BuiltPoleActor = CloneIdToBuildable.Find(CloneId);
         if (!BuiltPoleActor || !IsValid(*BuiltPoleActor))
@@ -5600,16 +5614,16 @@ int32 USFExtendService::GenerateAndExecuteWiring(AFGBuildableFactory* NewFactory
             UE_LOG(LogSmartFoundations, Warning, TEXT("⚡ EXTEND Power Wire: Clone pole %s not found in built actors"), *CloneId);
             continue;
         }
-        
+
         AFGBuildablePowerPole* ClonePole = Cast<AFGBuildablePowerPole>(*BuiltPoleActor);
         if (!ClonePole)
         {
             UE_LOG(LogSmartFoundations, Warning, TEXT("⚡ EXTEND Power Wire: Built actor %s is not a power pole"), *CloneId);
             continue;
         }
-        
+
         UE_LOG(LogSmartFoundations, Log, TEXT("⚡ EXTEND Power Wire: Processing %s -> %s"), *CloneId, *ClonePole->GetName());
-        
+
         // --- Wire 1: Clone Factory ↔ Clone Pole ---
         if (WireClass && IsValid(NewFactory))
         {
@@ -5617,24 +5631,24 @@ int32 USFExtendService::GenerateAndExecuteWiring(AFGBuildableFactory* NewFactory
             // (belt/pipe connectors use separate class hierarchies, so only power conns returned)
             TArray<UFGCircuitConnectionComponent*> FactoryCircuitConns;
             NewFactory->GetComponents<UFGCircuitConnectionComponent>(FactoryCircuitConns);
-            
+
             TArray<UFGCircuitConnectionComponent*> PoleCircuitConns;
             ClonePole->GetComponents<UFGCircuitConnectionComponent>(PoleCircuitConns);
-            
+
             UE_LOG(LogSmartFoundations, Log, TEXT("⚡ EXTEND Power Wire: Factory %s has %d circuit conns, Pole %s has %d circuit conns"),
                 *NewFactory->GetName(), FactoryCircuitConns.Num(), *ClonePole->GetName(), PoleCircuitConns.Num());
-            
+
             if (FactoryCircuitConns.Num() > 0 && PoleCircuitConns.Num() > 0)
             {
                 UFGCircuitConnectionComponent* FactoryConn = FactoryCircuitConns[0];
                 UFGCircuitConnectionComponent* PoleConn = PoleCircuitConns[0];
-                
+
                 FActorSpawnParameters SpawnParams;
                 SpawnParams.SpawnCollisionHandlingOverride = ESpawnActorCollisionHandlingMethod::AlwaysSpawn;
-                
+
                 AFGBuildableWire* NewWire = GetWorld()->SpawnActor<AFGBuildableWire>(
                     WireClass, ClonePole->GetActorLocation(), FRotator::ZeroRotator, SpawnParams);
-                
+
                 if (NewWire)
                 {
                     bool bConnected = NewWire->Connect(FactoryConn, PoleConn);
@@ -5657,30 +5671,30 @@ int32 USFExtendService::GenerateAndExecuteWiring(AFGBuildableFactory* NewFactory
                     *NewFactory->GetClass()->GetName(), FactoryCircuitConns.Num(), PoleCircuitConns.Num());
             }
         }
-        
+
         // --- Wire 2: Source Pole ↔ Clone Pole (only if source has free connections) ---
         if (WireClass && SourceData.SourcePole.IsValid() && SourceData.bSourceHasFreeConnections)
         {
             AFGBuildablePowerPole* SourcePole = SourceData.SourcePole.Get();
-            
+
             // Get circuit connections on both poles
             TArray<UFGCircuitConnectionComponent*> SourceCircuitConns;
             SourcePole->GetComponents<UFGCircuitConnectionComponent>(SourceCircuitConns);
-            
+
             TArray<UFGCircuitConnectionComponent*> CloneCircuitConns;
             ClonePole->GetComponents<UFGCircuitConnectionComponent>(CloneCircuitConns);
-            
+
             if (SourceCircuitConns.Num() > 0 && CloneCircuitConns.Num() > 0)
             {
                 UFGCircuitConnectionComponent* SourceConn = SourceCircuitConns[0];
                 UFGCircuitConnectionComponent* CloneConn = CloneCircuitConns[0];
-                
+
                 FActorSpawnParameters SpawnParams;
                 SpawnParams.SpawnCollisionHandlingOverride = ESpawnActorCollisionHandlingMethod::AlwaysSpawn;
-                
+
                 AFGBuildableWire* NewWire = GetWorld()->SpawnActor<AFGBuildableWire>(
                     WireClass, SourcePole->GetActorLocation(), FRotator::ZeroRotator, SpawnParams);
-                
+
                 if (NewWire)
                 {
                     bool bConnected = NewWire->Connect(SourceConn, CloneConn);
@@ -5704,18 +5718,18 @@ int32 USFExtendService::GenerateAndExecuteWiring(AFGBuildableFactory* NewFactory
                 *SourceData.SourcePole->GetName());
         }
     }
-    
+
     if (PowerWiredCount > 0)
     {
         UE_LOG(LogSmartFoundations, Log, TEXT("⚡ EXTEND Power Wire: Complete - %d power connections established"), PowerWiredCount);
     }
     WiredCount += PowerWiredCount;
-    
+
     // Capture built factory topology for comparison with source
     FSFSourceTopology BuiltTopology = FSFSourceTopology::CaptureFromBuiltFactory(NewFactory);
     BuiltTopology.SaveToFile(LogDir / TEXT("ManifoldBuilt.json"));
     UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("📋 EXTEND: Saved ManifoldBuilt.json for comparison with ManifoldSource.json"));
-    
+
     // ==================== Scaled Extend: Additional Clone Wiring (Issue #265) ====================
     // Process wiring for each additional clone set beyond clone 1
     int32 ScaledExtendWiredCount = 0;
@@ -5726,12 +5740,12 @@ int32 USFExtendService::GenerateAndExecuteWiring(AFGBuildableFactory* NewFactory
         {
             continue;
         }
-        
+
         // Find this clone's factory building from built actors
         // The factory hologram was registered as "factory" in the clone's SpawnedHolograms
         // But we need to find the BUILT factory, not the hologram
         AFGBuildableFactory* CloneFactory = nullptr;
-        
+
         // Search JsonBuiltActors for any factory building near the clone's expected position
         // Clone.WorldOffset is relative to SOURCE building, not clone 1
         FVector SourcePos = CurrentExtendTarget.IsValid() ? CurrentExtendTarget->GetActorLocation() : (NewFactory->GetActorLocation() - ScaledExtendClones[0].WorldOffset);
@@ -5749,7 +5763,7 @@ int32 USFExtendService::GenerateAndExecuteWiring(AFGBuildableFactory* NewFactory
                 }
             }
         }
-        
+
         if (!CloneFactory)
         {
             // Try finding from OnActorSpawned-registered factories
@@ -5763,17 +5777,17 @@ int32 USFExtendService::GenerateAndExecuteWiring(AFGBuildableFactory* NewFactory
                 }
             }
         }
-        
+
         if (!CloneFactory)
         {
             UE_LOG(LogSmartFoundations, Warning, TEXT("⚡ SCALED EXTEND Wire: Could not find built factory for Clone[%d] at expected position"), CloneIdx);
             continue;
         }
-        
+
         // Build clone_id -> buildable mapping for this clone set
         TMap<FString, AActor*> CloneBuiltActors;
         CloneBuiltActors.Add(TEXT("parent"), CloneFactory);
-        
+
         // Find all built actors with this clone's prefix
         FString ClonePrefix = FString::Printf(TEXT("sc%d_"), CloneIdx);
         for (const auto& Pair : JsonBuiltActors)
@@ -5785,10 +5799,10 @@ int32 USFExtendService::GenerateAndExecuteWiring(AFGBuildableFactory* NewFactory
                 CloneBuiltActors.Add(OriginalId, Pair.Value);
             }
         }
-        
+
         UE_LOG(LogSmartFoundations, Log, TEXT("⚡ SCALED EXTEND Wire: Clone[%d] - %d built actors mapped (factory=%s)"),
             CloneIdx, CloneBuiltActors.Num(), *CloneFactory->GetName());
-        
+
         // Generate and execute wiring for this clone
         // Use the clone's topology but with stripped IDs (matching original topology structure)
         FSFCloneTopology StrippedTopology = *Clone.CloneTopology;
@@ -5798,15 +5812,19 @@ int32 USFExtendService::GenerateAndExecuteWiring(AFGBuildableFactory* NewFactory
             {
                 Holo.HologramId = Holo.HologramId.Mid(ClonePrefix.Len());
             }
+            if (Holo.ConnectedPowerPoleHologramId.StartsWith(ClonePrefix))
+            {
+                Holo.ConnectedPowerPoleHologramId = Holo.ConnectedPowerPoleHologramId.Mid(ClonePrefix.Len());
+            }
         }
-        
+
         FSFWiringManifest CloneManifest = FSFWiringManifest::Generate(
             StrippedTopology, CloneBuiltActors, CloneFactory);
-        
+
         int32 CloneWired = CloneManifest.ExecuteWiring(GetWorld());
         int32 CloneChains = CloneManifest.CreateChainActors(GetWorld(), CloneBuiltActors);
         int32 ClonePipes = CloneManifest.RebuildPipeNetworks(GetWorld(), CloneBuiltActors);
-        
+
         // Lift ↔ Passthrough linking for scaled clone (Issue #260) — world search approach
         {
             TArray<AFGBuildableConveyorLift*> CloneLifts;
@@ -5854,7 +5872,7 @@ int32 USFExtendService::GenerateAndExecuteWiring(AFGBuildableFactory* NewFactory
                 }
             }
         }
-        
+
         // Pipe ↔ Passthrough linking for scaled clone
         {
             TArray<AFGBuildablePipeline*> ClonePipeList;
@@ -5915,7 +5933,7 @@ int32 USFExtendService::GenerateAndExecuteWiring(AFGBuildableFactory* NewFactory
                 }
             }
         }
-        
+
         // Power pole wiring for this clone — connect built power poles to clone factory
         int32 ClonePowerWired = 0;
         if (WireClass)
@@ -5923,26 +5941,26 @@ int32 USFExtendService::GenerateAndExecuteWiring(AFGBuildableFactory* NewFactory
             for (const auto& BuiltPair : CloneBuiltActors)
             {
                 if (!BuiltPair.Key.Contains(TEXT("power_pole"))) continue;
-                
+
                 AFGBuildablePowerPole* ClonePole = Cast<AFGBuildablePowerPole>(BuiltPair.Value);
                 if (!ClonePole) continue;
-                
+
                 // Get circuit connections on both pole and factory
                 // Factory power connections are UFGCircuitConnectionComponent subclass
                 TArray<UFGCircuitConnectionComponent*> PoleCircuitConns;
                 ClonePole->GetComponents<UFGCircuitConnectionComponent>(PoleCircuitConns);
-                
+
                 TArray<UFGCircuitConnectionComponent*> FactoryCircuitConns;
                 CloneFactory->GetComponents<UFGCircuitConnectionComponent>(FactoryCircuitConns);
-                
+
                 if (PoleCircuitConns.Num() > 0 && FactoryCircuitConns.Num() > 0)
                 {
                     FActorSpawnParameters SpawnParams;
                     SpawnParams.SpawnCollisionHandlingOverride = ESpawnActorCollisionHandlingMethod::AlwaysSpawn;
-                    
+
                     AFGBuildableWire* NewWire = GetWorld()->SpawnActor<AFGBuildableWire>(
                         WireClass, ClonePole->GetActorLocation(), FRotator::ZeroRotator, SpawnParams);
-                    
+
                     if (NewWire)
                     {
                         bool bConnected = NewWire->Connect(FactoryCircuitConns[0], PoleCircuitConns[0]);
@@ -5960,20 +5978,103 @@ int32 USFExtendService::GenerateAndExecuteWiring(AFGBuildableFactory* NewFactory
                 }
             }
         }
-        
+
+        for (const FSFCloneHologram& Holo : StrippedTopology.ChildHolograms)
+        {
+            if (Holo.Role != TEXT("pipe_attachment")) continue;
+            if (Holo.ConnectedPowerPoleHologramId.IsEmpty()) continue;
+            if (!WireClass) continue;
+
+            AActor* const* PumpActorPtr = CloneBuiltActors.Find(Holo.HologramId);
+            AActor* const* PoleActorPtr = CloneBuiltActors.Find(Holo.ConnectedPowerPoleHologramId);
+            if (!PumpActorPtr || !*PumpActorPtr || !PoleActorPtr || !*PoleActorPtr)
+            {
+                continue;
+            }
+
+            AFGBuildablePipelinePump* ClonePump = Cast<AFGBuildablePipelinePump>(*PumpActorPtr);
+            AFGBuildablePowerPole* ClonePole = Cast<AFGBuildablePowerPole>(*PoleActorPtr);
+            if (!ClonePump || !ClonePole) continue;
+
+            UFGPowerConnectionComponent* PumpPowerConn = ClonePump->FindComponentByClass<UFGPowerConnectionComponent>();
+            if (!PumpPowerConn) continue;
+
+            TArray<UFGCircuitConnectionComponent*> PoleCircuitConns;
+            ClonePole->GetComponents<UFGCircuitConnectionComponent>(PoleCircuitConns);
+            if (PoleCircuitConns.Num() == 0) continue;
+
+            UFGCircuitConnectionComponent* PoleConn = PoleCircuitConns[0];
+            TArray<UFGCircuitConnectionComponent*> CurrentPumpPartners;
+            PumpPowerConn->GetConnections(CurrentPumpPartners);
+            if (CurrentPumpPartners.Contains(PoleConn))
+            {
+                continue;
+            }
+
+            if (PumpPowerConn->IsConnected())
+            {
+                TArray<AFGBuildableWire*> ExistingPumpWires;
+                PumpPowerConn->GetWires(ExistingPumpWires);
+                for (AFGBuildableWire* ExistingWire : ExistingPumpWires)
+                {
+                    if (!ExistingWire) continue;
+                    UFGCircuitConnectionComponent* OtherConn = (ExistingWire->GetConnection(0) == PumpPowerConn)
+                        ? ExistingWire->GetConnection(1)
+                        : ExistingWire->GetConnection(0);
+                    if (OtherConn != PoleConn)
+                    {
+                        UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("⚡ SCALED EXTEND Pump Power: Clone[%d] replacing incorrect pump wire %s (%s → %s, expected %s)"),
+                            CloneIdx, *ExistingWire->GetName(), *ClonePump->GetName(),
+                            OtherConn && OtherConn->GetOwner() ? *OtherConn->GetOwner()->GetName() : TEXT("<unknown>"),
+                            *ClonePole->GetName());
+                        ExistingWire->Destroy();
+                    }
+                }
+            }
+
+            if (PoleConn->GetNumConnections() >= PoleConn->GetMaxNumConnections())
+            {
+                UE_LOG(LogSmartFoundations, Warning, TEXT("⚡ SCALED EXTEND Pump Power: Clone[%d] pole %s reached capacity (%d/%d) — skipping pump %s"),
+                    CloneIdx, *ClonePole->GetName(), PoleConn->GetNumConnections(), PoleConn->GetMaxNumConnections(), *ClonePump->GetName());
+                continue;
+            }
+
+            FActorSpawnParameters SpawnParams;
+            SpawnParams.SpawnCollisionHandlingOverride = ESpawnActorCollisionHandlingMethod::AlwaysSpawn;
+            AFGBuildableWire* NewWire = GetWorld()->SpawnActor<AFGBuildableWire>(
+                WireClass, ClonePump->GetActorLocation(), FRotator::ZeroRotator, SpawnParams);
+            if (!NewWire)
+            {
+                continue;
+            }
+
+            if (NewWire->Connect(PumpPowerConn, PoleConn))
+            {
+                ClonePowerWired++;
+                UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("⚡ SCALED EXTEND Pump Power: Clone[%d] connected pump %s ↔ pole %s"),
+                    CloneIdx, *ClonePump->GetName(), *ClonePole->GetName());
+            }
+            else
+            {
+                NewWire->Destroy();
+                UE_LOG(LogSmartFoundations, Warning, TEXT("⚡ SCALED EXTEND Pump Power: Clone[%d] Wire Connect() failed for pump %s ↔ pole %s"),
+                    CloneIdx, *ClonePump->GetName(), *ClonePole->GetName());
+            }
+        }
+
         ScaledExtendWiredCount += CloneWired + ClonePowerWired;
-        
+
         UE_LOG(LogSmartFoundations, Log, TEXT("⚡ SCALED EXTEND Wire: Clone[%d] - %d belt/pipe, %d power, %d chains, %d pipe networks%s"),
             CloneIdx, CloneWired, ClonePowerWired, CloneChains, ClonePipes, Clone.bIsSeed ? TEXT(" [SEED]") : TEXT(""));
     }
-    
+
     if (ScaledExtendWiredCount > 0)
     {
         UE_LOG(LogSmartFoundations, Display, TEXT("⚡ SCALED EXTEND Wire: Total %d additional connections across %d clones"),
             ScaledExtendWiredCount, ScaledExtendClones.Num());
         WiredCount += ScaledExtendWiredCount;
     }
-    
+
     // ==================== Power Pole Chaining (Issue #229/#265) ====================
     // Chain power poles between consecutive clones: clone1_pole → clone2_pole → clone3_pole...
     // IDs: "power_pole_N" (clone 1), "sc0_power_pole_N" (clone 2), "sc1_power_pole_N" (clone 3), etc.
@@ -5991,13 +6092,13 @@ int32 USFExtendService::GenerateAndExecuteWiring(AFGBuildableFactory* NewFactory
                 PoleIndices.AddUnique(Idx);
             }
         }
-        
+
         int32 ChainWiredCount = 0;
         for (int32 PoleIdx : PoleIndices)
         {
             // Build ordered list: clone 1 pole, then each scaled clone's pole
             TArray<AFGBuildablePowerPole*> PoleChain;
-            
+
             // Clone 1's pole
             FString Clone1PoleId = FString::Printf(TEXT("power_pole_%d"), PoleIdx);
             if (AActor* const* Actor = CloneIdToBuildable.Find(Clone1PoleId))
@@ -6005,7 +6106,7 @@ int32 USFExtendService::GenerateAndExecuteWiring(AFGBuildableFactory* NewFactory
                 if (AFGBuildablePowerPole* Pole = Cast<AFGBuildablePowerPole>(*Actor))
                     PoleChain.Add(Pole);
             }
-            
+
             // Each scaled clone's pole
             for (int32 CloneIdx = 0; CloneIdx < ScaledExtendClones.Num(); CloneIdx++)
             {
@@ -6016,25 +6117,25 @@ int32 USFExtendService::GenerateAndExecuteWiring(AFGBuildableFactory* NewFactory
                         PoleChain.Add(Pole);
                 }
             }
-            
+
             // Wire consecutive poles in the chain
             for (int32 j = 0; j < PoleChain.Num() - 1; j++)
             {
                 AFGBuildablePowerPole* PoleA = PoleChain[j];
                 AFGBuildablePowerPole* PoleB = PoleChain[j + 1];
-                
+
                 TArray<UFGCircuitConnectionComponent*> ConnsA, ConnsB;
                 PoleA->GetComponents<UFGCircuitConnectionComponent>(ConnsA);
                 PoleB->GetComponents<UFGCircuitConnectionComponent>(ConnsB);
-                
+
                 if (ConnsA.Num() > 0 && ConnsB.Num() > 0)
                 {
                     FActorSpawnParameters SpawnParams;
                     SpawnParams.SpawnCollisionHandlingOverride = ESpawnActorCollisionHandlingMethod::AlwaysSpawn;
-                    
+
                     AFGBuildableWire* ChainWire = GetWorld()->SpawnActor<AFGBuildableWire>(
                         WireClass, PoleA->GetActorLocation(), FRotator::ZeroRotator, SpawnParams);
-                    
+
                     if (ChainWire)
                     {
                         bool bConnected = ChainWire->Connect(ConnsA[0], ConnsB[0]);
@@ -6052,7 +6153,7 @@ int32 USFExtendService::GenerateAndExecuteWiring(AFGBuildableFactory* NewFactory
                 }
             }
         }
-        
+
         if (ChainWiredCount > 0)
         {
             UE_LOG(LogSmartFoundations, Display, TEXT("⚡ POWER CHAIN: %d pole-to-pole connections across %d pole indices"),
@@ -6060,16 +6161,16 @@ int32 USFExtendService::GenerateAndExecuteWiring(AFGBuildableFactory* NewFactory
             WiredCount += ChainWiredCount;
         }
     }
-    
+
     // Clear stored topology and built actors after wiring
     StoredCloneTopology.Reset();
     JsonSpawnedHolograms.Empty();
     JsonBuiltActors.Empty();
     PowerPoleWiringData.Empty();
-    
+
     // Clear scaled extend clones (their topologies were consumed by wiring)
     ScaledExtendClones.Empty();
-    
+
     return WiredCount;
 }
 
@@ -6079,7 +6180,7 @@ void USFExtendService::RegisterJsonBuiltActor(const FString& CloneId, AActor* Bu
     {
         return;
     }
-    
+
     JsonBuiltActors.Add(CloneId, BuiltActor);
     UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("🔌 EXTEND: Registered built actor %s -> %s"),
         *CloneId, *BuiltActor->GetName());
@@ -6091,13 +6192,13 @@ AFGBuildable* USFExtendService::GetBuiltActorByCloneId(const FString& CloneId) c
     {
         return nullptr;
     }
-    
+
     // Check JsonBuiltActors map
     if (AActor* const* FoundActor = JsonBuiltActors.Find(CloneId))
     {
         return Cast<AFGBuildable>(*FoundActor);
     }
-    
+
     return nullptr;
 }
 
@@ -6107,7 +6208,7 @@ AFGBuildable* USFExtendService::GetSourceBuildableByName(const FString& ActorNam
     {
         return nullptr;
     }
-    
+
     // Search world for buildable with matching name
     // This is used by lane segments to find the source distributor (existing buildable)
     UWorld* World = GetWorld();
@@ -6115,7 +6216,7 @@ AFGBuildable* USFExtendService::GetSourceBuildableByName(const FString& ActorNam
     {
         return nullptr;
     }
-    
+
     for (TActorIterator<AFGBuildable> It(World); It; ++It)
     {
         AFGBuildable* Buildable = *It;
@@ -6124,7 +6225,7 @@ AFGBuildable* USFExtendService::GetSourceBuildableByName(const FString& ActorNam
             return Buildable;
         }
     }
-    
+
     UE_LOG(LogSmartFoundations, Warning, TEXT("🛤️ LANE: Source buildable '%s' not found in world"), *ActorName);
     return nullptr;
 }
@@ -6137,7 +6238,7 @@ int32 USFExtendService::GetExtendCloneCount() const
     {
         return 0;
     }
-    
+
     // X counter = total clones (parent + additional). X=1 means source only (0 clones).
     // X=2 means 2 clones (parent + 1 additional), X=3 means 3, etc.
     const FSFCounterState& State = Subsystem->GetCounterState();
@@ -6151,7 +6252,7 @@ int32 USFExtendService::GetExtendRowCount() const
     {
         return 1;
     }
-    
+
     // Y counter controls number of rows. Y=1 = single row (current behavior).
     const FSFCounterState& State = Subsystem->GetCounterState();
     return FMath::Max(1, FMath::Abs(State.GridCounters.Y));
@@ -6168,24 +6269,24 @@ void USFExtendService::OnScaledExtendStateChanged()
     {
         return;
     }
-    
+
     // First scale action commits to Extend (enables sticky behavior)
     if (!bExtendCommitted)
     {
         bExtendCommitted = true;
         UE_LOG(LogSmartFoundations, Log, TEXT("⚡ SCALED EXTEND: Committed (first scale action)"));
     }
-    
+
     int32 CloneCount = GetExtendCloneCount();
     int32 RowCount = GetExtendRowCount();
-    
+
     UE_LOG(LogSmartFoundations, Log, TEXT("⚡ SCALED EXTEND: State changed - X=%d (clones=%d), Y=%d (rows=%d)"),
         CloneCount + 1, CloneCount, RowCount, RowCount);
-    
+
     // Clear all existing previews (both primary clone infrastructure and scaled extend clones)
     ClearBeltPreviews();
     ClearScaledExtendClones();
-    
+
     // CRITICAL: Refresh hologram position BEFORE creating belt previews.
     // RefreshExtension applies spacing/steps to clone 1's position.
     // CreateBeltPreviews derives infrastructure positions from the parent hologram's
@@ -6193,11 +6294,11 @@ void USFExtendService::OnScaledExtendStateChanged()
     // must be at the correct position first.
     // Force refresh even if inspection lock is active - grid changes should always apply
     RefreshExtension(CurrentExtendHologram.Get(), true);
-    
+
     // Now recreate the primary clone's infrastructure (clone 1 = parent hologram position)
     // This is the existing single-clone Extend behavior
     CreateBeltPreviews(CurrentExtendHologram.Get());
-    
+
     // Apply rigid body rotation to clone 1's infrastructure when rotation is active.
     // CreateBeltPreviews positions infrastructure based on source topology + translation,
     // but doesn't rotate. The factory building was rotated in RefreshExtension(),
@@ -6216,11 +6317,11 @@ void USFExtendService::OnScaledExtendStateChanged()
             float DirSignRot = (CurDir == ESFExtendDirection::Right) ? 1.0f : -1.0f;
             FRotator Clone1RotOffset(0.0f, State.RotationZ * DirSignRot, 0.0f);
             FVector FactoryCenter = CurrentExtendHologram->GetActorLocation();
-            
+
             // Step 1: Rotate topology data (same as Step 2.25 for additional clones)
             // WorldOffset from source to clone 1 (used to determine clone-side of lane segments)
             FVector Clone1WorldOffset = FactoryCenter - CurrentExtendTarget->GetActorLocation();
-            
+
             for (FSFCloneHologram& Holo : StoredCloneTopology->ChildHolograms)
             {
                 if (Holo.bIsLaneSegment)
@@ -6233,7 +6334,7 @@ void USFExtendService::OnScaledExtendStateChanged()
                         FVector EndWorld = Holo.SplineData.Points.Last().World.ToFVector();
                         FVector LaneDir = EndWorld - StartWorld;
                         bool bCloneAtEnd = (FVector::DotProduct(LaneDir, Clone1WorldOffset) > 0.0f);
-                        
+
                         if (bCloneAtEnd)
                         {
                             FVector RelEnd = EndWorld - FactoryCenter;
@@ -6248,7 +6349,7 @@ void USFExtendService::OnScaledExtendStateChanged()
                             Holo.SplineData.Points[0].World = FSFVec3(RotatedStart);
                             Holo.LaneStartNormal = FSFVec3(Clone1RotOffset.RotateVector(Holo.LaneStartNormal.ToFVector()));
                         }
-                        
+
                         // Recalculate transform from updated endpoints
                         FVector NewStart = Holo.SplineData.Points[0].World.ToFVector();
                         FVector NewEnd = Holo.SplineData.Points.Last().World.ToFVector();
@@ -6257,14 +6358,14 @@ void USFExtendService::OnScaledExtendStateChanged()
                     }
                     continue;
                 }
-                
+
                 // Rotate position around factory center
                 FVector HoloPos = Holo.Transform.Location.ToFVector();
                 FVector RelPos = HoloPos - FactoryCenter;
                 FVector RotatedPos = FactoryCenter + Clone1RotOffset.RotateVector(RelPos);
                 FRotator RotatedRot = Holo.Transform.Rotation.ToFRotator() + Clone1RotOffset;
                 Holo.Transform = FSFTransform(RotatedPos, RotatedRot);
-                
+
                 // Rotate spline world positions
                 if (Holo.bHasSplineData)
                 {
@@ -6275,7 +6376,7 @@ void USFExtendService::OnScaledExtendStateChanged()
                         Point.World = FSFVec3(FactoryCenter + Clone1RotOffset.RotateVector(RelPt));
                     }
                 }
-                
+
                 // Rotate lift data
                 if (Holo.bHasLiftData)
                 {
@@ -6283,14 +6384,14 @@ void USFExtendService::OnScaledExtendStateChanged()
                     FVector TopRel = TopPos - FactoryCenter;
                     Holo.LiftData.TopTransform.Location = FSFVec3(FactoryCenter + Clone1RotOffset.RotateVector(TopRel));
                     Holo.LiftData.TopTransform.Rotation = FSFRot3(Holo.LiftData.TopTransform.Rotation.ToFRotator() + Clone1RotOffset);
-                    
+
                     FVector BotPos = Holo.LiftData.BottomTransform.Location.ToFVector();
                     FVector BotRel = BotPos - FactoryCenter;
                     Holo.LiftData.BottomTransform.Location = FSFVec3(FactoryCenter + Clone1RotOffset.RotateVector(BotRel));
                     Holo.LiftData.BottomTransform.Rotation = FSFRot3(Holo.LiftData.BottomTransform.Rotation.ToFRotator() + Clone1RotOffset);
                 }
             }
-            
+
             // Step 2: Reposition spawned holograms from rotated topology + regenerate meshes
             // Build IntendedPositions maps from rotated topology (same pattern as SpawnScaledExtendPreviews)
             TMap<FString, FVector> IntendedPositions;
@@ -6302,20 +6403,20 @@ void USFExtendService::OnScaledExtendStateChanged()
                 IntendedRotations.Add(Holo.HologramId, Holo.Transform.Rotation.ToFRotator());
                 HologramDataMap.Add(Holo.HologramId, &Holo);
             }
-            
+
             // Reposition each spawned hologram
             for (const auto& Pair : JsonSpawnedHolograms)
             {
                 AFGHologram* SpawnedHolo = Pair.Value;
                 if (!SpawnedHolo) continue;
-                
+
                 FVector IntendedPos = SpawnedHolo->GetActorLocation();
                 FRotator IntendedRot = SpawnedHolo->GetActorRotation();
                 if (FVector* FoundPos = IntendedPositions.Find(Pair.Key))
                     IntendedPos = *FoundPos;
                 if (FRotator* FoundRot = IntendedRotations.Find(Pair.Key))
                     IntendedRot = *FoundRot;
-                
+
                 // Reposition actor
                 SpawnedHolo->SetActorLocation(IntendedPos);
                 SpawnedHolo->SetActorRotation(IntendedRot);
@@ -6324,18 +6425,18 @@ void USFExtendService::OnScaledExtendStateChanged()
                     Root->SetWorldLocation(IntendedPos);
                     Root->SetWorldRotation(IntendedRot);
                 }
-                
+
                 // Force component transforms to update before spline regeneration.
                 // Without this, the spline component may use stale transforms when
                 // converting local → world during mesh generation.
                 SpawnedHolo->UpdateComponentTransforms();
-                
+
                 // Regenerate spline meshes at correct position
                 // (same pattern as SpawnScaledExtendPreviews lines 5922-5980)
                 if (const FSFCloneHologram** HoloDataPtr = HologramDataMap.Find(Pair.Key))
                 {
                     const FSFCloneHologram& HoloData = **HoloDataPtr;
-                    
+
                     if (ASFConveyorBeltHologram* Belt = Cast<ASFConveyorBeltHologram>(SpawnedHolo))
                     {
                         if (HoloData.bIsLaneSegment && HoloData.bHasSplineData && HoloData.SplineData.Points.Num() >= 2)
@@ -6375,7 +6476,7 @@ void USFExtendService::OnScaledExtendStateChanged()
                             FVector EndPos = HoloData.SplineData.Points.Last().World.ToFVector();
                             FVector StartNormal = HoloData.LaneStartNormal.ToFVector();
                             FVector EndNormal = HoloData.LaneEndNormal.ToFVector();
-                            
+
                             Pipe->TryUseBuildModeRouting(StartPos, StartNormal, EndPos, EndNormal);
                             Pipe->TriggerMeshGeneration();
                             Pipe->ForceApplyHologramMaterial();
@@ -6398,17 +6499,17 @@ void USFExtendService::OnScaledExtendStateChanged()
                         }
                     }
                 }
-                
+
                 // Update tracking
                 if (HologramService)
                 {
                     HologramService->TrackChildHologram(SpawnedHolo, IntendedPos, IntendedRot);
                 }
             }
-            
+
             UE_LOG(LogSmartFoundations, Log, TEXT("⚡ SCALED EXTEND: Applied rigid rotation (%.1f°) to clone 1 topology + repositioned %d holograms"),
                 State.RotationZ, JsonSpawnedHolograms.Num());
-            
+
             // CRITICAL: Disable clearance detection on the parent hologram when rotation is active.
             // Vanilla's CheckValidPlacement checks the parent's clearance box against nearby
             // buildings. With any rotation, the parent shifts enough to overlap with the source
@@ -6425,21 +6526,21 @@ void USFExtendService::OnScaledExtendStateChanged()
             }
         }
     }
-    
+
     // If we have additional clones beyond the first, calculate and spawn them
     if (CloneCount > 1 || RowCount > 1)
     {
         // Calculate positions for additional clones (everything beyond clone 1 in row 0)
         CalculateScaledExtendPositions();
-        
+
         // Validate constraints (belt/pipe lengths, angles, and Issue #288 pole capacity)
         bScaledExtendValid = ValidateScaledExtendConstraints() && ValidatePowerCapacity();
-        
+
         if (bScaledExtendValid)
         {
             // Spawn factory holograms + infrastructure for additional clones
             SpawnScaledExtendPreviews();
-            
+
             // Phase 6: Merge all scaled extend clone topologies into StoredCloneTopology.
             // The existing wiring system uses StoredCloneTopology to generate wiring manifests.
             // Without this merge, only clone 1's topology is available for post-build wiring.
@@ -6464,7 +6565,7 @@ void USFExtendService::OnScaledExtendStateChanged()
         else
         {
             UE_LOG(LogSmartFoundations, Warning, TEXT("⚡ SCALED EXTEND: Configuration invalid - %s"), *ScaledExtendInvalidReason);
-            
+
             // Phase 7: Invalidate the grid - set hologram material to red/error
             if (CurrentExtendHologram.IsValid())
             {
@@ -6473,28 +6574,28 @@ void USFExtendService::OnScaledExtendStateChanged()
             }
         }
     }
-    
+
 }
 
 void USFExtendService::CalculateScaledExtendPositions()
 {
     ScaledExtendClones.Empty();
-    
+
     if (!CurrentExtendTarget.IsValid() || !Subsystem.IsValid())
     {
         return;
     }
-    
+
     AFGBuildable* SourceBuilding = CurrentExtendTarget.Get();
     const FSFCounterState& State = Subsystem->GetCounterState();
-    
+
     // Get building size from registry
     USFBuildableSizeRegistry::Initialize();
     FSFBuildableSizeProfile Profile = USFBuildableSizeRegistry::GetProfile(SourceBuilding->GetClass());
     FVector BuildingSize = Profile.DefaultSize;
-    
+
     FRotator SourceRotation = SourceBuilding->GetActorRotation();
-    
+
     // Calculate effective Y row height from topology extent (prevents row overlap).
     // Infrastructure (distributors, belts, pipes) may extend beyond the factory's Y footprint.
     float EffectiveRowHeight = BuildingSize.Y;
@@ -6503,14 +6604,14 @@ void USFExtendService::CalculateScaledExtendPositions()
         FVector CloneOffset = StoredCloneTopology->WorldOffset.ToFVector();
         FVector CloneFactoryCenter = SourceBuilding->GetActorLocation() + CloneOffset;
         FRotator InvRot = SourceRotation.GetInverse();
-        
+
         float MinLocalY = 0.0f, MaxLocalY = 0.0f;
         for (const FSFCloneHologram& Holo : StoredCloneTopology->ChildHolograms)
         {
             if (Holo.bIsLaneSegment) continue;  // Lane segments span between clones, not relevant
             FVector WorldPos = Holo.Transform.Location.ToFVector();
             FVector LocalPos = InvRot.RotateVector(WorldPos - CloneFactoryCenter);
-            
+
             // Expand bounds by half the building's Y width to use edges instead of centers.
             // Distributors (splitters/mergers/junctions) are the outermost infrastructure
             // and are ~200cm wide (half = 100cm). Belt/pipe segments are thin and don't
@@ -6520,30 +6621,30 @@ void USFExtendService::CalculateScaledExtendPositions()
             {
                 HalfY = 200.0f;  // Splitters/mergers are ~400cm wide, half = 200cm
             }
-            
+
             MinLocalY = FMath::Min(MinLocalY, LocalPos.Y - HalfY);
             MaxLocalY = FMath::Max(MaxLocalY, LocalPos.Y + HalfY);
         }
         float TopologyYExtent = MaxLocalY - MinLocalY;
         EffectiveRowHeight = FMath::Max(BuildingSize.Y, TopologyYExtent);
-        
+
         if (TopologyYExtent > BuildingSize.Y)
         {
             UE_LOG(LogSmartFoundations, Log, TEXT("⚡ SCALED EXTEND: Topology Y extent (%.0f) > BuildingSize.Y (%.0f) — using topology extent for row spacing"),
                 TopologyYExtent, BuildingSize.Y);
         }
     }
-    
+
     int32 CloneCount = GetExtendCloneCount();
     int32 RowCount = GetExtendRowCount();
-    
+
     // Get extend direction offset (perpendicular to belt flow)
     ESFExtendDirection CurrentDir = DetectionService ? DetectionService->GetExtendDirection() : ESFExtendDirection::Right;
     float XDirectionSign = (CurrentDir == ESFExtendDirection::Right) ? 1.0f : -1.0f;
-    
+
     // Determine Y direction sign (negative Y = opposite perpendicular)
     int32 YDir = (Subsystem->GetCounterState().GridCounters.Y >= 0) ? 1 : -1;
-    
+
     // For each row and clone position, calculate the world offset
     for (int32 Row = 0; Row < RowCount; Row++)
     {
@@ -6554,7 +6655,7 @@ void USFExtendService::CalculateScaledExtendPositions()
             SeedClone.GridX = 0;
             SeedClone.GridY = Row;
             SeedClone.bIsSeed = true;
-            
+
             // Seed position: offset in Y direction (perpendicular to extend direction)
             // Y direction is perpendicular to X (extend) direction
             FVector YOffset = FVector(0.0f, EffectiveRowHeight * Row * YDir, 0.0f);
@@ -6562,14 +6663,14 @@ void USFExtendService::CalculateScaledExtendPositions()
             YOffset.Y += State.SpacingY * Row * YDir;
             // Add Y steps (vertical offset per row for terraced look)
             float YSteps = State.StepsY * Row;
-            
+
             SeedClone.WorldOffset = SourceRotation.RotateVector(YOffset);
             SeedClone.WorldOffset.Z += YSteps;
             SeedClone.RotationOffset = FRotator::ZeroRotator;
-            
+
             ScaledExtendClones.Add(SeedClone);
         }
-        
+
         // For each clone in this row
         // Row 0: Skip clone 1 (CloneIndex=1) — that's the parent hologram handled by existing flow
         // Row 1+: Include all clones (1+) since they all need factory holograms
@@ -6577,18 +6678,18 @@ void USFExtendService::CalculateScaledExtendPositions()
         for (int32 Clone = StartClone; Clone < CloneCount; Clone++)
         {
             int32 CloneIndex = Clone + 1;  // 1-based (clone 1 is adjacent to source/seed)
-            
+
             FSFScaledExtendClone ExtendClone;
             ExtendClone.GridX = CloneIndex;
             ExtendClone.GridY = Row;
             ExtendClone.bIsSeed = false;
-            
+
             // Check if rotation is active
             bool bRotationActive = !FMath::IsNearlyZero(State.RotationZ);
-            
+
             FVector CloneOffset;
             FRotator CloneRotation = FRotator::ZeroRotator;
-            
+
             if (bRotationActive)
             {
                 // Arc/radial placement - cumulative rotation per clone
@@ -6596,25 +6697,25 @@ void USFExtendService::CalculateScaledExtendPositions()
                 float ArcLength = BuildingSize.X + static_cast<float>(State.SpacingX);
                 float StepRadians = FMath::Abs(FMath::DegreesToRadians(State.RotationZ));
                 float Radius = (StepRadians > KINDA_SMALL_NUMBER) ? ArcLength / StepRadians : 0.0f;
-                
+
                 float AngleDeg = static_cast<float>(CloneIndex) * State.RotationZ;
                 float AngleRad = FMath::DegreesToRadians(AngleDeg);
                 float SignRotation = (State.RotationZ >= 0.0f) ? 1.0f : -1.0f;
-                
+
                 // Arc position in local space — matches CalculateRotationOffset pattern:
                 //   X = SignX * R * Sin(|θ|)              (direction determines forward/backward)
                 //   Y = SignRotation * (R - R*Cos(|θ|))   (NO direction sign — canonical)
                 //   Rotation = AngleDeg * XDirectionSign  (sign baked into angle)
                 float AbsAngleRad = FMath::Abs(AngleRad);
                 float SignX = XDirectionSign;
-                
+
                 CloneOffset.X = SignX * Radius * FMath::Sin(AbsAngleRad);
                 CloneOffset.Y = SignRotation * (Radius - Radius * FMath::Cos(AbsAngleRad));
                 CloneOffset.Z = 0.0f;
-                
+
                 // Apply steps (vertical offset per clone)
                 CloneOffset.Z += State.StepsX * CloneIndex;
-                
+
                 CloneRotation = FRotator(0.0f, AngleDeg * XDirectionSign, 0.0f);
             }
             else
@@ -6624,25 +6725,25 @@ void USFExtendService::CalculateScaledExtendPositions()
                 CloneOffset.Y = 0.0f;
                 CloneOffset.Z = State.StepsX * CloneIndex;  // Steps = vertical offset per clone
             }
-            
+
             // Add Y row offset
             if (Row > 0)
             {
                 CloneOffset.Y += EffectiveRowHeight * Row * YDir + State.SpacingY * Row * YDir;
                 CloneOffset.Z += State.StepsY * Row;
             }
-            
+
             // Rotate offset by source building rotation to get world space
             ExtendClone.WorldOffset = SourceRotation.RotateVector(CloneOffset);
             // Preserve Z offset (steps) without rotation
             ExtendClone.WorldOffset.Z = CloneOffset.Z;
-            
+
             ExtendClone.RotationOffset = CloneRotation;
-            
+
             ScaledExtendClones.Add(ExtendClone);
         }
     }
-    
+
     UE_LOG(LogSmartFoundations, Log, TEXT("⚡ SCALED EXTEND: Calculated %d clone positions (Clones=%d, Rows=%d)"),
         ScaledExtendClones.Num(), CloneCount, RowCount);
 }
@@ -6653,42 +6754,42 @@ void USFExtendService::SpawnScaledExtendPreviews()
     {
         return;
     }
-    
+
     if (ScaledExtendClones.Num() == 0)
     {
         return;
     }
-    
+
     AFGBuildable* SourceBuilding = CurrentExtendTarget.Get();
     AFGHologram* ParentHologram = CurrentExtendHologram.Get();
     FVector SourceLocation = SourceBuilding->GetActorLocation();
     FRotator SourceRotation = SourceBuilding->GetActorRotation();
-    
+
     // Get source topology (already walked)
     const FSFExtendTopology& Topology = TopologyService->GetCurrentTopology();
     if (!Topology.bIsValid)
     {
         return;
     }
-    
+
     // Capture source topology once for cloning
     FSFSourceTopology SourceTopo = FSFSourceTopology::CaptureFromTopology(Topology);
-    
+
     int32 TotalHologramsSpawned = 0;
-    
+
     for (int32 i = 0; i < ScaledExtendClones.Num(); i++)
     {
         FSFScaledExtendClone& Clone = ScaledExtendClones[i];
-        
+
         // Calculate world position for this clone's factory building
         FVector CloneWorldPos = SourceLocation + Clone.WorldOffset;
         FRotator CloneWorldRot = SourceRotation + Clone.RotationOffset;
-        
+
         // === Step 1: Spawn factory building hologram for this clone ===
         // Use the same mechanism as normal grid scaling (SpawnChildHologramFromRecipe)
         static int32 ScaledExtendChildCounter = 0;
         FName ChildName = *FString::Printf(TEXT("SE_Factory_%d_%d_%d"), Clone.GridX, Clone.GridY, ScaledExtendChildCounter++);
-        
+
         AFGHologram* FactoryHologram = AFGHologram::SpawnChildHologramFromRecipe(
             ParentHologram,
             ChildName,
@@ -6697,27 +6798,27 @@ void USFExtendService::SpawnScaledExtendPreviews()
             CloneWorldPos,
             nullptr
         );
-        
+
         if (FactoryHologram)
         {
             // Position and rotate the factory hologram
             FactoryHologram->SetActorLocation(CloneWorldPos);
             FactoryHologram->SetActorRotation(CloneWorldRot);
-            
+
             // Mark as child and disable validation (same as normal grid scaling)
             USFHologramDataService::DisableValidation(FactoryHologram);
             USFHologramDataService::MarkAsChild(FactoryHologram, ParentHologram, ESFChildHologramType::ScalingGrid);
-            
+
             // Copy stored recipe to this clone
             if (Subsystem.IsValid() && Subsystem->bHasStoredProductionRecipe)
             {
                 USFHologramDataService::StoreRecipe(FactoryHologram, Subsystem->StoredProductionRecipe);
             }
-            
+
             // Force valid appearance
             FactoryHologram->SetPlacementMaterialState(EHologramMaterialState::HMS_OK);
             FactoryHologram->SetActorTickEnabled(false);
-            
+
             // CRITICAL: Disable clearance detection on child factory holograms.
             // Vanilla CheckValidPlacement on the parent iterates mChildren and calls
             // CheckValidPlacement on each. These vanilla FGFactoryHologram children have
@@ -6732,10 +6833,10 @@ void USFExtendService::SpawnScaledExtendPreviews()
                 Box->SetGenerateOverlapEvents(false);
             }
             // Box collision disabling above is sufficient to prevent clearance overlap detection
-            
+
             // Tag as Smart! child so HologramService's mChildren filter catches it
             FactoryHologram->Tags.AddUnique(FName(TEXT("SF_ExtendChild")));
-            
+
             // Set JsonCloneId so the factory registers in JsonBuiltActors during Construct()
             // This is needed for the wiring system to resolve "sc{i}_factory" references
             FString FactoryCloneId = FString::Printf(TEXT("sc%d_factory"), i);
@@ -6748,19 +6849,19 @@ void USFExtendService::SpawnScaledExtendPreviews()
             {
                 FactoryHoloData->JsonCloneId = FactoryCloneId;
             }
-            
+
             // Track in preview list
             BeltPreviewHolograms.Add(FactoryHologram);
             Clone.SpawnedHolograms.Add(TEXT("factory"), FactoryHologram);
-            
+
             // Track in hologram service for position refresh
             if (HologramService)
             {
                 HologramService->TrackChildHologram(FactoryHologram, CloneWorldPos, CloneWorldRot);
             }
-            
+
             TotalHologramsSpawned++;
-            
+
             UE_LOG(LogSmartFoundations, Log, TEXT("⚡ SCALED EXTEND: Spawned factory hologram for Clone[%d] (%d,%d) at (%+.0f, %+.0f, %+.0f)%s"),
                 i, Clone.GridX, Clone.GridY, CloneWorldPos.X, CloneWorldPos.Y, CloneWorldPos.Z,
                 Clone.bIsSeed ? TEXT(" [SEED]") : TEXT(""));
@@ -6770,10 +6871,10 @@ void USFExtendService::SpawnScaledExtendPreviews()
             UE_LOG(LogSmartFoundations, Error, TEXT("⚡ SCALED EXTEND: Failed to spawn factory hologram for Clone[%d]"), i);
             continue;
         }
-        
+
         // === Step 2: Spawn infrastructure (belts, distributors, pipes, power) around this clone ===
         Clone.CloneTopology = MakeShared<FSFCloneTopology>(FSFCloneTopology::FromSource(SourceTopo, Clone.WorldOffset));
-        
+
         // === Step 2.25: RIGID BODY ROTATION ===
         // Clone topology is a rigid body relative to the factory building.
         // FromSource generates positions with translation only (no rotation).
@@ -6784,7 +6885,7 @@ void USFExtendService::SpawnScaledExtendPreviews()
         {
             // Factory center = source factory position + this clone's world offset
             FVector FactoryCenter = SourceTopo.Factory.Transform.Location.ToFVector() + Clone.WorldOffset;
-            
+
             for (FSFCloneHologram& Holo : Clone.CloneTopology->ChildHolograms)
             {
                 if (Holo.bIsLaneSegment)
@@ -6797,7 +6898,7 @@ void USFExtendService::SpawnScaledExtendPreviews()
                         FVector EndWorld = Holo.SplineData.Points.Last().World.ToFVector();
                         FVector LaneDir = EndWorld - StartWorld;
                         bool bCloneAtEnd = (FVector::DotProduct(LaneDir, Clone.WorldOffset) > 0.0f);
-                        
+
                         if (bCloneAtEnd)
                         {
                             // End is at clone — rotate end around factory center
@@ -6816,7 +6917,7 @@ void USFExtendService::SpawnScaledExtendPreviews()
                             // Rotate clone-side normal
                             Holo.LaneStartNormal = FSFVec3(Clone.RotationOffset.RotateVector(Holo.LaneStartNormal.ToFVector()));
                         }
-                        
+
                         // Recalculate transform from updated endpoints
                         FVector NewStart = Holo.SplineData.Points[0].World.ToFVector();
                         FVector NewEnd = Holo.SplineData.Points.Last().World.ToFVector();
@@ -6832,7 +6933,7 @@ void USFExtendService::SpawnScaledExtendPreviews()
                     FVector RotatedPos = FactoryCenter + Clone.RotationOffset.RotateVector(RelPos);
                     FRotator RotatedRot = Holo.Transform.Rotation.ToFRotator() + Clone.RotationOffset;
                     Holo.Transform = FSFTransform(RotatedPos, RotatedRot);
-                    
+
                     // Rotate spline world positions for belt/pipe segments
                     if (Holo.bHasSplineData)
                     {
@@ -6843,7 +6944,7 @@ void USFExtendService::SpawnScaledExtendPreviews()
                             Point.World = FSFVec3(FactoryCenter + Clone.RotationOffset.RotateVector(RelPt));
                         }
                     }
-                    
+
                     // Rotate lift data transforms
                     if (Holo.bHasLiftData)
                     {
@@ -6855,11 +6956,11 @@ void USFExtendService::SpawnScaledExtendPreviews()
                     }
                 }
             }
-            
+
             UE_LOG(LogSmartFoundations, Log, TEXT("⚡ RIGID ROTATION: Clone[%d] rotated %d holograms by (%.0f,%.0f,%.0f) around factory center"),
                 i, Clone.CloneTopology->ChildHolograms.Num(), Clone.RotationOffset.Pitch, Clone.RotationOffset.Yaw, Clone.RotationOffset.Roll);
         }
-        
+
         // === Step 2.5: CHAIN TOPOLOGY - Modify lane segments to chain from previous clone ===
         // FromSource creates lane segments from Source(0,0,0) → ThisClone(WorldOffset).
         // For scaled extend, lanes must chain: PrevClone → ThisClone.
@@ -6901,10 +7002,10 @@ void USFExtendService::SpawnScaledExtendPreviews()
                 PrevCloneOffset = ScaledExtendClones[i-1].WorldOffset;
                 PrevCloneRotation = ScaledExtendClones[i-1].RotationOffset;
             }
-            
+
             // Source factory center (needed for rotating source-side around prev clone's factory center)
             FVector SourceFactoryPos = SourceTopo.Factory.Transform.Location.ToFVector();
-            
+
             // Modify lane segments: move the "source" end to the previous clone's
             // ROTATED distributor connector position.
             // FromSource generates lanes between Source ↔ ThisClone.
@@ -6913,18 +7014,18 @@ void USFExtendService::SpawnScaledExtendPreviews()
             for (FSFCloneHologram& Holo : Clone.CloneTopology->ChildHolograms)
             {
                 if (!Holo.bIsLaneSegment) continue;
-                
+
                 if (Holo.bHasSplineData && Holo.SplineData.Points.Num() >= 2)
                 {
                     FVector OldStartWorld = Holo.SplineData.Points[0].World.ToFVector();
                     FVector OldEndWorld = Holo.SplineData.Points.Last().World.ToFVector();
-                    
+
                     // Determine which end is the "source" end:
                     // If lane direction (start→end) aligns with source→clone direction,
                     // then start is at source. If anti-aligned, end is at source.
                     FVector LaneDir = OldEndWorld - OldStartWorld;
                     bool bSourceAtStart = (FVector::DotProduct(LaneDir, Clone.WorldOffset) > 0.0f);
-                    
+
                     // Helper: compute the previous clone's ROTATED connector position.
                     // The source-side endpoint is at the SOURCE distributor connector.
                     // The previous clone's matching connector = same relative position
@@ -6937,7 +7038,7 @@ void USFExtendService::SpawnScaledExtendPreviews()
                         FVector RelPos = SourceEndpoint - SourceFactoryPos;
                         return PrevFactoryCenter + PrevCloneRotation.RotateVector(RelPos);
                     };
-                    
+
                     FVector NewStartWorld, NewEndWorld;
                     if (bSourceAtStart)
                     {
@@ -6961,21 +7062,21 @@ void USFExtendService::SpawnScaledExtendPreviews()
                             Holo.LaneEndNormal = FSFVec3(PrevCloneRotation.RotateVector(Holo.LaneEndNormal.ToFVector()));
                         }
                     }
-                    
+
                     // Recalculate spline
                     float NewLength = FVector::Dist(NewStartWorld, NewEndWorld);
                     FRotator NewRotation = (NewEndWorld - NewStartWorld).Rotation();
-                    
+
                     // Update transform (position = start, rotation = direction)
                     Holo.Transform = FSFTransform(NewStartWorld, NewRotation);
-                    
+
                     // Update spline data
                     Holo.SplineData.Length = NewLength;
                     Holo.SplineData.Points[0].World = FSFVec3(NewStartWorld);
                     Holo.SplineData.Points[0].Local = FSFVec3(FVector::ZeroVector);
                     Holo.SplineData.Points.Last().World = FSFVec3(NewEndWorld);
                     Holo.SplineData.Points.Last().Local = FSFVec3(FVector(NewLength, 0, 0));
-                    
+
                     UE_LOG(LogSmartFoundations, Log, TEXT("⚡ CHAIN: Clone[%d] lane %s: %s shifted by PrevOffset(%.0f,%.0f,%.0f), length %.0f→%.0f"),
                         i, *Holo.HologramId, bSourceAtStart ? TEXT("START") : TEXT("END"),
                         PrevCloneOffset.X, PrevCloneOffset.Y, PrevCloneOffset.Z,
@@ -6986,7 +7087,7 @@ void USFExtendService::SpawnScaledExtendPreviews()
                     // Shift lift bottom transform by PrevCloneOffset
                     FVector OldBottom = Holo.LiftData.BottomTransform.Location.ToFVector();
                     Holo.LiftData.BottomTransform.Location = FSFVec3(OldBottom + PrevCloneOffset);
-                    
+
                     // Update transform too
                     FVector OldTransformPos = Holo.Transform.Location.ToFVector();
                     Holo.Transform.Location = FSFVec3(OldTransformPos + PrevCloneOffset);
@@ -6994,11 +7095,11 @@ void USFExtendService::SpawnScaledExtendPreviews()
             }
             } // end else (non-seed lane post-processing)
         }
-        
+
         // Prefix all hologram IDs and update connection targets for uniqueness
         FString ClonePrefix = FString::Printf(TEXT("sc%d_"), i);
         FString FactoryCloneId = FString::Printf(TEXT("sc%d_factory"), i);
-        
+
         // Determine previous clone's prefix for lane segment source-side target updates
         FString PrevClonePrefix;
         if (Clone.GridY == 0 && (i == 0 || ScaledExtendClones[i-1].GridY != Clone.GridY))
@@ -7009,16 +7110,16 @@ void USFExtendService::SpawnScaledExtendPreviews()
         {
             PrevClonePrefix = FString::Printf(TEXT("sc%d_"), i - 1);
         }
-        
+
         for (FSFCloneHologram& Holo : Clone.CloneTopology->ChildHolograms)
         {
             // Save original targets BEFORE modifications (needed for lane segment cross-references)
             FString OrigConn0Target = Holo.CloneConnections.ConveyorAny0.Target;
             FString OrigConn1Target = Holo.CloneConnections.ConveyorAny1.Target;
-            
+
             // Prefix hologram ID
             Holo.HologramId = ClonePrefix + Holo.HologramId;
-            
+
             // === Conn0 target resolution ===
             if (OrigConn0Target == TEXT("parent"))
             {
@@ -7035,7 +7136,7 @@ void USFExtendService::SpawnScaledExtendPreviews()
                 // Internal clone reference — prefix it
                 Holo.CloneConnections.ConveyorAny0.Target = ClonePrefix + OrigConn0Target;
             }
-            
+
             // === Conn1 target resolution ===
             if (OrigConn1Target == TEXT("parent"))
             {
@@ -7053,14 +7154,14 @@ void USFExtendService::SpawnScaledExtendPreviews()
                 Holo.CloneConnections.ConveyorAny1.Target = ClonePrefix + OrigConn1Target;
             }
         }
-        
+
         // Spawn infrastructure child holograms
         TMap<FString, AFGHologram*> InfraHolograms;
         int32 InfraSpawned = Clone.CloneTopology->SpawnChildHolograms(
             ParentHologram, this, InfraHolograms);
-        
+
         TotalHologramsSpawned += InfraSpawned;
-        
+
         // Build maps of hologram ID → intended transforms and spline data from clone topology.
         // We need this because AddChild() inside SpawnChildHolograms repositions actors
         // to the parent hologram's location, AND generates spline meshes at the wrong
@@ -7074,7 +7175,7 @@ void USFExtendService::SpawnScaledExtendPreviews()
             IntendedRotations.Add(Holo.HologramId, Holo.Transform.Rotation.ToFRotator());
             HologramDataMap.Add(Holo.HologramId, &Holo);
         }
-        
+
         // Track all infrastructure holograms
         for (auto& Pair : InfraHolograms)
         {
@@ -7082,7 +7183,7 @@ void USFExtendService::SpawnScaledExtendPreviews()
             {
                 BeltPreviewHolograms.Add(Pair.Value);
                 Clone.SpawnedHolograms.Add(Pair.Key, Pair.Value);
-                
+
                 // Get intended position from topology (NOT from GetActorLocation which
                 // may have been reset by AddChild to parent hologram's position)
                 FVector IntendedPos = Pair.Value->GetActorLocation();
@@ -7095,10 +7196,10 @@ void USFExtendService::SpawnScaledExtendPreviews()
                 {
                     IntendedRot = *FoundRot;
                 }
-                
+
                 // NOTE: RotationOffset is already applied in Step 2.25 (rigid body rotation
                 // in the topology). Do NOT apply it again here — would double-rotate.
-                
+
                 // Force actor to intended position BEFORE regenerating meshes
                 Pair.Value->SetActorLocation(IntendedPos);
                 Pair.Value->SetActorRotation(IntendedRot);
@@ -7107,7 +7208,7 @@ void USFExtendService::SpawnScaledExtendPreviews()
                     Root->SetWorldLocation(IntendedPos);
                     Root->SetWorldRotation(IntendedRot);
                 }
-                
+
                 // CRITICAL: Re-apply spline data and regenerate meshes AFTER repositioning.
                 // SpawnChildHolograms generates meshes while the actor is at the parent's
                 // position (due to AddChild). The spline mesh components are placed in world
@@ -7116,7 +7217,7 @@ void USFExtendService::SpawnScaledExtendPreviews()
                 if (const FSFCloneHologram** HoloDataPtr = HologramDataMap.Find(Pair.Key))
                 {
                     const FSFCloneHologram& HoloData = **HoloDataPtr;
-                    
+
                     if (ASFConveyorBeltHologram* Belt = Cast<ASFConveyorBeltHologram>(Pair.Value))
                     {
                         if (HoloData.bIsLaneSegment && HoloData.bHasSplineData && HoloData.SplineData.Points.Num() >= 2)
@@ -7126,7 +7227,7 @@ void USFExtendService::SpawnScaledExtendPreviews()
                             FVector EndPos = HoloData.SplineData.Points.Last().World.ToFVector();
                             FVector StartNormal = HoloData.LaneStartNormal.ToFVector();
                             FVector EndNormal = HoloData.LaneEndNormal.ToFVector();
-                            
+
                             Belt->AutoRouteSplineWithNormals(StartPos, StartNormal, EndPos, EndNormal);
                             Belt->TriggerMeshGeneration();
                             Belt->ForceApplyHologramMaterial();
@@ -7157,7 +7258,7 @@ void USFExtendService::SpawnScaledExtendPreviews()
                             FVector EndPos = HoloData.SplineData.Points.Last().World.ToFVector();
                             FVector StartNormal = HoloData.LaneStartNormal.ToFVector();
                             FVector EndNormal = HoloData.LaneEndNormal.ToFVector();
-                            
+
                             Pipe->TryUseBuildModeRouting(StartPos, StartNormal, EndPos, EndNormal);
                             Pipe->TriggerMeshGeneration();
                             Pipe->ForceApplyHologramMaterial();
@@ -7180,7 +7281,7 @@ void USFExtendService::SpawnScaledExtendPreviews()
                         }
                     }
                 }
-                
+
                 // Track in HologramService for position refresh using
                 // the TOPOLOGY-derived position, not GetActorLocation().
                 if (HologramService)
@@ -7190,14 +7291,14 @@ void USFExtendService::SpawnScaledExtendPreviews()
                 }
             }
         }
-        
+
         UE_LOG(LogSmartFoundations, Log, TEXT("⚡ SCALED EXTEND: Clone[%d] (%d,%d) - factory + %d infrastructure holograms%s"),
             i, Clone.GridX, Clone.GridY, InfraSpawned, Clone.bIsSeed ? TEXT(" [SEED]") : TEXT(""));
     }
-    
+
     UE_LOG(LogSmartFoundations, Display, TEXT("⚡ SCALED EXTEND: Total %d holograms spawned across %d additional clone sets"),
         TotalHologramsSpawned, ScaledExtendClones.Num());
-    
+
     // CRITICAL: Scrub nulls from parent's mChildren array.
     // SpawnChildHologramFromRecipe may add entries to mChildren before the spawn completes.
     // If spawning fails, null entries are left in mChildren which crash
@@ -7234,9 +7335,9 @@ void USFExtendService::ClearScaledExtendClones()
     {
         return;
     }
-    
+
     UE_LOG(LogSmartFoundations, Log, TEXT("⚡ SCALED EXTEND: Clearing %d clone sets"), ScaledExtendClones.Num());
-    
+
     // CRITICAL: Remove all scaled extend children from parent hologram's mChildren array
     // BEFORE destroying them. Without this, destroyed holograms leave dangling pointers
     // in mChildren, causing crash in AFGHologram::ResetConstructDisqualifiers during tick.
@@ -7260,7 +7361,7 @@ void USFExtendService::ClearScaledExtendClones()
                         }
                     }
                 }
-                
+
                 // Remove them from mChildren (iterate backwards for safe removal)
                 int32 RemovedCount = 0;
                 for (int32 i = ChildrenArray->Num() - 1; i >= 0; --i)
@@ -7271,7 +7372,7 @@ void USFExtendService::ClearScaledExtendClones()
                         RemovedCount++;
                     }
                 }
-                
+
                 if (RemovedCount > 0)
                 {
                     UE_LOG(LogSmartFoundations, Log, TEXT("⚡ SCALED EXTEND: Removed %d children from parent mChildren"), RemovedCount);
@@ -7279,7 +7380,7 @@ void USFExtendService::ClearScaledExtendClones()
             }
         }
     }
-    
+
     // Now safe to destroy the holograms
     // CRITICAL: Use TWeakObjectPtr for the destroy phase. Raw pointers in SpawnedHolograms
     // can become dangling if the engine already destroyed the holograms (e.g., build gun
@@ -7299,7 +7400,7 @@ void USFExtendService::ClearScaledExtendClones()
         Clone.CloneTopology.Reset();
     }
     ScaledExtendClones.Empty();
-    
+
     // Destroy using weak pointers (safe against already-destroyed/GC'd objects)
     for (TWeakObjectPtr<AFGHologram>& WeakHolo : WeakHologramsToDestroy)
     {
@@ -7311,7 +7412,7 @@ void USFExtendService::ClearScaledExtendClones()
             Holo->Destroy();
         }
     }
-    
+
     bScaledExtendValid = true;
     ScaledExtendInvalidReason.Empty();
 }
@@ -7322,7 +7423,7 @@ bool USFExtendService::ValidateScaledExtendConstraints()
     {
         return true;  // No clones = no constraints to check
     }
-    
+
     // ========================================================================
     // Lane Segment Validation (Phase 8)
     // ========================================================================
@@ -7334,37 +7435,37 @@ bool USFExtendService::ValidateScaledExtendConstraints()
     // all adjacent pairs), we only need to validate StoredCloneTopology's lane segments
     // (Source → Clone1). If those pass, all subsequent clone pairs will too.
     // ========================================================================
-    
+
     // Belt constraints (matching CreateOrUpdateBeltPreview in SFAutoConnectService)
     constexpr float MinBeltLength = 50.0f;       // 0.5m minimum
     constexpr float MaxBeltLength = 5600.0f;     // 56m maximum
     constexpr float MaxBeltAngleDeg = 30.0f;     // 30° max at each connector
-    
+
     // Pipe constraints (matching ProcessPipeJunctions in SFPipeAutoConnectManager)
     constexpr float MinPipeLength = 50.0f;       // 0.5m minimum (straight)
     constexpr float MaxPipeLength = 2500.0f;     // 25m maximum
     constexpr float MaxPipeAngleDeg = 30.0f;     // 30° max at each connector
-    
+
     if (StoredCloneTopology.IsValid())
     {
         for (const FSFCloneHologram& Holo : StoredCloneTopology->ChildHolograms)
         {
             if (!Holo.bIsLaneSegment) continue;
             if (!Holo.bHasSplineData || Holo.SplineData.Points.Num() < 2) continue;
-            
+
             FVector StartPos = Holo.SplineData.Points[0].World.ToFVector();
             FVector EndPos = Holo.SplineData.Points.Last().World.ToFVector();
             FVector StartNormal = Holo.LaneStartNormal.ToFVector();
             FVector EndNormal = Holo.LaneEndNormal.ToFVector();
-            
+
             float SegmentLength = FVector::Dist(StartPos, EndPos);
             bool bIsPipe = (Holo.LaneSegmentType == TEXT("pipe"));
-            
+
             float MinLength = bIsPipe ? MinPipeLength : MinBeltLength;
             float MaxLength = bIsPipe ? MaxPipeLength : MaxBeltLength;
             float MaxAngle = bIsPipe ? MaxPipeAngleDeg : MaxBeltAngleDeg;
             const TCHAR* TypeName = bIsPipe ? TEXT("Pipe") : TEXT("Belt");
-            
+
             // Distance validation
             if (SegmentLength < MinLength)
             {
@@ -7374,7 +7475,7 @@ bool USFExtendService::ValidateScaledExtendConstraints()
                 UE_LOG(LogSmartFoundations, Warning, TEXT("⚡ SCALED EXTEND: INVALID - %s"), *ScaledExtendInvalidReason);
                 return false;
             }
-            
+
             if (SegmentLength > MaxLength)
             {
                 ScaledExtendInvalidReason = FString::Printf(
@@ -7383,19 +7484,19 @@ bool USFExtendService::ValidateScaledExtendConstraints()
                 UE_LOG(LogSmartFoundations, Warning, TEXT("⚡ SCALED EXTEND: INVALID - %s"), *ScaledExtendInvalidReason);
                 return false;
             }
-            
+
             // Angle validation — check departure angle at start and arrival angle at end
             // Same dual-angle check as CreateOrUpdateBeltPreview
             FVector SegmentDir = (EndPos - StartPos).GetSafeNormal();
-            
+
             // Start connector: angle between connector normal and segment direction
             float DotStart = FVector::DotProduct(StartNormal, SegmentDir);
             float AngleStart = FMath::RadiansToDegrees(FMath::Acos(FMath::Clamp(DotStart, -1.0f, 1.0f)));
-            
+
             // End connector: angle between connector normal and reverse segment direction
             float DotEnd = FVector::DotProduct(EndNormal, -SegmentDir);
             float AngleEnd = FMath::RadiansToDegrees(FMath::Acos(FMath::Clamp(DotEnd, -1.0f, 1.0f)));
-            
+
             if (AngleStart > MaxAngle || AngleEnd > MaxAngle)
             {
                 ScaledExtendInvalidReason = FString::Printf(
@@ -7404,12 +7505,12 @@ bool USFExtendService::ValidateScaledExtendConstraints()
                 UE_LOG(LogSmartFoundations, Warning, TEXT("⚡ SCALED EXTEND: INVALID - %s"), *ScaledExtendInvalidReason);
                 return false;
             }
-            
+
             UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("⚡ VALIDATE: %s lane OK — length %.1fm, angles %.0f°/%.0f°"),
                 TypeName, SegmentLength / 100.0f, AngleStart, AngleEnd);
         }
     }
-    
+
     ScaledExtendInvalidReason.Empty();
     return true;
 }
@@ -7423,12 +7524,12 @@ bool USFExtendService::ValidatePowerCapacity()
     // automatically because their ConnectedPowerPoleHologramId is empty.
     // Called from both regular-Extend and Scaled Extend preview paths so the
     // 1-clone case gets the same protection as 2+ clones.
-    
+
     if (!StoredCloneTopology.IsValid() || StoredCloneTopology->ChildHolograms.Num() == 0)
     {
         return true;  // No topology → no poles → nothing to validate
     }
-    
+
     // Tally pumps per clone pole HologramId in a single pass.
     TMap<FString, int32> PumpsPerClonePole;
     for (const FSFCloneHologram& Holo : StoredCloneTopology->ChildHolograms)
@@ -7438,18 +7539,18 @@ bool USFExtendService::ValidatePowerCapacity()
             PumpsPerClonePole.FindOrAdd(Holo.ConnectedPowerPoleHologramId) += 1;
         }
     }
-    
+
     // Walk poles; first over-capacity entry aborts with a descriptive reason.
     for (const FSFCloneHologram& Holo : StoredCloneTopology->ChildHolograms)
     {
         if (Holo.Role != TEXT("power_pole")) continue;
         if (Holo.PowerPoleMaxConnections <= 0) continue;  // Defensive: no tier data, skip
-        
+
         const int32 PumpCount = PumpsPerClonePole.FindRef(Holo.HologramId);
         constexpr int32 FactoryConn = 1;   // clone factory ↔ clone pole
         constexpr int32 InterPoleConn = 1; // source pole ↔ clone pole (Power Extend)
         const int32 Projected = FactoryConn + InterPoleConn + PumpCount;
-        
+
         if (Projected > Holo.PowerPoleMaxConnections)
         {
             // Human-readable tier label — we only know the class name, which is
@@ -7458,7 +7559,7 @@ bool USFExtendService::ValidatePowerCapacity()
             FString Tier = Holo.SourceClass;
             Tier.RemoveFromStart(TEXT("Build_"));
             Tier.RemoveFromEnd(TEXT("_C"));
-            
+
             ScaledExtendInvalidReason = FString::Printf(
                 TEXT("Clone %s needs %d/%d connections (factory + inter-pole + %d pump%s) — upgrade the source pole, or move a pump to another pole"),
                 *Tier, Projected, Holo.PowerPoleMaxConnections, PumpCount, (PumpCount == 1 ? TEXT("") : TEXT("s")));
@@ -7466,6 +7567,6 @@ bool USFExtendService::ValidatePowerCapacity()
             return false;
         }
     }
-    
+
     return true;
 }

--- a/Source/SmartFoundations/Private/Features/Extend/SFWiringManifest.cpp
+++ b/Source/SmartFoundations/Private/Features/Extend/SFWiringManifest.cpp
@@ -31,10 +31,10 @@ FSFWiringManifest FSFWiringManifest::Generate(
     AFGBuildableFactory* ParentFactory)
 {
     FSFWiringManifest Manifest;
-    
+
     // Set timestamp
     Manifest.Timestamp = FDateTime::UtcNow().ToIso8601();
-    
+
     // Set parent factory info
     if (ParentFactory)
     {
@@ -42,28 +42,28 @@ FSFWiringManifest FSFWiringManifest::Generate(
         Manifest.ParentClass = ParentFactory->GetClass()->GetName();
         Manifest.ParentLocation = ParentFactory->GetActorLocation();
     }
-    
+
     UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("🔌 WIRING MANIFEST: Generating from %d child holograms, %d mapped buildables"),
         CloneTopology.ChildHolograms.Num(), CloneIdToBuildable.Num());
-    
+
     // Build the BuiltBuildables array from the mapping
     for (const auto& Pair : CloneIdToBuildable)
     {
         const FString& CloneId = Pair.Key;
         AActor* Buildable = Pair.Value;
-        
+
         if (!Buildable)
         {
             continue;
         }
-        
+
         FSFBuiltBuildable Entry;
         Entry.CloneId = CloneId;
         Entry.ActorName = Buildable->GetName();
         Entry.BuildClass = Buildable->GetClass()->GetName();
         Entry.Location = Buildable->GetActorLocation();
         Entry.ResolvedActor = Buildable;
-        
+
         // Determine role from class
         if (Buildable->IsA<AFGBuildableConveyorBelt>())
         {
@@ -99,12 +99,12 @@ FSFWiringManifest FSFWiringManifest::Generate(
         {
             Entry.Role = TEXT("unknown");
         }
-        
+
         Manifest.BuiltBuildables.Add(Entry);
     }
-    
+
     Manifest.TotalBuildables = Manifest.BuiltBuildables.Num();
-    
+
     // Generate connections from CloneTopology
     for (const FSFCloneHologram& ChildData : CloneTopology.ChildHolograms)
     {
@@ -116,10 +116,10 @@ FSFWiringManifest FSFWiringManifest::Generate(
                 *ChildData.HologramId);
             continue;
         }
-        
+
         AActor* SourceBuildable = *SourceBuildablePtr;
         const FString& SourceActorName = SourceBuildable->GetName();
-        
+
         // Process belt/lift connections (including belt lane segments)
         bool bIsBeltLane = (ChildData.Role == TEXT("lane_segment") && ChildData.LaneSegmentType == TEXT("belt"));
         if (ChildData.Role == TEXT("belt_segment") || ChildData.Role == TEXT("lift_segment") || bIsBeltLane)
@@ -130,36 +130,36 @@ FSFWiringManifest FSFWiringManifest::Generate(
             {
                 const FString& TargetCloneId = ChildData.CloneConnections.ConveyorAny0.Target;
                 AActor* const* TargetBuildablePtr = CloneIdToBuildable.Find(TargetCloneId);
-                
+
                 if (TargetBuildablePtr && *TargetBuildablePtr)
                 {
                     FSFWiringEndpoint Source(ChildData.HologramId, SourceActorName, TEXT("ConveyorAny0"));
-                    FSFWiringEndpoint Target(TargetCloneId, (*TargetBuildablePtr)->GetName(), 
+                    FSFWiringEndpoint Target(TargetCloneId, (*TargetBuildablePtr)->GetName(),
                         ChildData.CloneConnections.ConveyorAny0.Connector);
-                    
+
                     Source.ResolvedActor = SourceBuildable;
                     Target.ResolvedActor = *TargetBuildablePtr;
-                    
+
                     Manifest.BeltConnections.Add(FSFWiringConnection(Source, Target));
                 }
             }
-            
+
             // ConveyorAny1 connection
             if (!ChildData.CloneConnections.ConveyorAny1.Target.IsEmpty() &&
                 ChildData.CloneConnections.ConveyorAny1.Target != TEXT("external"))
             {
                 const FString& TargetCloneId = ChildData.CloneConnections.ConveyorAny1.Target;
                 AActor* const* TargetBuildablePtr = CloneIdToBuildable.Find(TargetCloneId);
-                
+
                 if (TargetBuildablePtr && *TargetBuildablePtr)
                 {
                     FSFWiringEndpoint Source(ChildData.HologramId, SourceActorName, TEXT("ConveyorAny1"));
                     FSFWiringEndpoint Target(TargetCloneId, (*TargetBuildablePtr)->GetName(),
                         ChildData.CloneConnections.ConveyorAny1.Connector);
-                    
+
                     Source.ResolvedActor = SourceBuildable;
                     Target.ResolvedActor = *TargetBuildablePtr;
-                    
+
                     Manifest.BeltConnections.Add(FSFWiringConnection(Source, Target));
                 }
             }
@@ -169,26 +169,26 @@ FSFWiringManifest FSFWiringManifest::Generate(
         {
             // For lane_segment, check if it's a pipe lane (has pipe connections)
             // Lane segments connecting to source junctions need special handling
-            bool bIsPipeLane = ChildData.Role == TEXT("lane_segment") && 
+            bool bIsPipeLane = ChildData.Role == TEXT("lane_segment") &&
                 (ChildData.CloneConnections.ConveyorAny0.Target.StartsWith(TEXT("source:")) ||
                  ChildData.CloneConnections.ConveyorAny1.Target.StartsWith(TEXT("source:")));
-            
+
             // PipelineConnection0
             if (!ChildData.CloneConnections.ConveyorAny0.Target.IsEmpty() &&
                 ChildData.CloneConnections.ConveyorAny0.Target != TEXT("external"))
             {
                 const FString& TargetCloneId = ChildData.CloneConnections.ConveyorAny0.Target;
                 AActor* const* TargetBuildablePtr = CloneIdToBuildable.Find(TargetCloneId);
-                
+
                 if (TargetBuildablePtr && *TargetBuildablePtr)
                 {
                     FSFWiringEndpoint Source(ChildData.HologramId, SourceActorName, TEXT("PipelineConnection0"));
                     FSFWiringEndpoint Target(TargetCloneId, (*TargetBuildablePtr)->GetName(),
                         ChildData.CloneConnections.ConveyorAny0.Connector);
-                    
+
                     Source.ResolvedActor = SourceBuildable;
                     Target.ResolvedActor = *TargetBuildablePtr;
-                    
+
                     Manifest.PipeConnections.Add(FSFWiringConnection(Source, Target));
                 }
                 else if (TargetCloneId.StartsWith(TEXT("source:")))
@@ -198,32 +198,32 @@ FSFWiringManifest FSFWiringManifest::Generate(
                     FSFWiringEndpoint Source(ChildData.HologramId, SourceActorName, TEXT("PipelineConnection0"));
                     FSFWiringEndpoint Target(TargetCloneId, TEXT(""), ChildData.CloneConnections.ConveyorAny0.Connector);
                     Target.bIsSourceBuildable = true;  // Mark as source buildable for Execute() to resolve
-                    
+
                     Source.ResolvedActor = SourceBuildable;
                     // Target.ResolvedActor will be resolved during Execute() using ExtendService
-                    
+
                     Manifest.PipeConnections.Add(FSFWiringConnection(Source, Target));
                     UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("🔌 WIRING MANIFEST: Added lane->source connection %s.Conn0 -> %s.%s"),
                         *ChildData.HologramId, *TargetCloneId, *ChildData.CloneConnections.ConveyorAny0.Connector);
                 }
             }
-            
+
             // PipelineConnection1
             if (!ChildData.CloneConnections.ConveyorAny1.Target.IsEmpty() &&
                 ChildData.CloneConnections.ConveyorAny1.Target != TEXT("external"))
             {
                 const FString& TargetCloneId = ChildData.CloneConnections.ConveyorAny1.Target;
                 AActor* const* TargetBuildablePtr = CloneIdToBuildable.Find(TargetCloneId);
-                
+
                 if (TargetBuildablePtr && *TargetBuildablePtr)
                 {
                     FSFWiringEndpoint Source(ChildData.HologramId, SourceActorName, TEXT("PipelineConnection1"));
                     FSFWiringEndpoint Target(TargetCloneId, (*TargetBuildablePtr)->GetName(),
                         ChildData.CloneConnections.ConveyorAny1.Connector);
-                    
+
                     Source.ResolvedActor = SourceBuildable;
                     Target.ResolvedActor = *TargetBuildablePtr;
-                    
+
                     Manifest.PipeConnections.Add(FSFWiringConnection(Source, Target));
                 }
                 else if (TargetCloneId.StartsWith(TEXT("source:")))
@@ -232,9 +232,9 @@ FSFWiringManifest FSFWiringManifest::Generate(
                     FSFWiringEndpoint Source(ChildData.HologramId, SourceActorName, TEXT("PipelineConnection1"));
                     FSFWiringEndpoint Target(TargetCloneId, TEXT(""), ChildData.CloneConnections.ConveyorAny1.Connector);
                     Target.bIsSourceBuildable = true;
-                    
+
                     Source.ResolvedActor = SourceBuildable;
-                    
+
                     Manifest.PipeConnections.Add(FSFWiringConnection(Source, Target));
                     UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("🔌 WIRING MANIFEST: Added lane->source connection %s.Conn1 -> %s.%s"),
                         *ChildData.HologramId, *TargetCloneId, *ChildData.CloneConnections.ConveyorAny1.Connector);
@@ -242,10 +242,10 @@ FSFWiringManifest FSFWiringManifest::Generate(
             }
         }
     }
-    
+
     UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("🔌 WIRING MANIFEST: Generated %d belt connections, %d pipe connections"),
         Manifest.BeltConnections.Num(), Manifest.PipeConnections.Num());
-    
+
     return Manifest;
 }
 
@@ -256,10 +256,10 @@ FSFWiringManifest FSFWiringManifest::Generate(
 bool FSFWiringManifest::SaveToFile(const FString& FilePath) const
 {
     TSharedRef<FJsonObject> RootObject = MakeShared<FJsonObject>();
-    
+
     RootObject->SetStringField(TEXT("schema_version"), SchemaVersion);
     RootObject->SetStringField(TEXT("timestamp"), Timestamp);
-    
+
     // Parent factory
     TSharedRef<FJsonObject> ParentObj = MakeShared<FJsonObject>();
     ParentObj->SetStringField(TEXT("actor_name"), ParentActorName);
@@ -270,7 +270,7 @@ bool FSFWiringManifest::SaveToFile(const FString& FilePath) const
     ParentLocObj->SetNumberField(TEXT("z"), ParentLocation.Z);
     ParentObj->SetObjectField(TEXT("location"), ParentLocObj);
     RootObject->SetObjectField(TEXT("parent_factory"), ParentObj);
-    
+
     // Built buildables
     TArray<TSharedPtr<FJsonValue>> BuildablesArray;
     for (const FSFBuiltBuildable& Entry : BuiltBuildables)
@@ -288,28 +288,28 @@ bool FSFWiringManifest::SaveToFile(const FString& FilePath) const
         BuildablesArray.Add(MakeShared<FJsonValueObject>(EntryObj));
     }
     RootObject->SetArrayField(TEXT("built_buildables"), BuildablesArray);
-    
+
     // Helper lambda for connection serialization
     auto SerializeConnection = [](const FSFWiringConnection& Conn) -> TSharedRef<FJsonObject>
     {
         TSharedRef<FJsonObject> ConnObj = MakeShared<FJsonObject>();
         ConnObj->SetStringField(TEXT("description"), Conn.Description);
-        
+
         TSharedRef<FJsonObject> SourceObj = MakeShared<FJsonObject>();
         SourceObj->SetStringField(TEXT("clone_id"), Conn.Source.CloneId);
         SourceObj->SetStringField(TEXT("actor_name"), Conn.Source.ActorName);
         SourceObj->SetStringField(TEXT("connector"), Conn.Source.Connector);
         ConnObj->SetObjectField(TEXT("source"), SourceObj);
-        
+
         TSharedRef<FJsonObject> TargetObj = MakeShared<FJsonObject>();
         TargetObj->SetStringField(TEXT("clone_id"), Conn.Target.CloneId);
         TargetObj->SetStringField(TEXT("actor_name"), Conn.Target.ActorName);
         TargetObj->SetStringField(TEXT("connector"), Conn.Target.Connector);
         ConnObj->SetObjectField(TEXT("target"), TargetObj);
-        
+
         return ConnObj;
     };
-    
+
     // Belt connections
     TArray<TSharedPtr<FJsonValue>> BeltConnsArray;
     for (const FSFWiringConnection& Conn : BeltConnections)
@@ -317,7 +317,7 @@ bool FSFWiringManifest::SaveToFile(const FString& FilePath) const
         BeltConnsArray.Add(MakeShared<FJsonValueObject>(SerializeConnection(Conn)));
     }
     RootObject->SetArrayField(TEXT("belt_connections"), BeltConnsArray);
-    
+
     // Pipe connections
     TArray<TSharedPtr<FJsonValue>> PipeConnsArray;
     for (const FSFWiringConnection& Conn : PipeConnections)
@@ -325,7 +325,7 @@ bool FSFWiringManifest::SaveToFile(const FString& FilePath) const
         PipeConnsArray.Add(MakeShared<FJsonValueObject>(SerializeConnection(Conn)));
     }
     RootObject->SetArrayField(TEXT("pipe_connections"), PipeConnsArray);
-    
+
     // Statistics
     TSharedRef<FJsonObject> StatsObj = MakeShared<FJsonObject>();
     StatsObj->SetNumberField(TEXT("total_buildables"), TotalBuildables);
@@ -337,12 +337,12 @@ bool FSFWiringManifest::SaveToFile(const FString& FilePath) const
     StatsObj->SetNumberField(TEXT("belt_connections_to_wire"), BeltConnections.Num());
     StatsObj->SetNumberField(TEXT("pipe_connections_to_wire"), PipeConnections.Num());
     RootObject->SetObjectField(TEXT("statistics"), StatsObj);
-    
+
     // Serialize to string
     FString OutputString;
     TSharedRef<TJsonWriter<>> Writer = TJsonWriterFactory<>::Create(&OutputString);
     FJsonSerializer::Serialize(RootObject, Writer);
-    
+
     // Save to file
     return FFileHelper::SaveStringToFile(OutputString, *FilePath);
 }
@@ -357,9 +357,9 @@ int32 FSFWiringManifest::ResolveActors(UWorld* World)
     {
         return 0;
     }
-    
+
     int32 ResolvedCount = 0;
-    
+
     // Build a map of actor names to actors for fast lookup
     TMap<FString, AActor*> ActorNameMap;
     for (TActorIterator<AActor> It(World); It; ++It)
@@ -370,7 +370,7 @@ int32 FSFWiringManifest::ResolveActors(UWorld* World)
             ActorNameMap.Add(Actor->GetName(), Actor);
         }
     }
-    
+
     // Resolve built buildables
     for (FSFBuiltBuildable& Entry : BuiltBuildables)
     {
@@ -383,7 +383,7 @@ int32 FSFWiringManifest::ResolveActors(UWorld* World)
             }
         }
     }
-    
+
     // Resolve belt connections
     for (FSFWiringConnection& Conn : BeltConnections)
     {
@@ -404,7 +404,7 @@ int32 FSFWiringManifest::ResolveActors(UWorld* World)
             }
         }
     }
-    
+
     // Resolve pipe connections
     for (FSFWiringConnection& Conn : PipeConnections)
     {
@@ -425,7 +425,7 @@ int32 FSFWiringManifest::ResolveActors(UWorld* World)
             }
         }
     }
-    
+
     return ResolvedCount;
 }
 
@@ -439,10 +439,10 @@ UFGFactoryConnectionComponent* FSFWiringManifest::FindBeltConnection(AActor* Act
     {
         return nullptr;
     }
-    
+
     TArray<UFGFactoryConnectionComponent*> Connections;
     Actor->GetComponents<UFGFactoryConnectionComponent>(Connections);
-    
+
     for (UFGFactoryConnectionComponent* Conn : Connections)
     {
         if (Conn && Conn->GetFName().ToString() == ConnectorName)
@@ -450,7 +450,7 @@ UFGFactoryConnectionComponent* FSFWiringManifest::FindBeltConnection(AActor* Act
             return Conn;
         }
     }
-    
+
     // Try partial match for common patterns
     for (UFGFactoryConnectionComponent* Conn : Connections)
     {
@@ -463,7 +463,7 @@ UFGFactoryConnectionComponent* FSFWiringManifest::FindBeltConnection(AActor* Act
             }
         }
     }
-    
+
     return nullptr;
 }
 
@@ -473,10 +473,10 @@ UFGPipeConnectionComponentBase* FSFWiringManifest::FindPipeConnection(AActor* Ac
     {
         return nullptr;
     }
-    
+
     TArray<UFGPipeConnectionComponentBase*> Connections;
     Actor->GetComponents<UFGPipeConnectionComponentBase>(Connections);
-    
+
     for (UFGPipeConnectionComponentBase* Conn : Connections)
     {
         if (Conn && Conn->GetFName().ToString() == ConnectorName)
@@ -484,7 +484,7 @@ UFGPipeConnectionComponentBase* FSFWiringManifest::FindPipeConnection(AActor* Ac
             return Conn;
         }
     }
-    
+
     // Try partial match
     for (UFGPipeConnectionComponentBase* Conn : Connections)
     {
@@ -497,7 +497,7 @@ UFGPipeConnectionComponentBase* FSFWiringManifest::FindPipeConnection(AActor* Ac
             }
         }
     }
-    
+
     return nullptr;
 }
 
@@ -505,31 +505,31 @@ bool FSFWiringManifest::WireBeltConnection(const FSFWiringConnection& Connection
 {
     AActor* SourceActor = Connection.Source.ResolvedActor;
     AActor* TargetActor = Connection.Target.ResolvedActor;
-    
+
     if (!SourceActor || !TargetActor)
     {
         UE_LOG(LogSmartFoundations, Warning, TEXT("🔌 WIRE BELT: Failed - actors not resolved for %s"),
             *Connection.Description);
         return false;
     }
-    
+
     UFGFactoryConnectionComponent* SourceConn = FindBeltConnection(SourceActor, Connection.Source.Connector);
     UFGFactoryConnectionComponent* TargetConn = FindBeltConnection(TargetActor, Connection.Target.Connector);
-    
+
     if (!SourceConn)
     {
         UE_LOG(LogSmartFoundations, Warning, TEXT("🔌 WIRE BELT: Source connector %s not found on %s"),
             *Connection.Source.Connector, *SourceActor->GetName());
         return false;
     }
-    
+
     if (!TargetConn)
     {
         UE_LOG(LogSmartFoundations, Warning, TEXT("🔌 WIRE BELT: Target connector %s not found on %s"),
             *Connection.Target.Connector, *TargetActor->GetName());
         return false;
     }
-    
+
     // Check if already connected
     if (SourceConn->IsConnected())
     {
@@ -537,7 +537,7 @@ bool FSFWiringManifest::WireBeltConnection(const FSFWiringConnection& Connection
             *Connection.Description);
         return true; // Not a failure, just already done
     }
-    
+
     // Check compatibility
     if (!SourceConn->CanConnectTo(TargetConn))
     {
@@ -545,10 +545,10 @@ bool FSFWiringManifest::WireBeltConnection(const FSFWiringConnection& Connection
             *Connection.Description);
         return false;
     }
-    
+
     // Wire the connection
     SourceConn->SetConnection(TargetConn);
-    
+
     UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("🔌 WIRE BELT: ✅ %s"), *Connection.Description);
     return true;
 }
@@ -557,31 +557,31 @@ bool FSFWiringManifest::WirePipeConnection(const FSFWiringConnection& Connection
 {
     AActor* SourceActor = Connection.Source.ResolvedActor;
     AActor* TargetActor = Connection.Target.ResolvedActor;
-    
+
     if (!SourceActor || !TargetActor)
     {
         UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("🔌 WIRE PIPE: Failed - actors not resolved for %s"),
             *Connection.Description);
         return false;
     }
-    
+
     UFGPipeConnectionComponentBase* SourceConn = FindPipeConnection(SourceActor, Connection.Source.Connector);
     UFGPipeConnectionComponentBase* TargetConn = FindPipeConnection(TargetActor, Connection.Target.Connector);
-    
+
     if (!SourceConn)
     {
         UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("🔌 WIRE PIPE: Source connector %s not found on %s"),
             *Connection.Source.Connector, *SourceActor->GetName());
         return false;
     }
-    
+
     if (!TargetConn)
     {
         UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("🔌 WIRE PIPE: Target connector %s not found on %s"),
             *Connection.Target.Connector, *TargetActor->GetName());
         return false;
     }
-    
+
     // Check if already connected
     if (SourceConn->IsConnected())
     {
@@ -589,7 +589,7 @@ bool FSFWiringManifest::WirePipeConnection(const FSFWiringConnection& Connection
             *Connection.Description);
         return true;
     }
-    
+
     // Check compatibility
     if (!SourceConn->CheckCompatibility(TargetConn, nullptr))
     {
@@ -597,15 +597,15 @@ bool FSFWiringManifest::WirePipeConnection(const FSFWiringConnection& Connection
             *Connection.Description);
         return false;
     }
-    
+
     // Wire the connection
     SourceConn->SetConnection(TargetConn);
-    
+
     // Handle pipe network merging
     // Cast to UFGPipeConnectionComponent to access GetPipeNetworkID()
     UFGPipeConnectionComponent* SourceNetworkConn = Cast<UFGPipeConnectionComponent>(SourceConn);
     UFGPipeConnectionComponent* TargetNetworkConn = Cast<UFGPipeConnectionComponent>(TargetConn);
-    
+
     if (World && SourceNetworkConn && TargetNetworkConn)
     {
         AFGPipeSubsystem* PipeSubsystem = AFGPipeSubsystem::Get(World);
@@ -613,12 +613,12 @@ bool FSFWiringManifest::WirePipeConnection(const FSFWiringConnection& Connection
         {
             int32 SourceNetworkID = SourceNetworkConn->GetPipeNetworkID();
             int32 TargetNetworkID = TargetNetworkConn->GetPipeNetworkID();
-            
+
             if (SourceNetworkID != TargetNetworkID && SourceNetworkID != INDEX_NONE && TargetNetworkID != INDEX_NONE)
             {
                 AFGPipeNetwork* SourceNetwork = PipeSubsystem->FindPipeNetwork(SourceNetworkID);
                 AFGPipeNetwork* TargetNetwork = PipeSubsystem->FindPipeNetwork(TargetNetworkID);
-                
+
                 if (SourceNetwork && TargetNetwork && SourceNetwork->IsValidLowLevel() && TargetNetwork->IsValidLowLevel())
                 {
                     SourceNetwork->MergeNetworks(TargetNetwork);
@@ -627,7 +627,7 @@ bool FSFWiringManifest::WirePipeConnection(const FSFWiringConnection& Connection
             }
         }
     }
-    
+
     UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("🔌 WIRE PIPE: ✅ %s"), *Connection.Description);
     return true;
 }
@@ -636,10 +636,10 @@ int32 FSFWiringManifest::ExecuteWiring(UWorld* World)
 {
     int32 SuccessCount = 0;
     int32 FailCount = 0;
-    
+
     UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("🔌 EXECUTE WIRING: Starting BATCH approach (Epp's AutoLink pattern) - %d belt connections, %d pipe connections"),
         BeltConnections.Num(), PipeConnections.Num());
-    
+
     // ========================================================================
     // BATCH BELT WIRING: Epp's AutoLink approach
     // 1. Collect ALL conveyors involved
@@ -648,40 +648,40 @@ int32 FSFWiringManifest::ExecuteWiring(UWorld* World)
     // 4. Re-add ALL to subsystem (triggers single chain rebuild)
     // This is fastest - one chain rebuild at the end instead of per-connection
     // ========================================================================
-    
+
     AFGBuildableSubsystem* BuildableSubsystem = AFGBuildableSubsystem::Get(World);
     if (!BuildableSubsystem)
     {
         UE_LOG(LogSmartFoundations, Error, TEXT("🔌 EXECUTE WIRING: Failed to get BuildableSubsystem!"));
         return 0;
     }
-    
+
     // Step 1: Collect all unique conveyors involved in belt connections
     TSet<AFGBuildableConveyorBase*> ConveyorsToRewire;
     TArray<TPair<UFGFactoryConnectionComponent*, UFGFactoryConnectionComponent*>> ConnectionsToMake;
-    
+
     for (const FSFWiringConnection& Conn : BeltConnections)
     {
         AActor* SourceActor = Conn.Source.ResolvedActor;
         AActor* TargetActor = Conn.Target.ResolvedActor;
-        
+
         if (!SourceActor || !TargetActor)
         {
             UE_LOG(LogSmartFoundations, Warning, TEXT("🔌 BATCH: Skipping %s - actors not resolved"), *Conn.Description);
             FailCount++;
             continue;
         }
-        
+
         UFGFactoryConnectionComponent* SourceConn = FindBeltConnection(SourceActor, Conn.Source.Connector);
         UFGFactoryConnectionComponent* TargetConn = FindBeltConnection(TargetActor, Conn.Target.Connector);
-        
+
         if (!SourceConn || !TargetConn)
         {
             UE_LOG(LogSmartFoundations, Warning, TEXT("🔌 BATCH: Skipping %s - connectors not found"), *Conn.Description);
             FailCount++;
             continue;
         }
-        
+
         // Skip if already connected
         if (SourceConn->IsConnected())
         {
@@ -689,67 +689,67 @@ int32 FSFWiringManifest::ExecuteWiring(UWorld* World)
             SuccessCount++;
             continue;
         }
-        
+
         // Collect conveyors (belts and lifts only - not distributors/factories)
         AFGBuildableConveyorBase* SourceConveyor = Cast<AFGBuildableConveyorBase>(SourceActor);
         AFGBuildableConveyorBase* TargetConveyor = Cast<AFGBuildableConveyorBase>(TargetActor);
-        
+
         if (SourceConveyor) ConveyorsToRewire.Add(SourceConveyor);
         if (TargetConveyor) ConveyorsToRewire.Add(TargetConveyor);
-        
+
         // Queue the connection
         ConnectionsToMake.Add(TPair<UFGFactoryConnectionComponent*, UFGFactoryConnectionComponent*>(SourceConn, TargetConn));
     }
-    
+
     UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("🔌 BATCH: Collected %d conveyors, %d connections to make"),
         ConveyorsToRewire.Num(), ConnectionsToMake.Num());
-    
+
     // ========================================================================
     // HOOK-BASED APPROACH: Make connections NOW, chain rebuild via SML hook
-    // 
+    //
     // Chain actor rebuilding is now handled by AFGBlueprintHologram::Construct
     // hook in SFGameInstanceModule. That hook runs DURING construction (like
     // AutoLink), before factory tick starts on these conveyors.
-    // 
+    //
     // We just need to make the connections here - the hook will do Remove→Add.
     // ========================================================================
-    
+
     // Step 2: Make ALL connections (chain rebuild handled by hook)
     UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("⛓️ BATCH Step 2: Making %d connections (chain rebuild via hook)..."), ConnectionsToMake.Num());
-    
+
     for (const auto& ConnPair : ConnectionsToMake)
     {
         UFGFactoryConnectionComponent* SourceConn = ConnPair.Key;
         UFGFactoryConnectionComponent* TargetConn = ConnPair.Value;
-        
+
         if (!SourceConn || !TargetConn || SourceConn->IsConnected())
         {
             continue;
         }
-        
+
         // Make the connection - chain rebuild handled by AFGBlueprintHologram::Construct hook
         SourceConn->SetConnection(TargetConn);
         SuccessCount++;
-        
+
         UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("🔌 BATCH: Connected %s → %s"),
             *SourceConn->GetOwner()->GetName(), *TargetConn->GetOwner()->GetName());
     }
-    
+
     UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("⛓️ BATCH: %d connections made."), SuccessCount);
-    
+
     // ========================================================================
     // NOTE: Chain rebuild is now handled in ConfigureComponents (pre-tick)
-    // 
+    //
     // Belt holograms have connection target info stored in FSFHologramData.
     // During ConfigureComponents, they look up already-built targets and
     // establish connections + do Remove→Add. This is the same timing as
     // AutoLink and is safe from parallel factory tick crashes.
-    // 
+    //
     // Any connections not made during ConfigureComponents (because target
     // wasn't built yet) will be handled here as a fallback, but without
     // the Remove→Add which causes crashes.
     // ========================================================================
-    
+
     // ========================================================================
     // PIPE WIRING: Standard approach (no chain actor issues)
     // ========================================================================
@@ -765,10 +765,10 @@ int32 FSFWiringManifest::ExecuteWiring(UWorld* World)
             FailCount++;
         }
     }
-    
+
     UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("🔌 EXECUTE WIRING: Complete - %d succeeded, %d failed"),
         SuccessCount, FailCount);
-    
+
     return SuccessCount;
 }
 
@@ -794,23 +794,23 @@ int32 FSFWiringManifest::CreateChainActors(UWorld* World, const TMap<FString, AA
     // 2. Collect their chain actors AND their neighbors' chain actors
     // 3. RemoveConveyorChainActor on each unique chain
     // 4. Vanilla rebuilds everything next frame
-    
+
     if (!World)
     {
         UE_LOG(LogSmartFoundations, Warning, TEXT("⛓️ CHAIN REBUILD: No world context"));
         return 0;
     }
-    
+
     AFGBuildableSubsystem* BuildableSubsystem = AFGBuildableSubsystem::Get(World);
     if (!BuildableSubsystem)
     {
         UE_LOG(LogSmartFoundations, Warning, TEXT("⛓️ CHAIN REBUILD: No buildable subsystem"));
         return 0;
     }
-    
+
     // Collect ALL built conveyors (belts AND lifts)
     TArray<AFGBuildableConveyorBase*> AllConveyors;
-    
+
     // From BuiltBuildables (belt_segment, lift_segment from main manifold)
     for (const FSFBuiltBuildable& Entry : BuiltBuildables)
     {
@@ -822,7 +822,7 @@ int32 FSFWiringManifest::CreateChainActors(UWorld* World, const TMap<FString, AA
             }
         }
     }
-    
+
     // From AdditionalActors (lane_segment, belt_segment, lift_segment from JSON build)
     for (const auto& Pair : AdditionalActors)
     {
@@ -834,13 +834,13 @@ int32 FSFWiringManifest::CreateChainActors(UWorld* World, const TMap<FString, AA
             }
         }
     }
-    
+
     if (AllConveyors.Num() == 0)
     {
         UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("⛓️ CHAIN REBUILD: No conveyors to process"));
         return 0;
     }
-    
+
     // Collect ALL affected chain actors — from our conveyors AND their neighbors —
     // and delegate invalidation + synchronous rebuild to USFChainActorService.
     // The service handles the Remove-then-Migrate-synchronously pattern proven
@@ -909,23 +909,23 @@ int32 FSFWiringManifest::RebuildPipeNetworks(UWorld* World, const TMap<FString, 
         UE_LOG(LogSmartFoundations, Warning, TEXT("🔧 PIPE NETWORKS: No world context"));
         return 0;
     }
-    
+
     AFGPipeSubsystem* PipeSubsystem = AFGPipeSubsystem::Get(World);
     if (!PipeSubsystem)
     {
         UE_LOG(LogSmartFoundations, Warning, TEXT("🔧 PIPE NETWORKS: No pipe subsystem"));
         return 0;
     }
-    
+
     // Helper lambda to collect network IDs from an actor
     auto CollectNetworkIDs = [](AActor* Actor, TSet<int32>& OutNetworkIDs)
     {
         if (!Actor) return;
-        
+
         // Try to get pipe connections from the actor
         TArray<UFGPipeConnectionComponent*> PipeConns;
         Actor->GetComponents<UFGPipeConnectionComponent>(PipeConns);
-        
+
         for (UFGPipeConnectionComponent* PipeConn : PipeConns)
         {
             if (PipeConn)
@@ -938,10 +938,10 @@ int32 FSFWiringManifest::RebuildPipeNetworks(UWorld* World, const TMap<FString, 
             }
         }
     };
-    
+
     // Collect all unique network IDs from pipes in this manifest
     TSet<int32> NetworkIDs;
-    
+
     // From BuiltBuildables (pipes that went through WiringManifest)
     for (const FSFBuiltBuildable& Entry : BuiltBuildables)
     {
@@ -950,7 +950,7 @@ int32 FSFWiringManifest::RebuildPipeNetworks(UWorld* World, const TMap<FString, 
             CollectNetworkIDs(Entry.ResolvedActor, NetworkIDs);
         }
     }
-    
+
     // From AdditionalActors (includes lane segment pipes)
     for (const auto& Pair : AdditionalActors)
     {
@@ -965,9 +965,9 @@ int32 FSFWiringManifest::RebuildPipeNetworks(UWorld* World, const TMap<FString, 
             CollectNetworkIDs(Pair.Value, NetworkIDs);
         }
     }
-    
+
     UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("🔧 PIPE NETWORKS: Found %d unique networks to rebuild"), NetworkIDs.Num());
-    
+
     // Mark all networks for full rebuild
     int32 RebuiltCount = 0;
     for (int32 NetworkID : NetworkIDs)
@@ -980,7 +980,7 @@ int32 FSFWiringManifest::RebuildPipeNetworks(UWorld* World, const TMap<FString, 
             UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("🔧 PIPE NETWORKS: Marked network %d for rebuild"), NetworkID);
         }
     }
-    
+
     UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("🔧 PIPE NETWORKS: Marked %d networks for rebuild"), RebuiltCount);
     return RebuiltCount;
 }
@@ -992,24 +992,24 @@ int32 FSFWiringManifest::RebuildPipeNetworks(UWorld* World, const TMap<FString, 
 TArray<FSFOrderedBeltChain> FSFWiringManifest::OrganizeConnectionsByChain() const
 {
     TArray<FSFOrderedBeltChain> OrderedChains;
-    
+
     // Build lookup maps
     TMap<FString, const FSFWiringConnection*> ConnectionsByDescription;
     TSet<FString> ProcessedConnections;
-    
+
     for (const FSFWiringConnection& Conn : BeltConnections)
     {
         ConnectionsByDescription.Add(Conn.Description, &Conn);
     }
-    
+
     // Find all connections that involve distributors (chain endpoints)
     // and connections that involve the factory (parent)
     TArray<const FSFWiringConnection*> DistributorConnections;
     TArray<const FSFWiringConnection*> FactoryConnections;
-    
+
     for (const FSFWiringConnection& Conn : BeltConnections)
     {
-        if (Conn.Source.CloneId.StartsWith(TEXT("distributor_")) || 
+        if (Conn.Source.CloneId.StartsWith(TEXT("distributor_")) ||
             Conn.Target.CloneId.StartsWith(TEXT("distributor_")))
         {
             DistributorConnections.Add(&Conn);
@@ -1019,10 +1019,10 @@ TArray<FSFOrderedBeltChain> FSFWiringManifest::OrganizeConnectionsByChain() cons
             FactoryConnections.Add(&Conn);
         }
     }
-    
+
     UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("⛓️ ORGANIZE: Found %d distributor connections, %d factory connections"),
         DistributorConnections.Num(), FactoryConnections.Num());
-    
+
     // For each distributor connection, trace the chain to the factory
     int32 ChainIndex = 0;
     for (const FSFWiringConnection* DistConn : DistributorConnections)
@@ -1032,14 +1032,14 @@ TArray<FSFOrderedBeltChain> FSFWiringManifest::OrganizeConnectionsByChain() cons
         {
             continue;
         }
-        
+
         FSFOrderedBeltChain Chain;
-        
+
         // Determine which end is the distributor
         FString DistributorId;
         FString FirstSegmentId;
         FString FirstSegmentConnector;
-        
+
         if (DistConn->Source.CloneId.StartsWith(TEXT("distributor_")))
         {
             DistributorId = DistConn->Source.CloneId;
@@ -1054,34 +1054,34 @@ TArray<FSFOrderedBeltChain> FSFWiringManifest::OrganizeConnectionsByChain() cons
             FirstSegmentConnector = DistConn->Source.Connector;
             Chain.bIsInputChain = false; // Belt outputs to distributor -> output chain
         }
-        
+
         Chain.ChainId = FString::Printf(TEXT("%s_%d"), Chain.bIsInputChain ? TEXT("input") : TEXT("output"), ChainIndex++);
         Chain.DistributorCloneId = DistributorId;
-        
+
         // Start with distributor connection
         Chain.OrderedConnections.Add(*DistConn);
         ProcessedConnections.Add(DistConn->Description);
-        
+
         // Walk the chain from first segment toward factory
         FString CurrentSegmentId = FirstSegmentId;
         TSet<FString> VisitedSegments;
         VisitedSegments.Add(DistributorId);
-        
+
         while (!CurrentSegmentId.IsEmpty() && CurrentSegmentId != TEXT("parent") && !VisitedSegments.Contains(CurrentSegmentId))
         {
             VisitedSegments.Add(CurrentSegmentId);
-            
+
             // Find the next connection from this segment
             const FSFWiringConnection* NextConn = nullptr;
             FString NextSegmentId;
-            
+
             for (const FSFWiringConnection& Conn : BeltConnections)
             {
                 if (ProcessedConnections.Contains(Conn.Description))
                 {
                     continue;
                 }
-                
+
                 // Check if this connection involves current segment
                 if (Conn.Source.CloneId == CurrentSegmentId && !VisitedSegments.Contains(Conn.Target.CloneId))
                 {
@@ -1096,7 +1096,7 @@ TArray<FSFOrderedBeltChain> FSFWiringManifest::OrganizeConnectionsByChain() cons
                     break;
                 }
             }
-            
+
             if (NextConn)
             {
                 Chain.OrderedConnections.Add(*NextConn);
@@ -1108,13 +1108,13 @@ TArray<FSFOrderedBeltChain> FSFWiringManifest::OrganizeConnectionsByChain() cons
                 break;
             }
         }
-        
+
         UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("⛓️ ORGANIZE: Chain %s has %d ordered connections (distributor=%s, isInput=%d)"),
             *Chain.ChainId, Chain.OrderedConnections.Num(), *Chain.DistributorCloneId, Chain.bIsInputChain ? 1 : 0);
-        
+
         OrderedChains.Add(Chain);
     }
-    
+
     return OrderedChains;
 }
 
@@ -1122,38 +1122,38 @@ TArray<FSFOrderedBeltChain> FSFWiringManifest::OrganizeConnectionsByChain() cons
 // FSFWiringManifest - Wire single belt with verification
 // ============================================================================
 
-bool FSFWiringManifest::WireSingleBeltAndVerify(const FSFWiringConnection& Connection, UWorld* World, 
+bool FSFWiringManifest::WireSingleBeltAndVerify(const FSFWiringConnection& Connection, UWorld* World,
     AFGConveyorChainActor*& OutChainActor) const
 {
     OutChainActor = nullptr;
-    
+
     // Resolve actors
     AActor* SourceActor = Connection.Source.ResolvedActor;
     AActor* TargetActor = Connection.Target.ResolvedActor;
-    
+
     if (!SourceActor || !TargetActor)
     {
         UE_LOG(LogSmartFoundations, Warning, TEXT("⛓️ WIRE SINGLE: Failed - actors not resolved for %s"),
             *Connection.Description);
         return false;
     }
-    
+
     UFGFactoryConnectionComponent* SourceConn = FindBeltConnection(SourceActor, Connection.Source.Connector);
     UFGFactoryConnectionComponent* TargetConn = FindBeltConnection(TargetActor, Connection.Target.Connector);
-    
+
     if (!SourceConn || !TargetConn)
     {
         UE_LOG(LogSmartFoundations, Warning, TEXT("⛓️ WIRE SINGLE: Connectors not found for %s"),
             *Connection.Description);
         return false;
     }
-    
+
     // Check if already connected
     if (SourceConn->IsConnected())
     {
         UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("⛓️ WIRE SINGLE: %s already connected"),
             *Connection.Description);
-        
+
         // Get chain actor from the conveyor
         AFGBuildableConveyorBase* Conveyor = Cast<AFGBuildableConveyorBase>(SourceActor);
         if (!Conveyor)
@@ -1166,26 +1166,26 @@ bool FSFWiringManifest::WireSingleBeltAndVerify(const FSFWiringConnection& Conne
         }
         return true;
     }
-    
+
     // Wire the connection
     SourceConn->SetConnection(TargetConn);
-    
+
     UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("⛓️ WIRE SINGLE: ✅ Connected %s"), *Connection.Description);
-    
+
     // Check chain actors on both sides
     AFGBuildableConveyorBase* SourceConveyor = Cast<AFGBuildableConveyorBase>(SourceActor);
     AFGBuildableConveyorBase* TargetConveyor = Cast<AFGBuildableConveyorBase>(TargetActor);
-    
+
     AFGConveyorChainActor* SourceChain = SourceConveyor ? SourceConveyor->GetConveyorChainActor() : nullptr;
     AFGConveyorChainActor* TargetChain = TargetConveyor ? TargetConveyor->GetConveyorChainActor() : nullptr;
-    
+
     // Log chain status
     UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("⛓️ WIRE SINGLE: Chain status - Source=%s (segments=%d), Target=%s (segments=%d)"),
         SourceChain ? *SourceChain->GetName() : TEXT("NULL"),
         SourceChain ? SourceChain->GetNumChainSegments() : 0,
         TargetChain ? *TargetChain->GetName() : TEXT("NULL"),
         TargetChain ? TargetChain->GetNumChainSegments() : 0);
-    
+
     // Check if chains are unified
     if (SourceChain && TargetChain)
     {
@@ -1210,7 +1210,7 @@ bool FSFWiringManifest::WireSingleBeltAndVerify(const FSFWiringConnection& Conne
     {
         OutChainActor = TargetChain;
     }
-    
+
     return true;
 }
 
@@ -1224,7 +1224,7 @@ void FSFWiringManifest::ScheduleDeferredChainRebuild(UWorld* World, const TArray
     {
         return;
     }
-    
+
     // Capture conveyors in weak pointers so they survive until the timer fires
     TArray<TWeakObjectPtr<AFGBuildableConveyorBase>> WeakConveyors;
     for (AFGBuildableConveyorBase* Conveyor : Conveyors)
@@ -1234,20 +1234,20 @@ void FSFWiringManifest::ScheduleDeferredChainRebuild(UWorld* World, const TArray
             WeakConveyors.Add(Conveyor);
         }
     }
-    
+
     // Schedule on next tick using a timer
     FTimerHandle TimerHandle;
     World->GetTimerManager().SetTimerForNextTick([WeakConveyors, World]()
     {
         UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("⛓️ DEFERRED: Chain rebuild starting for %d conveyors..."), WeakConveyors.Num());
-        
+
         AFGBuildableSubsystem* BuildableSubsystem = AFGBuildableSubsystem::Get(World);
         if (!BuildableSubsystem)
         {
             UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("⛓️ DEFERRED: Failed to get BuildableSubsystem!"));
             return;
         }
-        
+
         // Collect valid conveyors
         TArray<AFGBuildableConveyorBase*> ValidConveyors;
         for (const TWeakObjectPtr<AFGBuildableConveyorBase>& WeakConveyor : WeakConveyors)
@@ -1257,29 +1257,29 @@ void FSFWiringManifest::ScheduleDeferredChainRebuild(UWorld* World, const TArray
                 ValidConveyors.Add(WeakConveyor.Get());
             }
         }
-        
+
         if (ValidConveyors.Num() == 0)
         {
             UE_LOG(LogSmartFoundations, Warning, TEXT("⛓️ DEFERRED: No valid conveyors remaining!"));
             return;
         }
-        
-        UE_LOG(LogSmartFoundations, Display, TEXT("⛓️ DEFERRED: Step 1 - Removing %d conveyors from subsystem..."), ValidConveyors.Num());
-        
+
+        UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("⛓️ DEFERRED: Step 1 - Removing %d conveyors from subsystem..."), ValidConveyors.Num());
+
         // Step 1: Remove all conveyors from subsystem
         for (AFGBuildableConveyorBase* Conveyor : ValidConveyors)
         {
             BuildableSubsystem->RemoveConveyor(Conveyor);
         }
-        
-        UE_LOG(LogSmartFoundations, Display, TEXT("⛓️ DEFERRED: Step 2 - Re-adding %d conveyors to subsystem..."), ValidConveyors.Num());
-        
+
+        UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("⛓️ DEFERRED: Step 2 - Re-adding %d conveyors to subsystem..."), ValidConveyors.Num());
+
         // Step 2: Re-add all conveyors to subsystem (triggers chain rebuild)
         for (AFGBuildableConveyorBase* Conveyor : ValidConveyors)
         {
             BuildableSubsystem->AddConveyor(Conveyor);
         }
-        
+
         // Log chain status after rebuild
         TSet<AFGConveyorChainActor*> UniqueChains;
         for (AFGBuildableConveyorBase* Conveyor : ValidConveyors)
@@ -1290,28 +1290,28 @@ void FSFWiringManifest::ScheduleDeferredChainRebuild(UWorld* World, const TArray
                 UniqueChains.Add(Chain);
             }
         }
-        
-        UE_LOG(LogSmartFoundations, Display, TEXT("⛓️ DEFERRED: Chain rebuild complete! %d conveyors now belong to %d unique chain actors"),
+
+        UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("⛓️ DEFERRED: Chain rebuild complete! %d conveyors now belong to %d unique chain actors"),
             ValidConveyors.Num(), UniqueChains.Num());
-        
+
         for (AFGConveyorChainActor* Chain : UniqueChains)
         {
-            UE_LOG(LogSmartFoundations, Display, TEXT("⛓️ DEFERRED:   Chain %s has %d segments"),
+            UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("⛓️ DEFERRED:   Chain %s has %d segments"),
                 *Chain->GetName(), Chain->GetNumChainSegments());
         }
-        
+
         // Success check
         if (UniqueChains.Num() < ValidConveyors.Num())
         {
-            UE_LOG(LogSmartFoundations, Display, TEXT("⛓️ DEFERRED: ✅ SUCCESS - chains unified from %d fragments to %d chains"),
+            UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("⛓️ DEFERRED: ✅ SUCCESS - chains unified from %d fragments to %d chains"),
                 ValidConveyors.Num(), UniqueChains.Num());
         }
         else
         {
-            UE_LOG(LogSmartFoundations, Warning, TEXT("⛓️ DEFERRED: ⚠️ Chains still fragmented (%d conveyors, %d chains)"),
+            UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("⛓️ DEFERRED:   Already unified: %d conveyors in %d chains"),
                 ValidConveyors.Num(), UniqueChains.Num());
         }
     });
-    
-    UE_LOG(LogSmartFoundations, Display, TEXT("⛓️ DEFERRED: Timer scheduled for next tick"));
+
+    UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("⛓️ DEFERRED: Timer scheduled for next tick"));
 }

--- a/Source/SmartFoundations/Private/Features/Upgrade/SFUpgradeExecutionService.cpp
+++ b/Source/SmartFoundations/Private/Features/Upgrade/SFUpgradeExecutionService.cpp
@@ -692,7 +692,7 @@ int32 USFUpgradeExecutionService::ProcessSingleUpgrade(AFGBuildable* Buildable, 
 	// SKIP if buildable is already the target class (no upgrade needed)
 	if (Buildable->GetClass() == NewBuildableClass)
 	{
-		UE_LOG(LogSmartFoundations, Display, TEXT("UpgradeExecutionService: Skipping %s - already target tier"),
+		UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("UpgradeExecutionService: Skipping %s - already target tier"),
 			*Buildable->GetName());
 		return 1;  // Return 1 to count as "handled" not failed
 	}
@@ -726,18 +726,18 @@ int32 USFUpgradeExecutionService::ProcessSingleUpgrade(AFGBuildable* Buildable, 
 	// Key: TryUpgrade + DoMultiStepPlacement + GenerateAndUpdateSpline + PreUpgrade/Upgrade_Implementation
 	if (AFGBuildableConveyorBelt* OldBelt = Cast<AFGBuildableConveyorBelt>(Buildable))
 	{
-		UE_LOG(LogSmartFoundations, Display, TEXT("UpgradeExecutionService: Upgrading belt %s (bucket=%d)"),
+		UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("UpgradeExecutionService: Upgrading belt %s (bucket=%d)"),
 			*OldBelt->GetName(), OldBelt->GetConveyorBucketID());
 
 		// Skip if already target class
 		if (OldBelt->GetClass() == NewBuildableClass)
 		{
-			UE_LOG(LogSmartFoundations, Display, TEXT("UpgradeExecutionService: Belt already target class, skipping"));
+			UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("UpgradeExecutionService: Belt already target class, skipping"));
 			return 1;
 		}
 
 		// STEP 1: Spawn hologram using vanilla factory method (exactly like MassUpgrade)
-		UE_LOG(LogSmartFoundations, Display, TEXT("⚙️ STEP 1: Spawning hologram via SpawnHologramFromRecipe..."));
+		UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("⚙️ STEP 1: Spawning hologram via SpawnHologramFromRecipe..."));
 		AFGHologram* Hologram = AFGHologram::SpawnHologramFromRecipe(
 			ActualTargetRecipe,
 			BuildGun,
@@ -750,13 +750,13 @@ int32 USFUpgradeExecutionService::ProcessSingleUpgrade(AFGBuildable* Buildable, 
 			UE_LOG(LogSmartFoundations, Warning, TEXT("UpgradeExecutionService: SpawnHologramFromRecipe failed"));
 			return 0;
 		}
-		UE_LOG(LogSmartFoundations, Display, TEXT("⚙️ STEP 1: Hologram spawned: %s"), *Hologram->GetName());
+		UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("⚙️ STEP 1: Hologram spawned: %s"), *Hologram->GetName());
 
 		// STEP 2: Set blueprint designer context if applicable
 		Hologram->SetInsideBlueprintDesigner(OldBelt->GetBlueprintDesigner());
 
 		// STEP 3: Create hit result and call TryUpgrade (NOT SetupUpgradeTarget!)
-		UE_LOG(LogSmartFoundations, Display, TEXT("⚙️ STEP 2: Calling TryUpgrade..."));
+		UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("⚙️ STEP 2: Calling TryUpgrade..."));
 		FHitResult HitResult(
 			OldBelt,
 			Hologram->GetComponentByClass<UPrimitiveComponent>(),
@@ -770,7 +770,7 @@ int32 USFUpgradeExecutionService::ProcessSingleUpgrade(AFGBuildable* Buildable, 
 			Hologram->Destroy();
 			return 0;
 		}
-		UE_LOG(LogSmartFoundations, Display, TEXT("⚙️ STEP 2: TryUpgrade succeeded"));
+		UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("⚙️ STEP 2: TryUpgrade succeeded"));
 
 		// STEP 4: Validate placement
 		UFGInventoryComponent* PlayerInventory = PlayerChar->GetInventory();
@@ -782,15 +782,15 @@ int32 USFUpgradeExecutionService::ProcessSingleUpgrade(AFGBuildable* Buildable, 
 			Hologram->Destroy();
 			return 0;
 		}
-		UE_LOG(LogSmartFoundations, Display, TEXT("⚙️ STEP 3: ValidatePlacementAndCost passed, IsUpgrade=true"));
+		UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("⚙️ STEP 3: ValidatePlacementAndCost passed, IsUpgrade=true"));
 
 		// STEP 5: Run multi-step placement loop (critical for spline buildables!)
-		UE_LOG(LogSmartFoundations, Display, TEXT("⚙️ STEP 4: Running DoMultiStepPlacement loop..."));
+		UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("⚙️ STEP 4: Running DoMultiStepPlacement loop..."));
 		while (Hologram->CanTakeNextBuildStep() && !Hologram->DoMultiStepPlacement(true))
 		{
 			// Loop until placement is complete
 		}
-		UE_LOG(LogSmartFoundations, Display, TEXT("⚙️ STEP 4: DoMultiStepPlacement complete"));
+		UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("⚙️ STEP 4: DoMultiStepPlacement complete"));
 
 		// STEP 5.5: Check affordability and deduct costs per-item
 		bool bNoCost = PlayerInventory->GetNoBuildCost();
@@ -801,13 +801,13 @@ int32 USFUpgradeExecutionService::ProcessSingleUpgrade(AFGBuildable* Buildable, 
 
 			// Get cost from hologram (length-aware for belts)
 			TArray<FItemAmount> BaseCost = Hologram->GetBaseCost();
-			UE_LOG(LogSmartFoundations, Log, TEXT("Belt upgrade cost: Hologram->GetBaseCost() returned %d items"), BaseCost.Num());
+			UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("Belt upgrade cost: Hologram->GetBaseCost() returned %d items"), BaseCost.Num());
 			for (const FItemAmount& ItemAmount : BaseCost)
 			{
 				if (ItemAmount.ItemClass)
 				{
 					ItemCost.FindOrAdd(ItemAmount.ItemClass) += ItemAmount.Amount;
-					UE_LOG(LogSmartFoundations, Log, TEXT("  New belt cost: +%d %s"),
+					UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("  New belt cost: +%d %s"),
 						ItemAmount.Amount, *UFGItemDescriptor::GetItemName(ItemAmount.ItemClass).ToString());
 				}
 			}
@@ -815,13 +815,13 @@ int32 USFUpgradeExecutionService::ProcessSingleUpgrade(AFGBuildable* Buildable, 
 			// Get refund from old buildable
 			TArray<FInventoryStack> Refunds;
 			OldBelt->GetDismantleRefundReturns(Refunds);
-			UE_LOG(LogSmartFoundations, Log, TEXT("Belt upgrade refund: GetDismantleRefundReturns() returned %d items"), Refunds.Num());
+			UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("Belt upgrade refund: GetDismantleRefundReturns() returned %d items"), Refunds.Num());
 			for (const FInventoryStack& Stack : Refunds)
 			{
 				if (Stack.Item.GetItemClass())
 				{
 					ItemCost.FindOrAdd(Stack.Item.GetItemClass()) -= Stack.NumItems;
-					UE_LOG(LogSmartFoundations, Log, TEXT("  Old belt refund: -%d %s"),
+					UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("  Old belt refund: -%d %s"),
 						Stack.NumItems, *UFGItemDescriptor::GetItemName(Stack.Item.GetItemClass()).ToString());
 				}
 			}
@@ -831,7 +831,7 @@ int32 USFUpgradeExecutionService::ProcessSingleUpgrade(AFGBuildable* Buildable, 
 			{
 				if (Entry.Key)
 				{
-					UE_LOG(LogSmartFoundations, Log, TEXT("  Net cost: %d %s"),
+					UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("  Net cost: %d %s"),
 						Entry.Value, *UFGItemDescriptor::GetItemName(Entry.Key).ToString());
 				}
 			}
@@ -869,7 +869,7 @@ int32 USFUpgradeExecutionService::ProcessSingleUpgrade(AFGBuildable* Buildable, 
 				{
 					UFGInventoryLibrary::GrabItemsFromInventoryAndCentralStorage(
 						PlayerInventory, CentralStorage, bTakeFromInventoryFirst, Entry.Key, Entry.Value);
-					UE_LOG(LogSmartFoundations, Log, TEXT("Belt upgrade: Deducted %d %s"),
+					UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("Belt upgrade: Deducted %d %s"),
 						Entry.Value, *UFGItemDescriptor::GetItemName(Entry.Key).ToString());
 				}
 				else if (Entry.Value < 0 && Entry.Key)
@@ -885,7 +885,7 @@ int32 USFUpgradeExecutionService::ProcessSingleUpgrade(AFGBuildable* Buildable, 
 					}
 					else
 					{
-						UE_LOG(LogSmartFoundations, Log, TEXT("Belt upgrade: Refunded %d %s"),
+						UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("Belt upgrade: Refunded %d %s"),
 							RefundAmount, *UFGItemDescriptor::GetItemName(Entry.Key).ToString());
 					}
 				}
@@ -896,9 +896,9 @@ int32 USFUpgradeExecutionService::ProcessSingleUpgrade(AFGBuildable* Buildable, 
 		// Friend access granted via AccessTransformers.ini
 		if (AFGConveyorBeltHologram* BeltHologram = Cast<AFGConveyorBeltHologram>(Hologram))
 		{
-			UE_LOG(LogSmartFoundations, Display, TEXT("⚙️ STEP 5: Calling GenerateAndUpdateSpline..."));
+			UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("⚙️ STEP 5: Calling GenerateAndUpdateSpline..."));
 			BeltHologram->GenerateAndUpdateSpline(HitResult);
-			UE_LOG(LogSmartFoundations, Display, TEXT("⚙️ STEP 5: GenerateAndUpdateSpline complete"));
+			UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("⚙️ STEP 5: GenerateAndUpdateSpline complete"));
 		}
 
 		// Capture chain actor from old belt before PreUpgrade clears upgrade-sensitive state.
@@ -910,11 +910,11 @@ int32 USFUpgradeExecutionService::ProcessSingleUpgrade(AFGBuildable* Buildable, 
 		// STEP 7: Let vanilla prepare the old belt for upgrade before constructing the replacement.
 		// PreUpgrade is documented as the hook that clears connections/state that can interfere
 		// with upgrades; calling it after Construct leaves the replacement born into stale chain state.
-		UE_LOG(LogSmartFoundations, Display, TEXT("⚙️ STEP 6a: Calling PreUpgrade_Implementation before Construct..."));
+		UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("⚙️ STEP 6a: Calling PreUpgrade_Implementation before Construct..."));
 		OldBelt->PreUpgrade_Implementation();
 
 		// STEP 8: Construct the new belt
-		UE_LOG(LogSmartFoundations, Display, TEXT("⚙️ STEP 6: Calling Construct()..."));
+		UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("⚙️ STEP 6: Calling Construct()..."));
 		TArray<AActor*> ConstructedChildren;
 		FNetConstructionID ConstructionID = BuildableSubsystem ? BuildableSubsystem->GetNewNetConstructionID() : FNetConstructionID();
 		AActor* ConstructedActor = Hologram->Construct(ConstructedChildren, ConstructionID);
@@ -927,25 +927,25 @@ int32 USFUpgradeExecutionService::ProcessSingleUpgrade(AFGBuildable* Buildable, 
 			UE_LOG(LogSmartFoundations, Warning, TEXT("UpgradeExecutionService: Construct failed for %s"), *OldBelt->GetName());
 			return 0;
 		}
-		UE_LOG(LogSmartFoundations, Display, TEXT("⚙️ STEP 6: Construct() created new belt: %s"), *NewBelt->GetName());
+		UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("⚙️ STEP 6: Construct() created new belt: %s"), *NewBelt->GetName());
 
 		// STEP 9: Call upgrade interface method on OLD belt (critical for chain transfer!)
-		UE_LOG(LogSmartFoundations, Display, TEXT("⚙️ STEP 7: Calling Upgrade_Implementation..."));
+		UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("⚙️ STEP 7: Calling Upgrade_Implementation..."));
 		OldBelt->Upgrade_Implementation(NewBelt);
-		UE_LOG(LogSmartFoundations, Display, TEXT("⚙️ STEP 7: Upgrade interface method complete"));
+		UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("⚙️ STEP 7: Upgrade interface method complete"));
 
 		// STEP 10: Check connections. The upgrade hologram plus PreUpgrade/Upgrade should
 		// transfer them; this prototype intentionally avoids manual ClearConnection/
 		// SetConnection after Construct because that can leave chain actors with stale
 		// segment state.
-		UE_LOG(LogSmartFoundations, Display, TEXT("⚙️ STEP 8: Checking connections..."));
+		UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("⚙️ STEP 8: Checking connections..."));
 		UFGFactoryConnectionComponent* OldConn0 = OldBelt->GetConnection0();
 		UFGFactoryConnectionComponent* OldConn1 = OldBelt->GetConnection1();
 		UFGFactoryConnectionComponent* NewConn0 = NewBelt->GetConnection0();
 		UFGFactoryConnectionComponent* NewConn1 = NewBelt->GetConnection1();
 
 		// Log chain actor state after Construct for diagnostics
-		UE_LOG(LogSmartFoundations, Log, TEXT("⚙️ STEP 8: NewBelt chain=%s, NewConn0 connected=%s, NewConn1 connected=%s"),
+		UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("⚙️ STEP 8: NewBelt chain=%s, NewConn0 connected=%s, NewConn1 connected=%s"),
 			NewBelt->GetConveyorChainActor() ? *NewBelt->GetConveyorChainActor()->GetName() : TEXT("null"),
 			NewConn0 && NewConn0->IsConnected() ? TEXT("yes") : TEXT("no"),
 			NewConn1 && NewConn1->IsConnected() ? TEXT("yes") : TEXT("no"));
@@ -956,7 +956,7 @@ int32 USFUpgradeExecutionService::ProcessSingleUpgrade(AFGBuildable* Buildable, 
 			{
 				if (NewConn0->IsConnected() && NewConn0->GetConnection() == Partner0)
 				{
-					UE_LOG(LogSmartFoundations, Display, TEXT("⚙️ STEP 8a: Conn0 already connected to %s by vanilla upgrade flow"),
+					UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("⚙️ STEP 8a: Conn0 already connected to %s by vanilla upgrade flow"),
 						*Partner0->GetOwner()->GetName());
 				}
 				else
@@ -973,7 +973,7 @@ int32 USFUpgradeExecutionService::ProcessSingleUpgrade(AFGBuildable* Buildable, 
 			{
 				if (NewConn1->IsConnected() && NewConn1->GetConnection() == Partner1)
 				{
-					UE_LOG(LogSmartFoundations, Display, TEXT("⚙️ STEP 8b: Conn1 already connected to %s by vanilla upgrade flow"),
+					UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("⚙️ STEP 8b: Conn1 already connected to %s by vanilla upgrade flow"),
 						*Partner1->GetOwner()->GetName());
 				}
 				else
@@ -983,10 +983,10 @@ int32 USFUpgradeExecutionService::ProcessSingleUpgrade(AFGBuildable* Buildable, 
 				}
 			}
 		}
-		UE_LOG(LogSmartFoundations, Display, TEXT("⚙️ STEP 8: Connections complete"));
+		UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("⚙️ STEP 8: Connections complete"));
 
 		// STEP 11: Destroy old belt and children
-		UE_LOG(LogSmartFoundations, Display, TEXT("⚙️ STEP 9: Destroying old belt..."));
+		UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("⚙️ STEP 9: Destroying old belt..."));
 		TArray<AActor*> ChildDismantleActors;
 		OldBelt->GetChildDismantleActors_Implementation(ChildDismantleActors);
 		for (AActor* ChildActor : ChildDismantleActors)
@@ -997,7 +997,7 @@ int32 USFUpgradeExecutionService::ProcessSingleUpgrade(AFGBuildable* Buildable, 
 			}
 		}
 		OldBelt->Destroy();
-		UE_LOG(LogSmartFoundations, Display, TEXT("⚙️ STEP 9: Old belt destroyed"));
+		UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("⚙️ STEP 9: Old belt destroyed"));
 
 		// Track upgraded conveyor
 		UpgradedConveyors.Add(NewBelt);
@@ -1006,7 +1006,7 @@ int32 USFUpgradeExecutionService::ProcessSingleUpgrade(AFGBuildable* Buildable, 
 		OldToNewConveyorMap.Add(OldBelt, NewBelt);
 		OldToNewBuildableMap.Add(OldBelt, NewBelt);
 
-		UE_LOG(LogSmartFoundations, Display, TEXT("⚙️ UPGRADE COMPLETE: %s → %s"),
+		UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("⚙️ UPGRADE COMPLETE: %s → %s"),
 			*Buildable->GetName(), *NewBelt->GetClass()->GetName());
 		return 1;
 	}
@@ -1030,7 +1030,7 @@ int32 USFUpgradeExecutionService::ProcessSingleUpgrade(AFGBuildable* Buildable, 
 		{
 			NewBuildableClass = TSubclassOf<AFGBuildable>(StyleClass);
 		}
-		UE_LOG(LogSmartFoundations, Display,
+		UE_LOG(LogSmartFoundations, VeryVerbose,
 			TEXT("UpgradeExecutionService: Pipe upgrade preserving indicator style (source=%s, bWithIndicator=%s, target class=%s)"),
 			*OldPipeClassName, bWithIndicator ? TEXT("true") : TEXT("false"),
 			NewBuildableClass ? *NewBuildableClass->GetName() : TEXT("null"));
@@ -1043,7 +1043,7 @@ int32 USFUpgradeExecutionService::ProcessSingleUpgrade(AFGBuildable* Buildable, 
 			return 0;
 		}
 
-		UE_LOG(LogSmartFoundations, Display, TEXT("UpgradeExecutionService: Old pipe %s with %d spline points"),
+		UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("UpgradeExecutionService: Old pipe %s with %d spline points"),
 			*OldPipe->GetName(), SplineData.Num());
 
 		// Spawn our Smart hologram with deferred construction
@@ -1135,7 +1135,7 @@ int32 USFUpgradeExecutionService::ProcessSingleUpgrade(AFGBuildable* Buildable, 
 				{
 					UFGInventoryLibrary::GrabItemsFromInventoryAndCentralStorage(
 						PipePlayerInventory, PipeCentralStorage, bPipeTakeFromInventoryFirst, Entry.Key, Entry.Value);
-					UE_LOG(LogSmartFoundations, Log, TEXT("Pipe upgrade: Deducted %d %s"),
+					UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("Pipe upgrade: Deducted %d %s"),
 						Entry.Value, *UFGItemDescriptor::GetItemName(Entry.Key).ToString());
 				}
 				else if (Entry.Value < 0 && Entry.Key)
@@ -1151,7 +1151,7 @@ int32 USFUpgradeExecutionService::ProcessSingleUpgrade(AFGBuildable* Buildable, 
 					}
 					else
 					{
-						UE_LOG(LogSmartFoundations, Log, TEXT("Pipe upgrade: Refunded %d %s"),
+						UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("Pipe upgrade: Refunded %d %s"),
 							RefundAmount, *UFGItemDescriptor::GetItemName(Entry.Key).ToString());
 					}
 				}
@@ -1200,7 +1200,7 @@ int32 USFUpgradeExecutionService::ProcessSingleUpgrade(AFGBuildable* Buildable, 
 		// Track old->new mapping for post-upgrade validation / pipe batch fix
 		OldToNewBuildableMap.Add(OldPipe, NewPipe);
 
-		UE_LOG(LogSmartFoundations, Display, TEXT("UpgradeExecutionService: Successfully upgraded pipe %s to %s"),
+		UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("UpgradeExecutionService: Successfully upgraded pipe %s to %s"),
 			*Buildable->GetName(), *NewPipe->GetClass()->GetName());
 		return 1;
 	}
@@ -1208,7 +1208,7 @@ int32 USFUpgradeExecutionService::ProcessSingleUpgrade(AFGBuildable* Buildable, 
 	// Handle Conveyor Lifts using vanilla upgrade flow (SpawnHologramFromRecipe pattern)
 	if (AFGBuildableConveyorLift* OldLift = Cast<AFGBuildableConveyorLift>(Buildable))
 	{
-		UE_LOG(LogSmartFoundations, Display, TEXT("UpgradeExecutionService: Upgrading lift %s"),
+		UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("UpgradeExecutionService: Upgrading lift %s"),
 			*OldLift->GetName());
 
 		// Log connection info for debugging floor hole issues
@@ -1362,7 +1362,7 @@ int32 USFUpgradeExecutionService::ProcessSingleUpgrade(AFGBuildable* Buildable, 
 		}
 
 		// Let vanilla prepare the old lift for upgrade before constructing the replacement.
-		UE_LOG(LogSmartFoundations, Display, TEXT("UpgradeExecutionService: Calling lift PreUpgrade before Construct"));
+		UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("UpgradeExecutionService: Calling lift PreUpgrade before Construct"));
 		OldLift->PreUpgrade_Implementation();
 
 		// Construct the new lift
@@ -1444,7 +1444,7 @@ int32 USFUpgradeExecutionService::ProcessSingleUpgrade(AFGBuildable* Buildable, 
 		OldToNewConveyorMap.Add(OldLift, NewLift);
 		OldToNewBuildableMap.Add(OldLift, NewLift);
 
-		UE_LOG(LogSmartFoundations, Display, TEXT("UpgradeExecutionService: Successfully upgraded lift %s to %s"),
+		UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("UpgradeExecutionService: Successfully upgraded lift %s to %s"),
 			*Buildable->GetName(), *NewLift->GetClass()->GetName());
 		return 1;
 	}
@@ -1452,7 +1452,7 @@ int32 USFUpgradeExecutionService::ProcessSingleUpgrade(AFGBuildable* Buildable, 
 	// Handle Power Poles and Wall Outlets (simple buildables - no spline data)
 	if (AFGBuildablePowerPole* OldPole = Cast<AFGBuildablePowerPole>(Buildable))
 	{
-		UE_LOG(LogSmartFoundations, Display, TEXT("UpgradeExecutionService: Upgrading power pole/outlet %s (class=%s) Family=%d TargetTier=%d"),
+		UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("UpgradeExecutionService: Upgrading power pole/outlet %s (class=%s) Family=%d TargetTier=%d"),
 			*OldPole->GetName(), *OldPole->GetClass()->GetName(),
 			static_cast<int32>(ActualFamily), CurrentParams.TargetTier);
 
@@ -1536,7 +1536,7 @@ int32 USFUpgradeExecutionService::ProcessSingleUpgrade(AFGBuildable* Buildable, 
 					}
 					else
 					{
-						UE_LOG(LogSmartFoundations, Log, TEXT("Pole upgrade: Refunded %d %s"),
+						UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("Pole upgrade: Refunded %d %s"),
 							RefundAmount, *UFGItemDescriptor::GetItemName(Entry.Key).ToString());
 					}
 				}
@@ -1544,7 +1544,7 @@ int32 USFUpgradeExecutionService::ProcessSingleUpgrade(AFGBuildable* Buildable, 
 		}
 
 		// Spawn new pole using vanilla hologram (MassUpgrade pattern)
-		UE_LOG(LogSmartFoundations, Display, TEXT("UpgradeExecutionService: Spawning hologram from recipe %s for %s"),
+		UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("UpgradeExecutionService: Spawning hologram from recipe %s for %s"),
 			*GetNameSafe(ActualTargetRecipe), *OldPole->GetName());
 		AFGHologram* PoleHologram = AFGHologram::SpawnHologramFromRecipe(
 			ActualTargetRecipe,
@@ -1559,7 +1559,7 @@ int32 USFUpgradeExecutionService::ProcessSingleUpgrade(AFGBuildable* Buildable, 
 				*GetNameSafe(ActualTargetRecipe));
 			return 0;
 		}
-		UE_LOG(LogSmartFoundations, Display, TEXT("UpgradeExecutionService: Spawned hologram %s (class=%s)"),
+		UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("UpgradeExecutionService: Spawned hologram %s (class=%s)"),
 			*PoleHologram->GetName(), *PoleHologram->GetClass()->GetName());
 
 		// Set blueprint designer (like MassUpgrade)
@@ -1575,7 +1575,7 @@ int32 USFUpgradeExecutionService::ProcessSingleUpgrade(AFGBuildable* Buildable, 
 			PoleHologram->Destroy();
 			return 0;
 		}
-		UE_LOG(LogSmartFoundations, Display, TEXT("UpgradeExecutionService: TryUpgrade succeeded for %s"), *OldPole->GetName());
+		UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("UpgradeExecutionService: TryUpgrade succeeded for %s"), *OldPole->GetName());
 
 		// Construct the new pole
 		TArray<AActor*> ConstructedChildren;
@@ -1610,7 +1610,7 @@ int32 USFUpgradeExecutionService::ProcessSingleUpgrade(AFGBuildable* Buildable, 
 		// Track old->new mapping for post-upgrade validation
 		OldToNewBuildableMap.Add(OldPole, NewPole);
 
-		UE_LOG(LogSmartFoundations, Display, TEXT("UpgradeExecutionService: Successfully upgraded pole %s to %s"),
+		UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("UpgradeExecutionService: Successfully upgraded pole %s to %s"),
 			*Buildable->GetName(), *NewPole->GetClass()->GetName());
 		return 1;
 	}
@@ -1640,7 +1640,7 @@ void USFUpgradeExecutionService::CompleteUpgrade()
 	if (UpgradedConveyors.Num() > 0 && ChainService)
 	{
 		PreRepairQueuedGroups = ChainService->InvalidateAndQueueVanillaRebuildForBelts(UpgradedConveyors, PreDestroyChainActors);
-		UE_LOG(LogSmartFoundations, Display,
+		UE_LOG(LogSmartFoundations, VeryVerbose,
 			TEXT("ChainActorService: pre-repair conveyor invalidation queued %d group(s) before connection repair"),
 			PreRepairQueuedGroups);
 	}
@@ -1661,7 +1661,7 @@ void USFUpgradeExecutionService::CompleteUpgrade()
 		if (ChainService)
 		{
 			PostRepairQueuedGroups = ChainService->ReRegisterAndQueueVanillaRebuildForBelts(UpgradedConveyors, PreDestroyChainActors);
-			UE_LOG(LogSmartFoundations, Display,
+			UE_LOG(LogSmartFoundations, VeryVerbose,
 				TEXT("⚙️ Upgrade batch complete - %d conveyors upgraded, chain groups queued pre-repair=%d post-reregister=%d"),
 				UpgradedConveyors.Num(), PreRepairQueuedGroups, PostRepairQueuedGroups);
 
@@ -1695,7 +1695,7 @@ void USFUpgradeExecutionService::CompleteUpgrade()
 				if (Entry.Key && Entry.Value > 0)
 				{
 					Stacks.Add(FInventoryStack(Entry.Value, Entry.Key));
-					UE_LOG(LogSmartFoundations, Log, TEXT("UpgradeExecutionService: Adding %d %s to overflow crate"),
+					UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("UpgradeExecutionService: Adding %d %s to overflow crate"),
 						Entry.Value, *UFGItemDescriptor::GetItemName(Entry.Key).ToString());
 				}
 			}
@@ -1711,7 +1711,7 @@ void USFUpgradeExecutionService::CompleteUpgrade()
 					OutCrate,
 					EFGCrateType::CT_DismantleCrate
 				);
-				UE_LOG(LogSmartFoundations, Log, TEXT("UpgradeExecutionService: Spawned overflow crate with %d item types"),
+				UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("UpgradeExecutionService: Spawned overflow crate with %d item types"),
 					Stacks.Num());
 			}
 		}
@@ -2291,7 +2291,7 @@ void USFUpgradeExecutionService::FixBatchConnectionReferences()
 
 	if (FixedCount > 0)
 	{
-		UE_LOG(LogSmartFoundations, Display, TEXT("FixBatchConnectionReferences: Fixed %d inter-connected references"), FixedCount);
+		UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("FixBatchConnectionReferences: Fixed %d inter-connected references"), FixedCount);
 
 		// NOTE: Do NOT call RemoveConveyor/AddConveyor here.
 		// The vanilla hologram upgrade path (TryUpgrade → ConfigureComponents → AddConveyor)
@@ -2443,7 +2443,7 @@ void USFUpgradeExecutionService::FixBatchPipeConnectionReferences()
 
 	if (FixedCount > 0)
 	{
-		UE_LOG(LogSmartFoundations, Display, TEXT("FixBatchPipeConnectionReferences: Fixed %d inter-connected pipe references"), FixedCount);
+		UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("FixBatchPipeConnectionReferences: Fixed %d inter-connected pipe references"), FixedCount);
 	}
 }
 
@@ -2623,7 +2623,7 @@ void USFUpgradeExecutionService::ValidateAndRepairConnections()
 					if (LocalConn->GetConnection() == PartnerConn)
 					{
 						Repaired++;
-						UE_LOG(LogSmartFoundations, Display,
+						UE_LOG(LogSmartFoundations, VeryVerbose,
 							TEXT("ValidateAndRepairConnections: REPAIRED factory %s.%s <-> %s.%s"),
 							*NewLocal->GetName(), *Edge.LocalConnectorName.ToString(),
 							*PartnerNew->GetName(), *Edge.PartnerConnectorName.ToString());
@@ -2665,7 +2665,7 @@ void USFUpgradeExecutionService::ValidateAndRepairConnections()
 					if (LocalConn->GetConnection() == PartnerConn)
 					{
 						Repaired++;
-						UE_LOG(LogSmartFoundations, Display,
+						UE_LOG(LogSmartFoundations, VeryVerbose,
 							TEXT("ValidateAndRepairConnections: REPAIRED pipe %s.%s <-> %s.%s"),
 							*NewLocal->GetName(), *Edge.LocalConnectorName.ToString(),
 							*PartnerNew->GetName(), *Edge.PartnerConnectorName.ToString());
@@ -2725,7 +2725,7 @@ void USFUpgradeExecutionService::ValidateAndRepairConnections()
 	WorkingResult.RepairedConnectionCount = Repaired;
 	WorkingResult.BrokenConnectionCount = Broken;
 
-	UE_LOG(LogSmartFoundations, Display,
+	UE_LOG(LogSmartFoundations, VeryVerbose,
 		TEXT("ValidateAndRepairConnections: validated=%d repaired=%d broken=%d"),
 		Validated, Repaired, Broken);
 }

--- a/Source/SmartFoundations/Private/HUD/SFHudWidget.cpp
+++ b/Source/SmartFoundations/Private/HUD/SFHudWidget.cpp
@@ -221,7 +221,7 @@ void USFHudWidget::BuildWidgetTree()
 		UE_LOG(LogSmartFoundations, Warning, TEXT("SFHudWidget::BuildWidgetTree: WidgetTree is null!"));
 		return;
 	}
-	UE_LOG(LogSmartFoundations, Log, TEXT("SFHudWidget::BuildWidgetTree: Starting (scale=%.1f)"), CachedScale);
+	UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("SFHudWidget::BuildWidgetTree: Starting (scale=%.1f)"), CachedScale);
 
 	// Clear existing content
 	TextPool.Empty();
@@ -254,7 +254,7 @@ void USFHudWidget::BuildWidgetTree()
 	WidgetTree->RootWidget = OuterBorder;
 	OuterBorder->AddChild(InnerBorder);
 	InnerBorder->AddChild(ContentBox);
-	UE_LOG(LogSmartFoundations, Log, TEXT("SFHudWidget::BuildWidgetTree: Root=%s, ContentBox=%s"),
+	UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("SFHudWidget::BuildWidgetTree: Root=%s, ContentBox=%s"),
 		OuterBorder ? TEXT("OK") : TEXT("NULL"),
 		ContentBox ? TEXT("OK") : TEXT("NULL"));
 

--- a/Source/SmartFoundations/Private/Holograms/Logistics/SFPipelineHologram.cpp
+++ b/Source/SmartFoundations/Private/Holograms/Logistics/SFPipelineHologram.cpp
@@ -79,7 +79,7 @@ AActor* ASFPipelineHologram::Construct(TArray<AActor*>& out_children, FNetConstr
 	// IMPORTANT: Return the previously built actor, NOT nullptr - vanilla crashes on nullptr!
 	if (bHasBeenConstructed)
 	{
-		UE_LOG(LogSmartFoundations, Log, TEXT("🔧 PIPE: Skipping duplicate Construct() for %s (already built, returning cached actor)"), *GetName());
+		UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("🔧 PIPE: Skipping duplicate Construct() for %s (already built, returning cached actor)"), *GetName());
 		return ConstructedActor.Get();
 	}
 	bHasBeenConstructed = true;
@@ -91,7 +91,7 @@ AActor* ASFPipelineHologram::Construct(TArray<AActor*>& out_children, FNetConstr
 	
 	if (bIsExtendChild || bIsStackableChild || bIsPipeAutoConnectChild)
 	{
-		UE_LOG(LogSmartFoundations, Log, TEXT("🔧 %s: Pipe hologram %s Construct() called - building as child"), 
+		UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("🔧 %s: Pipe hologram %s Construct() called - building as child"), 
 			bIsPipeAutoConnectChild ? TEXT("PIPE AUTO-CONNECT") : (bIsStackableChild ? TEXT("STACKABLE") : TEXT("EXTEND")), *GetName());
 		
 		// IMPORTANT: For EXTEND children, we need to build the pipe directly without
@@ -135,7 +135,7 @@ AActor* ASFPipelineHologram::Construct(TArray<AActor*>& out_children, FNetConstr
 			}
 			
 			// Log the mapping for debugging
-			UE_LOG(LogSmartFoundations, Log, TEXT("🔧 %s: ✅ Pipe hologram %s → Buildable %s (ID: %u), discarded %d child actors"), 
+			UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("🔧 %s: ✅ Pipe hologram %s → Buildable %s (ID: %u), discarded %d child actors"), 
 				bIsStackableChild ? TEXT("STACKABLE") : (bIsPipeAutoConnectChild ? TEXT("PIPE AUTO-CONNECT") : TEXT("EXTEND")),
 				*GetName(), *BuiltActor->GetName(), BuiltActor->GetUniqueID(), DiscardedChildren.Num());
 			
@@ -165,7 +165,8 @@ AActor* ASFPipelineHologram::Construct(TArray<AActor*>& out_children, FNetConstr
 						if (NeighborConn && !NeighborConn->IsConnected() && NeighborConn->GetOwner() != Pipe)
 						{
 							Conn0->SetConnection(NeighborConn);
-							UE_LOG(LogSmartFoundations, Log, TEXT("🔧 STACKABLE: Wired Conn0 to neighbor pipe %s.%s"), 
+							UE_LOG(LogSmartFoundations, VeryVerbose, TEXT(" %s: Wired Conn0 to neighbor pipe %s.%s"), 
+								bIsStackableChild ? TEXT("STACKABLE") : (bIsPipeAutoConnectChild ? TEXT("PIPE AUTO-CONNECT") : TEXT("EXTEND")),
 								*NeighborConn->GetOwner()->GetName(), *NeighborConn->GetName());
 						}
 					}
@@ -180,7 +181,7 @@ AActor* ASFPipelineHologram::Construct(TArray<AActor*>& out_children, FNetConstr
 						if (NeighborConn && !NeighborConn->IsConnected() && NeighborConn->GetOwner() != Pipe)
 						{
 							Conn1->SetConnection(NeighborConn);
-							UE_LOG(LogSmartFoundations, Log, TEXT("🔧 STACKABLE: Wired Conn1 to neighbor pipe %s.%s"), 
+							UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("🔧 STACKABLE: Wired Conn1 to neighbor pipe %s.%s"), 
 								*NeighborConn->GetOwner()->GetName(), *NeighborConn->GetName());
 						}
 					}

--- a/Source/SmartFoundations/Private/Holograms/Logistics/SFWallHoleChildHologram.cpp
+++ b/Source/SmartFoundations/Private/Holograms/Logistics/SFWallHoleChildHologram.cpp
@@ -32,7 +32,7 @@ void ASFWallHoleChildHologram::CheckValidPlacement()
 
 AActor* ASFWallHoleChildHologram::Construct(TArray<AActor*>& out_children, FNetConstructionID constructionID)
 {
-    UE_LOG(LogSmartFoundations, Log, TEXT("🧱 WALL HOLE CHILD: Construct() called for %s"), *GetName());
+    UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("🧱 WALL HOLE CHILD: Construct() called for %s"), *GetName());
 
     // Delegate to vanilla wall-attachment construction — spawns the AFGBuildable, triggers
     // snap-point consumption on the underlying wall, registers with the buildable subsystem.
@@ -54,7 +54,7 @@ AActor* ASFWallHoleChildHologram::Construct(TArray<AActor*>& out_children, FNetC
             }
         }
 
-        UE_LOG(LogSmartFoundations, Log, TEXT("🧱 WALL HOLE CHILD: Successfully built %s -> %s (CloneId=%s)"),
+        UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("🧱 WALL HOLE CHILD: Successfully built %s -> %s (CloneId=%s)"),
             *GetName(), *BuiltActor->GetName(),
             HoloData ? *HoloData->JsonCloneId : TEXT("none"));
     }

--- a/Source/SmartFoundations/Private/Holograms/Logistics/SFWaterPumpChildHologram.cpp
+++ b/Source/SmartFoundations/Private/Holograms/Logistics/SFWaterPumpChildHologram.cpp
@@ -46,7 +46,7 @@ void ASFWaterPumpChildHologram::ConfigureActor(AFGBuildable* inBuildable) const
 
 AActor* ASFWaterPumpChildHologram::Construct(TArray<AActor*>& out_children, FNetConstructionID constructionID)
 {
-	UE_LOG(LogSmartFoundations, Display, TEXT("WaterPump Construct: %s at %s"), 
+	UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("WaterPump Construct: %s at %s"), 
 		*GetName(), *GetActorLocation().ToString());
 	return Super::Construct(out_children, constructionID);
 }
@@ -139,7 +139,7 @@ bool ASFWaterPumpChildHologram::ValidateWaterPosition() const
 				// the sky and the water at this point — a player couldn't aim here.
 				if (SkyHit.ImpactPoint.Z > ChildLocation.Z + SkyAccessTolerance)
 				{
-					UE_LOG(LogSmartFoundations, Log, TEXT("WaterPump %s: Sky access blocked at offset (%.0f,%.0f) — terrain Z=%.1f above waterline Z=%.1f"),
+					UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("WaterPump %s: Sky access blocked at offset (%.0f,%.0f) — terrain Z=%.1f above waterline Z=%.1f"),
 						*GetName(), Offset.X, Offset.Y, SkyHit.ImpactPoint.Z, ChildLocation.Z);
 					return false;
 				}
@@ -165,7 +165,7 @@ bool ASFWaterPumpChildHologram::ValidateWaterPosition() const
 	
 	if (!ContainingVolume)
 	{
-		UE_LOG(LogSmartFoundations, Log, TEXT("WaterPump %s: Position %s is NOT in any water volume"),
+		UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("WaterPump %s: Position %s is NOT in any water volume"),
 			*GetName(), *ChildLocation.ToString());
 		return false;
 	}
@@ -190,7 +190,7 @@ bool ASFWaterPumpChildHologram::ValidateWaterPosition() const
 		
 		if (DepthBelowChild < MinimumWaterDepth)
 		{
-			UE_LOG(LogSmartFoundations, Log, TEXT("WaterPump %s: Too shallow %.1f cm at %s"),
+			UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("WaterPump %s: Too shallow %.1f cm at %s"),
 				*GetName(), DepthBelowChild, *ChildLocation.ToString());
 			return false;
 		}
@@ -198,7 +198,7 @@ bool ASFWaterPumpChildHologram::ValidateWaterPosition() const
 		// Terrain hit must be inside the water volume — if outside, we're at a bank/cliff edge
 		if (!ContainingVolume->EncompassesPoint(TerrainPoint))
 		{
-			UE_LOG(LogSmartFoundations, Log, TEXT("WaterPump %s: Terrain hit outside water volume at %s — bank/cliff edge"),
+			UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("WaterPump %s: Terrain hit outside water volume at %s — bank/cliff edge"),
 				*GetName(), *ChildLocation.ToString());
 			return false;
 		}

--- a/Source/SmartFoundations/Private/Holograms/Power/SFWireHologram.cpp
+++ b/Source/SmartFoundations/Private/Holograms/Power/SFWireHologram.cpp
@@ -18,7 +18,7 @@ void ASFWireHologram::BeginPlay()
 {
 	Super::BeginPlay();
 	
-	UE_LOG(LogSmartFoundations, Log, TEXT("⚡ SFWireHologram::BeginPlay - %s"), *GetName());
+	UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("⚡ SFWireHologram::BeginPlay - %s"), *GetName());
 }
 
 TArray<FItemAmount> ASFWireHologram::GetCost(bool includeChildren) const
@@ -52,7 +52,7 @@ TArray<FItemAmount> ASFWireHologram::GetCost(bool includeChildren) const
 
 AActor* ASFWireHologram::Construct(TArray<AActor*>& out_children, FNetConstructionID constructionID)
 {
-	UE_LOG(LogSmartFoundations, Log, TEXT("⚡ SFWireHologram::Construct - Building wire %s (Parent: %s)"),
+	UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("⚡ SFWireHologram::Construct - Building wire %s (Parent: %s)"),
 		*GetName(), GetParentHologram() ? *GetParentHologram()->GetName() : TEXT("none"));
 	
 	// Issue #229: Extend wire children have no connections set — vanilla Construct()
@@ -72,13 +72,13 @@ AActor* ASFWireHologram::Construct(TArray<AActor*>& out_children, FNetConstructi
 			
 			if (Wire)
 			{
-				UE_LOG(LogSmartFoundations, Log, TEXT("⚡ SFWireHologram::Construct - Extend wire spawned: %s (post-build wiring will connect)"),
-					*Wire->GetName());
+				UE_LOG(LogSmartFoundations, VeryVerbose, TEXT(" SFWireHologram::Construct - Extend wire spawned: %s (post-build wiring will connect)"),
+				*Wire->GetName());
 				return Wire;
 			}
 		}
 		
-		UE_LOG(LogSmartFoundations, Error, TEXT("⚡ SFWireHologram::Construct - Failed to spawn extend wire!"));
+		UE_LOG(LogSmartFoundations, Error, TEXT(" SFWireHologram::Construct - Failed to spawn extend wire!"));
 		// Fallback: must not return nullptr or vanilla crashes
 	}
 	
@@ -91,7 +91,7 @@ void ASFWireHologram::CheckValidPlacement()
 	// Skip validation for child holograms used as previews
 	if (GetParentHologram())
 	{
-		UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("⚡ Wire child preview - skipping placement validation"));
+		UE_LOG(LogSmartFoundations, VeryVerbose, TEXT(" Wire child preview - skipping placement validation"));
 		return;
 	}
 
@@ -128,7 +128,7 @@ void ASFWireHologram::SetupWirePreview(UFGPowerConnectionComponent* StartConnect
 {
 	if (!StartConnection || !EndConnection)
 	{
-		UE_LOG(LogSmartFoundations, Warning, TEXT("⚡ SetupWirePreview: Invalid connections"));
+		UE_LOG(LogSmartFoundations, Warning, TEXT(" SetupWirePreview: Invalid connections"));
 		return;
 	}
 
@@ -140,9 +140,9 @@ void ASFWireHologram::SetupWirePreview(UFGPowerConnectionComponent* StartConnect
 	CachedStartPos = StartConnection->GetComponentLocation();
 	CachedEndPos = EndConnection->GetComponentLocation();
 
-	UE_LOG(LogSmartFoundations, Log, TEXT("⚡ SetupWirePreview: %s"), *GetName());
-	UE_LOG(LogSmartFoundations, Log, TEXT("   Start: %s"), *CachedStartPos.ToString());
-	UE_LOG(LogSmartFoundations, Log, TEXT("   End: %s"), *CachedEndPos.ToString());
+	UE_LOG(LogSmartFoundations, VeryVerbose, TEXT(" SetupWirePreview: %s"), *GetName());
+	UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("   Start: %s"), *CachedStartPos.ToString());
+	UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("   End: %s"), *CachedEndPos.ToString());
 
 	// Create our own wire mesh with proper catenary curve
 	CreateWireMeshWithCatenary(CachedStartPos, CachedEndPos);
@@ -160,7 +160,7 @@ void ASFWireHologram::TriggerMeshGeneration()
 {
 	if (!bWireConfigured)
 	{
-		UE_LOG(LogSmartFoundations, Warning, TEXT("⚡ TriggerMeshGeneration called but wire not configured"));
+		UE_LOG(LogSmartFoundations, Warning, TEXT(" TriggerMeshGeneration called but wire not configured"));
 		return;
 	}
 
@@ -170,7 +170,7 @@ void ASFWireHologram::TriggerMeshGeneration()
 	// Force visibility
 	ForceVisibilityUpdate();
 
-	UE_LOG(LogSmartFoundations, Log, TEXT("⚡ TriggerMeshGeneration: Wire mesh updated"));
+	UE_LOG(LogSmartFoundations, VeryVerbose, TEXT(" TriggerMeshGeneration: Wire mesh updated"));
 }
 
 void ASFWireHologram::ForceVisibilityUpdate()
@@ -224,7 +224,7 @@ void ASFWireHologram::ConfigureActor(AFGBuildable* inBuildable) const
 	AFGBuildableWire* Wire = Cast<AFGBuildableWire>(inBuildable);
 	if (!Wire)
 	{
-		UE_LOG(LogSmartFoundations, Warning, TEXT("⚡ SFWireHologram::ConfigureActor - inBuildable is not a wire!"));
+		UE_LOG(LogSmartFoundations, Warning, TEXT(" SFWireHologram::ConfigureActor - inBuildable is not a wire!"));
 		return;
 	}
 	
@@ -258,8 +258,8 @@ void ASFWireHologram::ConfigureActor(AFGBuildable* inBuildable) const
 						if (CircuitConns.Num() > 0)
 						{
 							ActualConn0 = CircuitConns[0];
-							UE_LOG(LogSmartFoundations, Log, TEXT("⚡ SFWireHologram::ConfigureActor - Pole-to-building: Found source pole %s"),
-								*Pole->GetName());
+							UE_LOG(LogSmartFoundations, VeryVerbose, TEXT(" SFWireHologram::ConfigureActor - Pole-to-building: Found source pole %s"),
+					*Pole->GetName());
 							break;
 						}
 					}
@@ -271,9 +271,9 @@ void ASFWireHologram::ConfigureActor(AFGBuildable* inBuildable) const
 				bool bConnected = Wire->Connect(ActualConn0, StoredConn1);
 				if (bConnected)
 				{
-					UE_LOG(LogSmartFoundations, Log, TEXT("⚡ SFWireHologram::ConfigureActor - Pole-to-building connected: %s to %s"),
-						ActualConn0->GetOwner() ? *ActualConn0->GetOwner()->GetName() : TEXT("null"),
-						StoredConn1->GetOwner() ? *StoredConn1->GetOwner()->GetName() : TEXT("null"));
+					UE_LOG(LogSmartFoundations, VeryVerbose, TEXT(" SFWireHologram::ConfigureActor - Pole-to-building connected: %s to %s"),
+					ActualConn0->GetOwner() ? *ActualConn0->GetOwner()->GetName() : TEXT("null"),
+					StoredConn1->GetOwner() ? *StoredConn1->GetOwner()->GetName() : TEXT("null"));
 				}
 			}
 			return;
@@ -282,7 +282,7 @@ void ASFWireHologram::ConfigureActor(AFGBuildable* inBuildable) const
 	
 	// Pole-to-pole wire: Target is still a hologram, skip connection here
 	// The deferred system will handle this after all poles are built
-	UE_LOG(LogSmartFoundations, Log, TEXT("⚡ SFWireHologram::ConfigureActor - Pole-to-pole wire: Deferring connection (target is hologram)"));
+	UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("⚡ SFWireHologram::ConfigureActor - Pole-to-pole wire: Deferring connection (target is hologram)"));
 }
 
 void ASFWireHologram::CreateWireMeshWithCatenary(const FVector& StartPos, const FVector& EndPos)
@@ -316,7 +316,7 @@ void ASFWireHologram::CreateWireMeshWithCatenary(const FVector& StartPos, const 
 			PreviewWireMesh->RegisterComponent();
 			PreviewWireMesh->AttachToComponent(GetRootComponent(), FAttachmentTransformRules::KeepRelativeTransform);
 			
-			UE_LOG(LogSmartFoundations, Log, TEXT("⚡ Created PreviewWireMesh component with Powerline_Inst material"));
+			UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("⚡ Created PreviewWireMesh component with Powerline_Inst material"));
 		}
 	}
 
@@ -367,7 +367,7 @@ void ASFWireHologram::CreateWireMeshWithCatenary(const FVector& StartPos, const 
 	PreviewWireMesh->SetVisibility(true, true);
 	PreviewWireMesh->MarkRenderStateDirty();
 
-	UE_LOG(LogSmartFoundations, Log, TEXT("⚡ Wire mesh configured: Length=%.1f cm, Scale=%.2f"), Length, ScaleFactor);
+	UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("⚡ Wire mesh configured: Length=%.1f cm, Scale=%.2f"), Length, ScaleFactor);
 }
 
 void ASFWireHologram::ApplyHologramMaterial(UMaterialInterface* Material)

--- a/Source/SmartFoundations/Private/Input/SFInputRegistry.cpp
+++ b/Source/SmartFoundations/Private/Input/SFInputRegistry.cpp
@@ -29,7 +29,7 @@ USFInputRegistry::USFInputRegistry()
 void USFInputRegistry::InitializeSmartInputSystem()
 {
 	UE_LOG(LogSmartFoundations, Log, TEXT("Smart! Enhanced Input system initialization - SML 3.11.x Blueprint approach"));
-	
+
 	UE_LOG(LogSmartFoundations, Log, TEXT("📋 Smart! Gameplay Tags ready for Blueprint binding:"));
 	UE_LOG(LogSmartFoundations, Log, TEXT("  - %s (Num8 - Scale Forward)"), *TAG_SCALE_X_POSITIVE);
 	UE_LOG(LogSmartFoundations, Log, TEXT("  - %s (Num5 - Scale Backward)"), *TAG_SCALE_X_NEGATIVE);
@@ -75,7 +75,7 @@ void USFInputRegistry::ClearInputCache()
 {
 	if (GSmartInputMappingContextCache)
 	{
-		UE_LOG(LogSmartFoundations, Log, TEXT("Clearing Smart! Input Mapping Context cache (world cleanup)"));
+		UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("Clearing Smart! Input Mapping Context cache (world cleanup)"));
 		GSmartInputMappingContextCache = nullptr;
 	}
 }
@@ -86,27 +86,27 @@ UFGInputMappingContext* USFInputRegistry::GetSmartInputMappingContext()
 	{
 		// Mapping context renamed to reflect broader input scope (not just numpad)
 		const FSoftObjectPath CorrectPath(TEXT("/SmartFoundations/SmartFoundations/Input/Contexts/MC_Smart_BuildGunBuild.MC_Smart_BuildGunBuild"));
-		
-		UE_LOG(LogSmartFoundations, Log, TEXT("🔍 Loading Smart! Input Mapping Context from: %s"), *CorrectPath.ToString());
-		
+
+		UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("🔍 Loading Smart! Input Mapping Context from: %s"), *CorrectPath.ToString());
+
 		// Try multiple loading methods
 		UObject* LoadedObject = CorrectPath.TryLoad();
-		
+
 		if (!LoadedObject)
 		{
 			LoadedObject = LoadObject<UFGInputMappingContext>(nullptr, *CorrectPath.ToString());
 		}
-		
+
 		if (!LoadedObject)
 		{
 			LoadedObject = StaticLoadObject(UFGInputMappingContext::StaticClass(), nullptr, *CorrectPath.ToString());
 		}
-		
+
 		GSmartInputMappingContextCache = Cast<UFGInputMappingContext>(LoadedObject);
-		
+
 		if (GSmartInputMappingContextCache)
 		{
-			UE_LOG(LogSmartFoundations, Log, TEXT("✅ Smart! Input Mapping Context loaded successfully"));
+			UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("✅ Smart! Input Mapping Context loaded successfully"));
 		}
 		else
 		{
@@ -115,7 +115,7 @@ UFGInputMappingContext* USFInputRegistry::GetSmartInputMappingContext()
 			UE_LOG(LogSmartFoundations, Error, TEXT("❌ Verify Blueprint asset exists in Unreal Editor"));
 		}
 	}
-	
+
 	return GSmartInputMappingContextCache;
 }
 
@@ -127,7 +127,7 @@ void USFInputRegistry::BindInputActionsToSubsystem(USFSubsystem* Subsystem, UFGE
 		return;
 	}
 
-	UE_LOG(LogSmartFoundations, Log, TEXT("Binding NEW Smart! Axis1D input actions to subsystem"));
+	UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("Binding NEW Smart! Axis1D input actions to subsystem"));
 
 	// Helper to load Input Action assets
 	auto LoadIA = [](const TCHAR* Path) -> UInputAction*
@@ -144,11 +144,11 @@ void USFInputRegistry::BindInputActionsToSubsystem(USFSubsystem* Subsystem, UFGE
 	// NOTE: Using Started event for NumPad keys (InputTriggerPressed)
 	//   - NumPad keys: InputTriggerPressed → Started event
 	//   - MouseWheel: Requires manual check (parent context consumes input first)
-	
+
 	if (UInputAction* IA_ScaleX = LoadIA(TEXT("/SmartFoundations/SmartFoundations/Input/Actions/IA_Smart_ScaleX.IA_Smart_ScaleX")))
 	{
 		InputComponent->BindAction(IA_ScaleX, ETriggerEvent::Started, Subsystem, &USFSubsystem::OnScaleXChanged);
-		UE_LOG(LogSmartFoundations, Log, TEXT("✅ Bound: Scale X (Axis1D) - Started event"));
+		UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("✅ Bound: Scale X (Axis1D) - Started event"));
 		++BoundCount;
 	}
 	else
@@ -159,7 +159,7 @@ void USFInputRegistry::BindInputActionsToSubsystem(USFSubsystem* Subsystem, UFGE
 	if (UInputAction* IA_ScaleY = LoadIA(TEXT("/SmartFoundations/SmartFoundations/Input/Actions/IA_Smart_ScaleY.IA_Smart_ScaleY")))
 	{
 		InputComponent->BindAction(IA_ScaleY, ETriggerEvent::Started, Subsystem, &USFSubsystem::OnScaleYChanged);
-		UE_LOG(LogSmartFoundations, Log, TEXT("✅ Bound: Scale Y (Axis1D) - Started event"));
+		UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("✅ Bound: Scale Y (Axis1D) - Started event"));
 		++BoundCount;
 	}
 	else
@@ -170,7 +170,7 @@ void USFInputRegistry::BindInputActionsToSubsystem(USFSubsystem* Subsystem, UFGE
 	if (UInputAction* IA_ScaleZ = LoadIA(TEXT("/SmartFoundations/SmartFoundations/Input/Actions/IA_Smart_ScaleZ.IA_Smart_ScaleZ")))
 	{
 		InputComponent->BindAction(IA_ScaleZ, ETriggerEvent::Started, Subsystem, &USFSubsystem::OnScaleZChanged);
-		UE_LOG(LogSmartFoundations, Log, TEXT("✅ Bound: Scale Z (Axis1D) - Started event"));
+		UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("✅ Bound: Scale Z (Axis1D) - Started event"));
 		++BoundCount;
 	}
 	else
@@ -179,11 +179,11 @@ void USFInputRegistry::BindInputActionsToSubsystem(USFSubsystem* Subsystem, UFGE
 	}
 
 	// === Mouse Wheel (Unified context-aware handler) ===
-	
+
 	if (UInputAction* IA_MouseWheel = LoadIA(TEXT("/SmartFoundations/SmartFoundations/Input/Actions/IA_Smart_MouseWheel.IA_Smart_MouseWheel")))
 	{
 		InputComponent->BindAction(IA_MouseWheel, ETriggerEvent::Triggered, Subsystem, &USFSubsystem::OnMouseWheelChanged);
-		UE_LOG(LogSmartFoundations, Log, TEXT("✅ Bound: Mouse Wheel (Axis1D - context-aware) - Triggered event"));
+		UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("✅ Bound: Mouse Wheel (Axis1D - context-aware) - Triggered event"));
 		++BoundCount;
 	}
 	else
@@ -192,12 +192,12 @@ void USFInputRegistry::BindInputActionsToSubsystem(USFSubsystem* Subsystem, UFGE
 	}
 
 	// === Modifier Actions (Boolean) ===
-	
+
 	if (UInputAction* IA_ModScaleX = LoadIA(TEXT("/SmartFoundations/SmartFoundations/Input/Actions/IA_Smart_Modifier_ScaleX.IA_Smart_Modifier_ScaleX")))
 	{
 		InputComponent->BindAction(IA_ModScaleX, ETriggerEvent::Started, Subsystem, &USFSubsystem::OnModifierScaleXPressed);
 		InputComponent->BindAction(IA_ModScaleX, ETriggerEvent::Completed, Subsystem, &USFSubsystem::OnModifierScaleXReleased);
-		UE_LOG(LogSmartFoundations, Log, TEXT("✅ Bound: Modifier Scale X (Boolean - Started+Completed)"));
+		UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("✅ Bound: Modifier Scale X (Boolean - Started+Completed)"));
 		BoundCount += 2;
 	}
 
@@ -205,27 +205,27 @@ void USFInputRegistry::BindInputActionsToSubsystem(USFSubsystem* Subsystem, UFGE
 	{
 		InputComponent->BindAction(IA_ModScaleY, ETriggerEvent::Started, Subsystem, &USFSubsystem::OnModifierScaleYPressed);
 		InputComponent->BindAction(IA_ModScaleY, ETriggerEvent::Completed, Subsystem, &USFSubsystem::OnModifierScaleYReleased);
-		UE_LOG(LogSmartFoundations, Log, TEXT("✅ Bound: Modifier Scale Y (Boolean - Started+Completed)"));
+		UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("✅ Bound: Modifier Scale Y (Boolean - Started+Completed)"));
 		BoundCount += 2;
 	}
 
 	// === Spacing Actions ===
-	
+
 	if (UInputAction* IA_SpacingMode = LoadIA(TEXT("/SmartFoundations/SmartFoundations/Input/Actions/IA_Smart_Spacing_Mode.IA_Smart_Spacing_Mode")))
 	{
 		InputComponent->BindAction(IA_SpacingMode, ETriggerEvent::Started, Subsystem, &USFSubsystem::OnSpacingModeChanged);
 		InputComponent->BindAction(IA_SpacingMode, ETriggerEvent::Completed, Subsystem, &USFSubsystem::OnSpacingModeChanged);
-		UE_LOG(LogSmartFoundations, Log, TEXT("✅ Bound: Spacing Mode (Boolean)"));
+		UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("✅ Bound: Spacing Mode (Boolean)"));
 		BoundCount += 2;
 	}
 
 	// === Recipe Actions ===
-	
+
 	if (UInputAction* IA_RecipeMode = LoadIA(TEXT("/SmartFoundations/SmartFoundations/Input/Actions/IA_Smart_RecipeMode.IA_Smart_RecipeMode")))
 	{
 		InputComponent->BindAction(IA_RecipeMode, ETriggerEvent::Started, Subsystem, &USFSubsystem::OnRecipeModeChanged);
 		InputComponent->BindAction(IA_RecipeMode, ETriggerEvent::Completed, Subsystem, &USFSubsystem::OnRecipeModeChanged);
-		UE_LOG(LogSmartFoundations, Log, TEXT("✅ Bound: Recipe Mode (Boolean)"));
+		UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("✅ Bound: Recipe Mode (Boolean)"));
 		BoundCount += 2;
 	}
 	else
@@ -234,11 +234,11 @@ void USFInputRegistry::BindInputActionsToSubsystem(USFSubsystem* Subsystem, UFGE
 	}
 
 	// === UNIFIED VALUE ADJUSTMENT (replaces individual Spacing/Steps/Stagger adjust actions) ===
-	
+
 	if (UInputAction* IA_IncreaseValue = LoadIA(TEXT("/SmartFoundations/SmartFoundations/Input/Actions/IA_Smart_IncreaseValue.IA_Smart_IncreaseValue")))
 	{
 		InputComponent->BindAction(IA_IncreaseValue, ETriggerEvent::Started, Subsystem, &USFSubsystem::OnValueIncreased);
-		UE_LOG(LogSmartFoundations, Log, TEXT("✅ Bound: Increase Value (Axis1D - context-aware) - Started event"));
+		UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("✅ Bound: Increase Value (Axis1D - context-aware) - Started event"));
 		++BoundCount;
 	}
 	else
@@ -249,7 +249,7 @@ void USFInputRegistry::BindInputActionsToSubsystem(USFSubsystem* Subsystem, UFGE
 	if (UInputAction* IA_DecreaseValue = LoadIA(TEXT("/SmartFoundations/SmartFoundations/Input/Actions/IA_Smart_DecreaseValue.IA_Smart_DecreaseValue")))
 	{
 		InputComponent->BindAction(IA_DecreaseValue, ETriggerEvent::Started, Subsystem, &USFSubsystem::OnValueDecreased);
-		UE_LOG(LogSmartFoundations, Log, TEXT("✅ Bound: Decrease Value (Axis1D - context-aware) - Started event"));
+		UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("✅ Bound: Decrease Value (Axis1D - context-aware) - Started event"));
 		++BoundCount;
 	}
 	else
@@ -261,55 +261,55 @@ void USFInputRegistry::BindInputActionsToSubsystem(USFSubsystem* Subsystem, UFGE
 	if (UInputAction* IA_CycleAxis = LoadIA(TEXT("/SmartFoundations/SmartFoundations/Input/Actions/IA_Smart_CycleAxis.IA_Smart_CycleAxis")))
 	{
 		InputComponent->BindAction(IA_CycleAxis, ETriggerEvent::Started, Subsystem, &USFSubsystem::OnCycleAxis);
-		UE_LOG(LogSmartFoundations, Log, TEXT("✅ Bound: Cycle Axis (Boolean - context-aware)"));
+		UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("✅ Bound: Cycle Axis (Boolean - context-aware)"));
 		++BoundCount;
 	}
 
 	// === Steps Actions ===
-	
+
 	if (UInputAction* IA_StepsMode = LoadIA(TEXT("/SmartFoundations/SmartFoundations/Input/Actions/IA_Smart_Steps_Mode.IA_Smart_Steps_Mode")))
 	{
 		InputComponent->BindAction(IA_StepsMode, ETriggerEvent::Started, Subsystem, &USFSubsystem::OnStepsModeChanged);
 		InputComponent->BindAction(IA_StepsMode, ETriggerEvent::Completed, Subsystem, &USFSubsystem::OnStepsModeChanged);
-		UE_LOG(LogSmartFoundations, Log, TEXT("✅ Bound: Steps Mode (Boolean)"));
+		UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("✅ Bound: Steps Mode (Boolean)"));
 		BoundCount += 2;
 	}
 
 	// === Stagger Actions (lateral grid offset) ===
-	
+
 	if (UInputAction* IA_StaggerMode = LoadIA(TEXT("/SmartFoundations/SmartFoundations/Input/Actions/IA_Smart_Stagger_Mode.IA_Smart_Stagger_Mode")))
 	{
 		InputComponent->BindAction(IA_StaggerMode, ETriggerEvent::Started, Subsystem, &USFSubsystem::OnStaggerModeChanged);
 		InputComponent->BindAction(IA_StaggerMode, ETriggerEvent::Completed, Subsystem, &USFSubsystem::OnStaggerModeChanged);
-		UE_LOG(LogSmartFoundations, Log, TEXT("✅ Bound: Stagger Mode (Boolean) - lateral grid offset"));
+		UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("✅ Bound: Stagger Mode (Boolean) - lateral grid offset"));
 		BoundCount += 2;
 	}
 
 	// === Rotation Actions (radial/arc placement) ===
-	
+
 	if (UInputAction* IA_RotationMode = LoadIA(TEXT("/SmartFoundations/SmartFoundations/Input/Actions/IA_Smart_Rotation_Mode.IA_Smart_Rotation_Mode")))
 	{
 		InputComponent->BindAction(IA_RotationMode, ETriggerEvent::Started, Subsystem, &USFSubsystem::OnRotationModeChanged);
 		InputComponent->BindAction(IA_RotationMode, ETriggerEvent::Completed, Subsystem, &USFSubsystem::OnRotationModeChanged);
-		UE_LOG(LogSmartFoundations, Log, TEXT("✅ Bound: Rotation Mode (Boolean) - radial/arc placement"));
+		UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("✅ Bound: Rotation Mode (Boolean) - radial/arc placement"));
 		BoundCount += 2;
 	}
 
 	// === Toggle Arrows (Unchanged) ===
-	
+
 	if (UInputAction* IA_ToggleArrows = LoadIA(TEXT("/SmartFoundations/SmartFoundations/Input/Actions/IA_Smart_ToggleArrows.IA_Smart_ToggleArrows")))
 	{
 		InputComponent->BindAction(IA_ToggleArrows, ETriggerEvent::Started, Subsystem, &USFSubsystem::OnToggleArrows);
-		UE_LOG(LogSmartFoundations, Log, TEXT("✅ Bound: Toggle Arrows (Boolean)"));
+		UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("✅ Bound: Toggle Arrows (Boolean)"));
 		++BoundCount;
 	}
 
 	// === Settings Form Interface (Phase 0 Validation) ===
-	
+
 	if (UInputAction* IA_ToggleSettingsForm = LoadIA(TEXT("/SmartFoundations/SmartFoundations/Input/Actions/IA_Smart_ToggleSettingsForm.IA_Smart_ToggleSettingsForm")))
 	{
 		InputComponent->BindAction(IA_ToggleSettingsForm, ETriggerEvent::Started, Subsystem, &USFSubsystem::OnToggleSettingsForm);
-		UE_LOG(LogSmartFoundations, Log, TEXT("✅ Bound: Toggle Settings Form (Boolean) - Phase 0 validation"));
+		UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("✅ Bound: Toggle Settings Form (Boolean) - Phase 0 validation"));
 		++BoundCount;
 	}
 	else
@@ -317,5 +317,5 @@ void USFInputRegistry::BindInputActionsToSubsystem(USFSubsystem* Subsystem, UFGE
 		UE_LOG(LogSmartFoundations, Error, TEXT("❌ Failed to load: IA_Smart_ToggleSettingsForm"));
 	}
 
-	UE_LOG(LogSmartFoundations, Log, TEXT("Smart! NEW input binding complete - %d action bindings registered"), BoundCount);
+	UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("Smart! NEW input binding complete - %d action bindings registered"), BoundCount);
 }

--- a/Source/SmartFoundations/Private/Module/SFGameInstanceModule.cpp
+++ b/Source/SmartFoundations/Private/Module/SFGameInstanceModule.cpp
@@ -52,7 +52,7 @@ void USFGameInstanceModule::DispatchLifecycleEvent(ELifecyclePhase Phase)
 	if (Phase == ELifecyclePhase::POST_INITIALIZATION)
 	{
 		UE_LOG(LogSmartFoundations, Display, TEXT("Smart! GameInstanceModule: POST_INITIALIZATION - Registering Smart! configuration"));
-		
+
 		// Register Smart! Configuration with SML for in-game menu access
 		// Use the SmartConfigClass property set in the blueprint
 		if (SmartConfigClass)
@@ -67,13 +67,13 @@ void USFGameInstanceModule::DispatchLifecycleEvent(ELifecyclePhase Phase)
 			UE_LOG(LogSmartFoundations, Warning, TEXT("❌ SmartConfigClass not set in blueprint Class Defaults"));
 			UE_LOG(LogSmartFoundations, Warning, TEXT("Config menu will not appear. Set SmartConfigClass to Smart_Config blueprint in SFGameInstanceModule_BP."));
 		}
-		
+
 		// Register SML hook for cost aggregation (belt preview costs)
 		RegisterCostAggregationHook();
-		
+
 		// Register SML hook for blueprint construct (chain actor rebuilding like AutoLink)
 		RegisterBlueprintConstructHook();
-		
+
 		// Widget hooks will be registered here once Blueprint widget is created
 	}
 }
@@ -86,7 +86,7 @@ void USFGameInstanceModule::RegisterWidgetHooks()
 	// 1. A Blueprint widget asset in Content/SmartFoundations/UI/
 	// 2. Target widget path (e.g., /Game/FactoryGame/Interface/UI/InGame/FGGameUI.FGGameUI_C)
 	// 3. Named slot in target widget to inject into
-	
+
 	// Example implementation (once Blueprint widget exists):
 	/*
 	if (CounterWidgetClass)
@@ -100,28 +100,28 @@ void USFGameInstanceModule::RegisterWidgetHooks()
 	}
 	*/
 
-	UE_LOG(LogSmartFoundations, Warning, 
+	UE_LOG(LogSmartFoundations, Warning,
 		TEXT("Widget Blueprint Hooks require Blueprint asset - placeholder ready for future implementation"));
 }
 
 void USFGameInstanceModule::RegisterCostAggregationHook()
 {
 	UE_LOG(LogSmartFoundations, Display, TEXT("💰 Registering GetCost hook for belt preview cost aggregation"));
-	
+
 	// ========================================
 	// SML Hook: GetCost for Conveyor Attachments
 	// ========================================
 	// We need an SML hook because the vanilla hologram Blueprint (Holo_ConveyorAttachment_C)
 	// is used, not our custom C++ class. Hook intercepts vanilla GetCost() to add belt costs.
 	// Vanilla ValidatePlacementAndCost() will then automatically handle affordability.
-	
+
 	// Hook AFGHologram::GetCost to inject belt preview costs
 	// Signature must match SML's TCallScope pattern
 	SUBSCRIBE_UOBJECT_METHOD(AFGHologram, GetCost, [](auto& scope, const AFGHologram* self, bool includeChildren)
 	{
 		// Call original GetCost implementation
 		TArray<FItemAmount> BaseCost = scope(self, includeChildren);
-		
+
 		// Process conveyor attachment holograms (splitters/mergers)
 		const AFGConveyorAttachmentHologram* Distributor = Cast<AFGConveyorAttachmentHologram>(self);
 		if (Distributor)
@@ -134,16 +134,16 @@ void USFGameInstanceModule::RegisterCostAggregationHook()
 					if (USFAutoConnectService* AutoConnect = Subsystem->GetAutoConnectService())
 					{
 						TArray<FItemAmount> BeltCosts = AutoConnect->GetBeltPreviewsCost(Distributor);
-						
+
 						if (BeltCosts.Num() > 0)
 						{
 							UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("💰 GetCost hook: Adding %d belt cost item types"), BeltCosts.Num());
-							
+
 							// Merge belt costs using FactorySpawner's pattern
 							for (const FItemAmount& BeltCost : BeltCosts)
 							{
 								if (!BeltCost.ItemClass) continue;
-								
+
 								FItemAmount* Existing = BaseCost.FindByPredicate([&](const FItemAmount& X) {
 									return X.ItemClass == BeltCost.ItemClass;
 								});
@@ -156,14 +156,14 @@ void USFGameInstanceModule::RegisterCostAggregationHook()
 									BaseCost.Add(BeltCost);
 								}
 							}
-							
+
 							UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("💰 GetCost hook: Returning %d item types total"), BaseCost.Num());
 						}
 					}
 				}
 			}
 		}
-		
+
 		// Process power pole holograms
 		else if (UWorld* World = self->GetWorld())
 		{
@@ -174,16 +174,16 @@ void USFGameInstanceModule::RegisterCostAggregationHook()
 					if (AutoConnect->IsPipelineJunctionHologram(self))
 					{
 						TArray<FItemAmount> PipeCosts = AutoConnect->GetPipePreviewsCost(self);
-						
+
 						if (PipeCosts.Num() > 0)
 						{
 							UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("💰 GetCost hook: Adding %d pipe cost item types"), PipeCosts.Num());
-							
+
 							// Merge pipe costs using same pattern
 							for (const FItemAmount& PipeCost : PipeCosts)
 							{
 								if (!PipeCost.ItemClass) continue;
-								
+
 								FItemAmount* Existing = BaseCost.FindByPredicate([&](const FItemAmount& X) {
 									return X.ItemClass == PipeCost.ItemClass;
 								});
@@ -196,28 +196,28 @@ void USFGameInstanceModule::RegisterCostAggregationHook()
 									BaseCost.Add(PipeCost);
 								}
 							}
-							
+
 							UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("💰 GetCost hook: Returning %d item types total (including pipes)"), BaseCost.Num());
 						}
 					}
 				}
 			}
 		}
-		
+
 		return BaseCost;
 	});
-	
+
 	// NOTE: ValidatePlacementAndCost hook removed in v24.2.0+
 	// After switching to vanilla child hologram patterns, vanilla affordability checks handle everything correctly.
 	// No custom cost validation needed - child holograms automatically aggregate costs via GetCost() override.
-	
+
 	UE_LOG(LogSmartFoundations, Display, TEXT("✅ GetCost hook registered - child hologram costs automatically aggregated by vanilla"));
 }
 
 void USFGameInstanceModule::RegisterBlueprintConstructHook()
 {
 	UE_LOG(LogSmartFoundations, Display, TEXT("⛓️ Registering AFGBlueprintHologram::Construct hook for chain actor rebuilding"));
-	
+
 	// ========================================
 	// SML Hook: AFGBlueprintHologram::Construct (AFTER)
 	// ========================================
@@ -229,7 +229,7 @@ void USFGameInstanceModule::RegisterBlueprintConstructHook()
 	//
 	// This is the SAME timing AutoLink uses, and it's safe because
 	// factory tick hasn't started on these conveyors yet.
-	
+
 	SUBSCRIBE_METHOD_VIRTUAL_AFTER(
 		AFGBlueprintHologram::Construct,
 		GetMutableDefault<AFGBlueprintHologram>(),
@@ -237,20 +237,20 @@ void USFGameInstanceModule::RegisterBlueprintConstructHook()
 		{
 			UE_LOG(LogSmartFoundations, Log, TEXT("⛓️ AFGBlueprintHologram::Construct AFTER: %s with %d children"),
 				*hologram->GetName(), out_children.Num());
-			
+
 			// Get the world and subsystems
 			UWorld* World = hologram->GetWorld();
 			if (!World)
 			{
 				return;
 			}
-			
+
 			AFGBuildableSubsystem* BuildableSubsystem = AFGBuildableSubsystem::Get(World);
 			if (!BuildableSubsystem)
 			{
 				return;
 			}
-			
+
 			// Collect all conveyors from children
 			TArray<AFGBuildableConveyorBase*> BuiltConveyors;
 			for (AActor* Child : out_children)
@@ -260,18 +260,18 @@ void USFGameInstanceModule::RegisterBlueprintConstructHook()
 					BuiltConveyors.Add(Conveyor);
 				}
 			}
-			
+
 			if (BuiltConveyors.Num() == 0)
 			{
 				return;  // No conveyors to process
 			}
-			
-			UE_LOG(LogSmartFoundations, Display, TEXT("⛓️ HOOK: Found %d conveyors in blueprint children"), BuiltConveyors.Num());
-			
+
+			UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("⛓️ HOOK: Found %d conveyors in blueprint children"), BuiltConveyors.Num());
+
 			// Check if this is a Smart EXTEND build by looking for our subsystem/service
 			USFSubsystem* SmartSubsystem = USFSubsystem::Get(World);
 			USFExtendService* ExtendService = SmartSubsystem ? SmartSubsystem->GetExtendService() : nullptr;
-			
+
 			// For each conveyor that has connections established, do Remove→Add to rebuild chains
 			// This is the AutoLink pattern - done DURING construction, BEFORE factory tick
 			int32 RebuildCount = 0;
@@ -281,32 +281,32 @@ void USFGameInstanceModule::RegisterBlueprintConstructHook()
 				{
 					continue;
 				}
-				
+
 				// Check if this conveyor has any connections
 				UFGFactoryConnectionComponent* Conn0 = Conveyor->GetConnection0();
 				UFGFactoryConnectionComponent* Conn1 = Conveyor->GetConnection1();
-				
+
 				bool bHasConnection = (Conn0 && Conn0->IsConnected()) || (Conn1 && Conn1->IsConnected());
-				
+
 				if (bHasConnection)
 				{
 					// AutoLink pattern: Remove → (connections already made) → Add
 					// This triggers chain actor rebuild with proper unification
-					UE_LOG(LogSmartFoundations, Log, TEXT("⛓️ HOOK: Rebuilding chain for %s (Conn0=%s, Conn1=%s)"),
+					UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("⛓️ HOOK: Rebuilding chain for %s (Conn0=%s, Conn1=%s)"),
 						*Conveyor->GetName(),
 						Conn0 && Conn0->IsConnected() ? TEXT("connected") : TEXT("open"),
 						Conn1 && Conn1->IsConnected() ? TEXT("connected") : TEXT("open"));
-					
+
 					BuildableSubsystem->RemoveConveyor(Conveyor);
 					BuildableSubsystem->AddConveyor(Conveyor);
 					RebuildCount++;
 				}
 			}
-			
+
 			if (RebuildCount > 0)
 			{
-				UE_LOG(LogSmartFoundations, Display, TEXT("⛓️ HOOK: Rebuilt chains for %d conveyors"), RebuildCount);
-				
+				UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("⛓️ HOOK: Rebuilt chains for %d conveyors"), RebuildCount);
+
 				// Log chain status after rebuild
 				TSet<AFGConveyorChainActor*> UniqueChains;
 				for (AFGBuildableConveyorBase* Conveyor : BuiltConveyors)
@@ -320,18 +320,18 @@ void USFGameInstanceModule::RegisterBlueprintConstructHook()
 						}
 					}
 				}
-				
-				UE_LOG(LogSmartFoundations, Display, TEXT("⛓️ HOOK: %d conveyors now belong to %d unique chain actors"),
+
+				UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("⛓️ HOOK: %d conveyors now belong to %d unique chain actors"),
 					BuiltConveyors.Num(), UniqueChains.Num());
-				
+
 				for (AFGConveyorChainActor* Chain : UniqueChains)
 				{
-					UE_LOG(LogSmartFoundations, Log, TEXT("⛓️ HOOK:   Chain %s has %d segments"),
+					UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("⛓️ HOOK:   Chain %s has %d segments"),
 						*Chain->GetName(), Chain->GetNumChainSegments());
 				}
 			}
 		}
 	);
-	
+
 	UE_LOG(LogSmartFoundations, Display, TEXT("✅ AFGBlueprintHologram::Construct hook registered - chain actors will rebuild during construction"));
 }

--- a/Source/SmartFoundations/Private/SFRCO.cpp
+++ b/Source/SmartFoundations/Private/SFRCO.cpp
@@ -25,14 +25,14 @@ void USFRCO::Server_ApplyScaling_Implementation(
 	int32 NewCounter
 )
 {
-	UE_LOG(LogSmartFoundations, Log, 
+	UE_LOG(LogSmartFoundations, VeryVerbose,
 		TEXT("[SFRCO] Server_ApplyScaling: Axis=%d, Delta=%d, Counter=%d, Hologram=%s"),
 		Axis, Delta, NewCounter, *GetNameSafe(HologramActor));
 
 	// Validate hologram exists
 	if (!IsValid(HologramActor))
 	{
-		UE_LOG(LogSmartFoundations, Warning, 
+		UE_LOG(LogSmartFoundations, Warning,
 			TEXT("[SFRCO] Server_ApplyScaling: Invalid hologram actor"));
 		return;
 	}
@@ -40,7 +40,7 @@ void USFRCO::Server_ApplyScaling_Implementation(
 	// Additional validation checks
 	if (!ValidateScalingRequest(HologramActor, Axis, Delta, NewCounter))
 	{
-		UE_LOG(LogSmartFoundations, Warning, 
+		UE_LOG(LogSmartFoundations, Warning,
 			TEXT("[SFRCO] Server_ApplyScaling: Validation failed"));
 		return;
 	}
@@ -49,7 +49,7 @@ void USFRCO::Server_ApplyScaling_Implementation(
 	USFSubsystem* Subsystem = USFSubsystem::Get(this);
 	if (!IsValid(Subsystem))
 	{
-		UE_LOG(LogSmartFoundations, Error, 
+		UE_LOG(LogSmartFoundations, Error,
 			TEXT("[SFRCO] Server_ApplyScaling: Failed to get SFSubsystem"));
 		return;
 	}
@@ -57,7 +57,7 @@ void USFRCO::Server_ApplyScaling_Implementation(
 	// Forward to subsystem's scaling logic
 	Subsystem->ApplyScalingFromRPC(HologramActor, Axis, Delta, NewCounter);
 
-	UE_LOG(LogSmartFoundations, Display, 
+	UE_LOG(LogSmartFoundations, VeryVerbose,
 		TEXT("[SFRCO] Server_ApplyScaling: SUCCESS - Forwarded to subsystem"));
 }
 
@@ -71,14 +71,14 @@ bool USFRCO::Server_ApplyScaling_Validate(
 	// Basic parameter validation
 	if (Axis > 2) // X=0, Y=1, Z=2
 	{
-		UE_LOG(LogSmartFoundations, Warning, 
+		UE_LOG(LogSmartFoundations, Warning,
 			TEXT("[SFRCO] Server_ApplyScaling_Validate: Invalid axis %d"), Axis);
 		return false;
 	}
 
 	if (FMath::Abs(Delta) != 1)
 	{
-		UE_LOG(LogSmartFoundations, Warning, 
+		UE_LOG(LogSmartFoundations, Warning,
 			TEXT("[SFRCO] Server_ApplyScaling_Validate: Invalid delta %d (must be ±1)"), Delta);
 		return false;
 	}
@@ -87,7 +87,7 @@ bool USFRCO::Server_ApplyScaling_Validate(
 	const int32 ClampedCounter = ClampCounter(NewCounter);
 	if (ClampedCounter != NewCounter)
 	{
-		UE_LOG(LogSmartFoundations, Warning, 
+		UE_LOG(LogSmartFoundations, Warning,
 			TEXT("[SFRCO] Server_ApplyScaling_Validate: Counter %d out of range"), NewCounter);
 		return false;
 	}
@@ -97,12 +97,12 @@ bool USFRCO::Server_ApplyScaling_Validate(
 
 void USFRCO::Server_ResetScaling_Implementation(AFGHologram* HologramActor)
 {
-	UE_LOG(LogSmartFoundations, Log, 
+	UE_LOG(LogSmartFoundations, VeryVerbose,
 		TEXT("[SFRCO] Server_ResetScaling: Hologram=%s"), *GetNameSafe(HologramActor));
 
 	if (!IsValid(HologramActor))
 	{
-		UE_LOG(LogSmartFoundations, Warning, 
+		UE_LOG(LogSmartFoundations, Warning,
 			TEXT("[SFRCO] Server_ResetScaling: Invalid hologram actor"));
 		return;
 	}
@@ -110,7 +110,7 @@ void USFRCO::Server_ResetScaling_Implementation(AFGHologram* HologramActor)
 	USFSubsystem* Subsystem = USFSubsystem::Get(this);
 	if (!IsValid(Subsystem))
 	{
-		UE_LOG(LogSmartFoundations, Error, 
+		UE_LOG(LogSmartFoundations, Error,
 			TEXT("[SFRCO] Server_ResetScaling: Failed to get SFSubsystem"));
 		return;
 	}
@@ -118,7 +118,7 @@ void USFRCO::Server_ResetScaling_Implementation(AFGHologram* HologramActor)
 	// Forward to subsystem
 	Subsystem->ResetScalingFromRPC(HologramActor);
 
-	UE_LOG(LogSmartFoundations, Display, 
+	UE_LOG(LogSmartFoundations, VeryVerbose,
 		TEXT("[SFRCO] Server_ResetScaling: SUCCESS - Forwarded to subsystem"));
 }
 
@@ -134,13 +134,13 @@ bool USFRCO::Server_ResetScaling_Validate(AFGHologram* HologramActor)
 
 void USFRCO::Server_SetSpacingMode_Implementation(ESFSpacingMode NewMode)
 {
-	UE_LOG(LogSmartFoundations, Log, 
+	UE_LOG(LogSmartFoundations, VeryVerbose,
 		TEXT("[SFRCO] Server_SetSpacingMode: NewMode=%d"), static_cast<uint8>(NewMode));
 
 	USFSubsystem* Subsystem = USFSubsystem::Get(this);
 	if (!IsValid(Subsystem))
 	{
-		UE_LOG(LogSmartFoundations, Error, 
+		UE_LOG(LogSmartFoundations, Error,
 			TEXT("[SFRCO] Server_SetSpacingMode: Failed to get SFSubsystem"));
 		return;
 	}
@@ -148,7 +148,7 @@ void USFRCO::Server_SetSpacingMode_Implementation(ESFSpacingMode NewMode)
 	// Forward to subsystem spacing logic
 	Subsystem->SetSpacingModeFromRPC(NewMode);
 
-	UE_LOG(LogSmartFoundations, Display, 
+	UE_LOG(LogSmartFoundations, VeryVerbose,
 		TEXT("[SFRCO] Server_SetSpacingMode: SUCCESS - Forwarded to subsystem"));
 }
 
@@ -165,13 +165,13 @@ bool USFRCO::Server_SetSpacingMode_Validate(ESFSpacingMode NewMode)
 
 void USFRCO::Server_ToggleArrows_Implementation(bool bVisible)
 {
-	UE_LOG(LogSmartFoundations, Log, 
+	UE_LOG(LogSmartFoundations, VeryVerbose,
 		TEXT("[SFRCO] Server_ToggleArrows: Visible=%d"), bVisible);
 
 	USFSubsystem* Subsystem = USFSubsystem::Get(this);
 	if (!IsValid(Subsystem))
 	{
-		UE_LOG(LogSmartFoundations, Error, 
+		UE_LOG(LogSmartFoundations, Error,
 			TEXT("[SFRCO] Server_ToggleArrows: Failed to get SFSubsystem"));
 		return;
 	}
@@ -179,7 +179,7 @@ void USFRCO::Server_ToggleArrows_Implementation(bool bVisible)
 	// Forward to subsystem arrow manager
 	Subsystem->SetArrowVisibilityFromRPC(bVisible);
 
-	UE_LOG(LogSmartFoundations, Display, 
+	UE_LOG(LogSmartFoundations, VeryVerbose,
 		TEXT("[SFRCO] Server_ToggleArrows: SUCCESS - Forwarded to subsystem"));
 }
 
@@ -195,7 +195,7 @@ bool USFRCO::Server_ToggleArrows_Validate(bool bVisible)
 
 void USFRCO::Server_StartUpgradeAudit_Implementation(FSFUpgradeAuditParams Params)
 {
-	UE_LOG(LogSmartFoundations, Log, TEXT("[SFRCO] Server_StartUpgradeAudit: Radius=%f"), Params.Radius);
+	UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("[SFRCO] Server_StartUpgradeAudit: Radius=%f"), Params.Radius);
 
 	USFSubsystem* Subsystem = USFSubsystem::Get(this);
 	if (!IsValid(Subsystem))
@@ -226,7 +226,7 @@ bool USFRCO::Server_StartUpgradeAudit_Validate(FSFUpgradeAuditParams Params)
 
 void USFRCO::Server_CancelUpgradeAudit_Implementation()
 {
-	UE_LOG(LogSmartFoundations, Log, TEXT("[SFRCO] Server_CancelUpgradeAudit"));
+	UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("[SFRCO] Server_CancelUpgradeAudit"));
 
 	USFSubsystem* Subsystem = USFSubsystem::Get(this);
 	if (IsValid(Subsystem))
@@ -245,7 +245,7 @@ bool USFRCO::Server_CancelUpgradeAudit_Validate()
 
 void USFRCO::Client_ReceiveAuditResult_Implementation(FSFUpgradeAuditResult Result)
 {
-	UE_LOG(LogSmartFoundations, Log, TEXT("[SFRCO] Client_ReceiveAuditResult: Success=%d, TotalScanned=%d"), Result.bSuccess, Result.TotalScanned);
+	UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("[SFRCO] Client_ReceiveAuditResult: Success=%d, TotalScanned=%d"), Result.bSuccess, Result.TotalScanned);
 
 	// Results are received on the client and injected into the local audit service
 	USFSubsystem* Subsystem = USFSubsystem::Get(this);
@@ -272,7 +272,7 @@ bool USFRCO::ValidateScalingRequest(
 	// Check hologram authority
 	if (!HasHologramAuthority(HologramActor))
 	{
-		UE_LOG(LogSmartFoundations, Warning, 
+		UE_LOG(LogSmartFoundations, Warning,
 			TEXT("[SFRCO] ValidateScalingRequest: Caller lacks hologram authority"));
 		return false;
 	}
@@ -280,7 +280,7 @@ bool USFRCO::ValidateScalingRequest(
 	// Check rate limiting
 	if (!CheckRateLimit())
 	{
-		UE_LOG(LogSmartFoundations, Warning, 
+		UE_LOG(LogSmartFoundations, Warning,
 			TEXT("[SFRCO] ValidateScalingRequest: Rate limit exceeded"));
 		return false;
 	}
@@ -316,7 +316,7 @@ bool USFRCO::CheckRateLimit() const
 {
 	// TODO Task #22: Implement proper rate limiting
 	// Max 20 requests/second with exponential backoff
-	
+
 	// Placeholder: always allow for now
 	return true;
 }

--- a/Source/SmartFoundations/Private/Services/RadarPulse/SFRadarPulseService.cpp
+++ b/Source/SmartFoundations/Private/Services/RadarPulse/SFRadarPulseService.cpp
@@ -130,7 +130,7 @@ FSFRadarPulseSnapshot USFRadarPulseService::CaptureSnapshotAtLocationFiltered(co
 
         // Pre-categorize to check filter before full capture
         FString Category = CategorizeActor(Actor);
-        
+
         // Skip if not in filter (when filter is active)
         if (bHasFilter && !FilterSet.Contains(Category))
         {
@@ -856,38 +856,38 @@ void USFRadarPulseService::InspectHologram(AFGHologram* Hologram, const FString&
         return;
     }
 
-    UE_LOG(LogSmartFoundations, Display, TEXT(""));
-    UE_LOG(LogSmartFoundations, Display, TEXT("╔═══════════════════════════════════════════════════════════════════════════════"));
-    UE_LOG(LogSmartFoundations, Display, TEXT("║ 📡 HOLOGRAM INSPECTION: %s"), *DebugLabel);
-    UE_LOG(LogSmartFoundations, Display, TEXT("╠═══════════════════════════════════════════════════════════════════════════════"));
-    UE_LOG(LogSmartFoundations, Display, TEXT("║ Name: %s"), *Hologram->GetName());
-    UE_LOG(LogSmartFoundations, Display, TEXT("║ Class: %s"), *Hologram->GetClass()->GetName());
-    UE_LOG(LogSmartFoundations, Display, TEXT("║ Location: %s"), *Hologram->GetActorLocation().ToString());
-    UE_LOG(LogSmartFoundations, Display, TEXT("║ Rotation: %s"), *Hologram->GetActorRotation().ToString());
-    UE_LOG(LogSmartFoundations, Display, TEXT("║ Hidden: %d | TickEnabled: %d | BegunPlay: %d"),
+    UE_LOG(LogSmartFoundations, VeryVerbose, TEXT(""));
+    UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("╔═══════════════════════════════════════════════════════════════════════════════"));
+    UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("║ 📡 HOLOGRAM INSPECTION: %s"), *DebugLabel);
+    UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("╠═══════════════════════════════════════════════════════════════════════════════"));
+    UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("║ Name: %s"), *Hologram->GetName());
+    UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("║ Class: %s"), *Hologram->GetClass()->GetName());
+    UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("║ Location: %s"), *Hologram->GetActorLocation().ToString());
+    UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("║ Rotation: %s"), *Hologram->GetActorRotation().ToString());
+    UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("║ Hidden: %d | TickEnabled: %d | BegunPlay: %d"),
         Hologram->IsHidden(), Hologram->PrimaryActorTick.bCanEverTick, Hologram->HasActorBegunPlay());
-    
+
     // Get material state
     EHologramMaterialState MatState = Hologram->GetHologramMaterialState();
-    UE_LOG(LogSmartFoundations, Display, TEXT("║ MaterialState: %d (0=OK, 1=Warning, 2=Error)"), (int32)MatState);
-    
+    UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("║ MaterialState: %d (0=OK, 1=Warning, 2=Error)"), (int32)MatState);
+
     // Note: mValidPlacementMaterial and mInvalidPlacementMaterial are protected members
     // We can inspect them indirectly through the materials applied to mesh components
-    
+
     // Check if it's a spline hologram (belt/pipe)
     if (AFGSplineHologram* SplineHologram = Cast<AFGSplineHologram>(Hologram))
     {
-        UE_LOG(LogSmartFoundations, Display, TEXT("╠═══════════════════════════════════════════════════════════════════════════════"));
-        UE_LOG(LogSmartFoundations, Display, TEXT("║ ═══ SPLINE HOLOGRAM DATA ═══"));
-        
+        UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("╠═══════════════════════════════════════════════════════════════════════════════"));
+        UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("║ ═══ SPLINE HOLOGRAM DATA ═══"));
+
         // Find spline component via FindComponentByClass (mSplineComponent is protected)
         if (USplineComponent* SplineComp = Hologram->FindComponentByClass<USplineComponent>())
         {
             int32 NumPoints = SplineComp->GetNumberOfSplinePoints();
             float SplineLength = SplineComp->GetSplineLength();
-            UE_LOG(LogSmartFoundations, Display, TEXT("║ SplineComponent: %d points, Length=%.1f cm"), NumPoints, SplineLength);
-            UE_LOG(LogSmartFoundations, Display, TEXT("║ SplineComponent World Location: %s"), *SplineComp->GetComponentLocation().ToString());
-            
+            UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("║ SplineComponent: %d points, Length=%.1f cm"), NumPoints, SplineLength);
+            UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("║ SplineComponent World Location: %s"), *SplineComp->GetComponentLocation().ToString());
+
             // Log each spline point
             for (int32 i = 0; i < NumPoints; i++)
             {
@@ -895,53 +895,53 @@ void USFRadarPulseService::InspectHologram(AFGHologram* Hologram, const FString&
                 FVector WorldLocation = SplineComp->GetLocationAtSplinePoint(i, ESplineCoordinateSpace::World);
                 FVector ArriveTangent = SplineComp->GetArriveTangentAtSplinePoint(i, ESplineCoordinateSpace::Local);
                 FVector LeaveTangent = SplineComp->GetLeaveTangentAtSplinePoint(i, ESplineCoordinateSpace::Local);
-                
-                UE_LOG(LogSmartFoundations, Display, TEXT("║   Point[%d] Local=%s World=%s"),
+
+                UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("║   Point[%d] Local=%s World=%s"),
                     i, *PointLocation.ToString(), *WorldLocation.ToString());
-                UE_LOG(LogSmartFoundations, Display, TEXT("║            ArriveTangent=%s LeaveTangent=%s"),
+                UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("║            ArriveTangent=%s LeaveTangent=%s"),
                     *ArriveTangent.ToString(), *LeaveTangent.ToString());
             }
         }
         else
         {
-            UE_LOG(LogSmartFoundations, Display, TEXT("║ SplineComponent: NULL (not found via FindComponentByClass)"));
+            UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("║ SplineComponent: NULL (not found via FindComponentByClass)"));
         }
-        
+
         // Check for belt hologram specific data
         if (AFGConveyorBeltHologram* BeltHologram = Cast<AFGConveyorBeltHologram>(SplineHologram))
         {
-            UE_LOG(LogSmartFoundations, Display, TEXT("╠═══════════════════════════════════════════════════════════════════════════════"));
-            UE_LOG(LogSmartFoundations, Display, TEXT("║ ═══ BELT HOLOGRAM SPECIFIC ═══"));
-            
-            UE_LOG(LogSmartFoundations, Display, TEXT("║ BuildClass: %s"),
+            UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("╠═══════════════════════════════════════════════════════════════════════════════"));
+            UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("║ ═══ BELT HOLOGRAM SPECIFIC ═══"));
+
+            UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("║ BuildClass: %s"),
                 BeltHologram->GetBuildClass() ? *BeltHologram->GetBuildClass()->GetName() : TEXT("NULL"));
-            UE_LOG(LogSmartFoundations, Display, TEXT("║ BuildClassPath: %s"),
+            UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("║ BuildClassPath: %s"),
                 BeltHologram->GetBuildClass() ? *BeltHologram->GetBuildClass()->GetPathName() : TEXT("NULL"));
-            
+
             // Check for snapped connections
-            UE_LOG(LogSmartFoundations, Display, TEXT("║ IsHologramLocked: %d"), BeltHologram->IsHologramLocked() ? 1 : 0);
+            UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("║ IsHologramLocked: %d"), BeltHologram->IsHologramLocked() ? 1 : 0);
         }
-        
+
         // Check for pipeline hologram specific data
         if (AFGPipelineHologram* PipeHologram = Cast<AFGPipelineHologram>(SplineHologram))
         {
-            UE_LOG(LogSmartFoundations, Display, TEXT("╠═══════════════════════════════════════════════════════════════════════════════"));
-            UE_LOG(LogSmartFoundations, Display, TEXT("║ ═══ PIPE HOLOGRAM SPECIFIC ═══"));
-            
-            UE_LOG(LogSmartFoundations, Display, TEXT("║ BuildClass: %s"),
+            UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("╠═══════════════════════════════════════════════════════════════════════════════"));
+            UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("║ ═══ PIPE HOLOGRAM SPECIFIC ═══"));
+
+            UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("║ BuildClass: %s"),
                 PipeHologram->GetBuildClass() ? *PipeHologram->GetBuildClass()->GetName() : TEXT("NULL"));
-            UE_LOG(LogSmartFoundations, Display, TEXT("║ BuildClassPath: %s"),
+            UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("║ BuildClassPath: %s"),
                 PipeHologram->GetBuildClass() ? *PipeHologram->GetBuildClass()->GetPathName() : TEXT("NULL"));
-            UE_LOG(LogSmartFoundations, Display, TEXT("║ IsHologramLocked: %d"), PipeHologram->IsHologramLocked() ? 1 : 0);
+            UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("║ IsHologramLocked: %d"), PipeHologram->IsHologramLocked() ? 1 : 0);
         }
-        
+
         // CRITICAL: Log SplineMeshComponents and their meshes - this is what we need for EXTEND
         TArray<USplineMeshComponent*> SplineMeshes;
         Hologram->GetComponents<USplineMeshComponent>(SplineMeshes);
         if (SplineMeshes.Num() > 0)
         {
-            UE_LOG(LogSmartFoundations, Display, TEXT("╠═══════════════════════════════════════════════════════════════════════════════"));
-            UE_LOG(LogSmartFoundations, Display, TEXT("║ ═══ SPLINE MESH COMPONENTS (%d) ═══"), SplineMeshes.Num());
+            UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("╠═══════════════════════════════════════════════════════════════════════════════"));
+            UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("║ ═══ SPLINE MESH COMPONENTS (%d) ═══"), SplineMeshes.Num());
             for (int32 i = 0; i < SplineMeshes.Num(); i++)
             {
                 USplineMeshComponent* MeshComp = SplineMeshes[i];
@@ -950,99 +950,99 @@ void USFRadarPulseService::InspectHologram(AFGHologram* Hologram, const FString&
                     UStaticMesh* Mesh = MeshComp->GetStaticMesh();
                     FString MeshPath = Mesh ? Mesh->GetPathName() : TEXT("NULL");
                     FString MeshName = Mesh ? Mesh->GetName() : TEXT("NULL");
-                    
-                    UE_LOG(LogSmartFoundations, Display, TEXT("║   [%d] Visible=%d Mesh=%s"), 
+
+                    UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("║   [%d] Visible=%d Mesh=%s"),
                         i, MeshComp->IsVisible() ? 1 : 0, *MeshName);
-                    UE_LOG(LogSmartFoundations, Display, TEXT("║       MeshPath: %s"), *MeshPath);
-                    
+                    UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("║       MeshPath: %s"), *MeshPath);
+
                     // Log material info with full paths and material instance details
                     int32 NumMaterials = MeshComp->GetNumMaterials();
                     for (int32 MatIdx = 0; MatIdx < NumMaterials; MatIdx++)
                     {
                         UMaterialInterface* Mat = MeshComp->GetMaterial(MatIdx);
-                        UE_LOG(LogSmartFoundations, Display, TEXT("║       Material[%d]: %s"), 
+                        UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("║       Material[%d]: %s"),
                             MatIdx, Mat ? *Mat->GetName() : TEXT("NULL"));
                         if (Mat)
                         {
-                            UE_LOG(LogSmartFoundations, Display, TEXT("║           Path: %s"), *Mat->GetPathName());
-                            UE_LOG(LogSmartFoundations, Display, TEXT("║           Class: %s"), *Mat->GetClass()->GetName());
-                            
+                            UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("║           Path: %s"), *Mat->GetPathName());
+                            UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("║           Class: %s"), *Mat->GetClass()->GetName());
+
                             // Check if it's a material instance (dynamic or constant)
                             if (UMaterialInstanceDynamic* DynMat = Cast<UMaterialInstanceDynamic>(Mat))
                             {
-                                UE_LOG(LogSmartFoundations, Display, TEXT("║           IsDynamic: YES"));
+                                UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("║           IsDynamic: YES"));
                                 if (DynMat->Parent)
                                 {
-                                    UE_LOG(LogSmartFoundations, Display, TEXT("║           Parent: %s"), *DynMat->Parent->GetPathName());
+                                    UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("║           Parent: %s"), *DynMat->Parent->GetPathName());
                                 }
                             }
                             else if (UMaterialInstanceConstant* ConstMat = Cast<UMaterialInstanceConstant>(Mat))
                             {
-                                UE_LOG(LogSmartFoundations, Display, TEXT("║           IsConstant: YES"));
+                                UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("║           IsConstant: YES"));
                                 if (ConstMat->Parent)
                                 {
-                                    UE_LOG(LogSmartFoundations, Display, TEXT("║           Parent: %s"), *ConstMat->Parent->GetPathName());
+                                    UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("║           Parent: %s"), *ConstMat->Parent->GetPathName());
                                 }
                             }
-                            
+
                             // Get base material for animation info
                             UMaterial* BaseMat = Mat->GetMaterial();
                             if (BaseMat)
                             {
-                                UE_LOG(LogSmartFoundations, Display, TEXT("║           BaseMaterial: %s"), *BaseMat->GetPathName());
+                                UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("║           BaseMaterial: %s"), *BaseMat->GetPathName());
                             }
                         }
                     }
-                    
+
                     // Log forward axis (important for belt direction)
                     ESplineMeshAxis::Type ForwardAxis = MeshComp->GetForwardAxis();
-                    UE_LOG(LogSmartFoundations, Display, TEXT("║       ForwardAxis: %d (0=X, 1=Y, 2=Z)"), (int32)ForwardAxis);
-                    
+                    UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("║       ForwardAxis: %d (0=X, 1=Y, 2=Z)"), (int32)ForwardAxis);
+
                     // Log spline mesh geometry - use individual getters
                     FVector StartPos = MeshComp->GetStartPosition();
                     FVector EndPos = MeshComp->GetEndPosition();
                     FVector StartTangent = MeshComp->GetStartTangent();
                     FVector EndTangent = MeshComp->GetEndTangent();
-                    UE_LOG(LogSmartFoundations, Display, TEXT("║       Start=%s End=%s"), 
+                    UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("║       Start=%s End=%s"),
                         *StartPos.ToString(), *EndPos.ToString());
-                    UE_LOG(LogSmartFoundations, Display, TEXT("║       StartTangent=%s EndTangent=%s"), 
+                    UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("║       StartTangent=%s EndTangent=%s"),
                         *StartTangent.ToString(), *EndTangent.ToString());
-                    
+
                     // Log render settings (custom depth stencil for hologram effect)
-                    UE_LOG(LogSmartFoundations, Display, TEXT("║       RenderCustomDepth=%d StencilValue=%d StencilWriteMask=%d"),
+                    UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("║       RenderCustomDepth=%d StencilValue=%d StencilWriteMask=%d"),
                         MeshComp->bRenderCustomDepth ? 1 : 0,
                         MeshComp->CustomDepthStencilValue,
                         (int32)MeshComp->CustomDepthStencilWriteMask);
-                    UE_LOG(LogSmartFoundations, Display, TEXT("║       HiddenInGame=%d CastShadow=%d"),
+                    UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("║       HiddenInGame=%d CastShadow=%d"),
                         MeshComp->bHiddenInGame ? 1 : 0,
                         MeshComp->CastShadow ? 1 : 0);
                 }
             }
         }
     }
-    
+
     // Check for lift hologram specific data
     if (AFGConveyorLiftHologram* LiftHologram = Cast<AFGConveyorLiftHologram>(Hologram))
     {
-        UE_LOG(LogSmartFoundations, Display, TEXT("╠═══════════════════════════════════════════════════════════════════════════════"));
-        UE_LOG(LogSmartFoundations, Display, TEXT("║ ═══ LIFT HOLOGRAM SPECIFIC ═══"));
-        
-        UE_LOG(LogSmartFoundations, Display, TEXT("║ BuildClass: %s"),
+        UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("╠═══════════════════════════════════════════════════════════════════════════════"));
+        UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("║ ═══ LIFT HOLOGRAM SPECIFIC ═══"));
+
+        UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("║ BuildClass: %s"),
             LiftHologram->GetBuildClass() ? *LiftHologram->GetBuildClass()->GetName() : TEXT("NULL"));
-        UE_LOG(LogSmartFoundations, Display, TEXT("║ BuildClassPath: %s"),
+        UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("║ BuildClassPath: %s"),
             LiftHologram->GetBuildClass() ? *LiftHologram->GetBuildClass()->GetPathName() : TEXT("NULL"));
-        UE_LOG(LogSmartFoundations, Display, TEXT("║ IsHologramLocked: %d"), LiftHologram->IsHologramLocked() ? 1 : 0);
-        
+        UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("║ IsHologramLocked: %d"), LiftHologram->IsHologramLocked() ? 1 : 0);
+
         // Note: Lift height and other properties are protected, but we can inspect components
     }
-    
+
     // ALL STATIC MESH COMPONENTS - captures lift meshes and any other static meshes
     TArray<UStaticMeshComponent*> StaticMeshes;
     Hologram->GetComponents<UStaticMeshComponent>(StaticMeshes);
     if (StaticMeshes.Num() > 0)
     {
-        UE_LOG(LogSmartFoundations, Display, TEXT("╠═══════════════════════════════════════════════════════════════════════════════"));
-        UE_LOG(LogSmartFoundations, Display, TEXT("║ ═══ ALL STATIC MESH COMPONENTS (%d) ═══"), StaticMeshes.Num());
+        UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("╠═══════════════════════════════════════════════════════════════════════════════"));
+        UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("║ ═══ ALL STATIC MESH COMPONENTS (%d) ═══"), StaticMeshes.Num());
         for (int32 i = 0; i < StaticMeshes.Num(); i++)
         {
             UStaticMeshComponent* MeshComp = StaticMeshes[i];
@@ -1053,111 +1053,111 @@ void USFRadarPulseService::InspectHologram(AFGHologram* Hologram, const FString&
                 FString MeshName = Mesh ? Mesh->GetName() : TEXT("NULL");
                 FString CompName = MeshComp->GetName();
                 FString CompClass = MeshComp->GetClass()->GetName();
-                
-                UE_LOG(LogSmartFoundations, Display, TEXT("║   [%d] %s (%s)"), i, *CompName, *CompClass);
-                UE_LOG(LogSmartFoundations, Display, TEXT("║       Visible=%d Mesh=%s"), 
+
+                UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("║   [%d] %s (%s)"), i, *CompName, *CompClass);
+                UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("║       Visible=%d Mesh=%s"),
                     MeshComp->IsVisible() ? 1 : 0, *MeshName);
-                UE_LOG(LogSmartFoundations, Display, TEXT("║       MeshPath: %s"), *MeshPath);
-                UE_LOG(LogSmartFoundations, Display, TEXT("║       RelativeLocation: %s"), *MeshComp->GetRelativeLocation().ToString());
-                UE_LOG(LogSmartFoundations, Display, TEXT("║       WorldLocation: %s"), *MeshComp->GetComponentLocation().ToString());
-                
+                UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("║       MeshPath: %s"), *MeshPath);
+                UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("║       RelativeLocation: %s"), *MeshComp->GetRelativeLocation().ToString());
+                UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("║       WorldLocation: %s"), *MeshComp->GetComponentLocation().ToString());
+
                 // Log materials with paths
                 int32 NumMaterials = MeshComp->GetNumMaterials();
                 for (int32 MatIdx = 0; MatIdx < NumMaterials && MatIdx < 3; MatIdx++)
                 {
                     UMaterialInterface* Mat = MeshComp->GetMaterial(MatIdx);
-                    UE_LOG(LogSmartFoundations, Display, TEXT("║       Material[%d]: %s"), 
+                    UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("║       Material[%d]: %s"),
                         MatIdx, Mat ? *Mat->GetName() : TEXT("NULL"));
                     if (Mat)
                     {
-                        UE_LOG(LogSmartFoundations, Display, TEXT("║           Path: %s"), *Mat->GetPathName());
+                        UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("║           Path: %s"), *Mat->GetPathName());
                     }
                 }
                 if (NumMaterials > 3)
                 {
-                    UE_LOG(LogSmartFoundations, Display, TEXT("║       ... and %d more materials"), NumMaterials - 3);
+                    UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("║       ... and %d more materials"), NumMaterials - 3);
                 }
-                
+
                 // Log render settings (custom depth stencil for hologram effect)
-                UE_LOG(LogSmartFoundations, Display, TEXT("║       RenderCustomDepth=%d StencilValue=%d StencilWriteMask=%d"),
+                UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("║       RenderCustomDepth=%d StencilValue=%d StencilWriteMask=%d"),
                     MeshComp->bRenderCustomDepth ? 1 : 0,
                     MeshComp->CustomDepthStencilValue,
                     (int32)MeshComp->CustomDepthStencilWriteMask);
-                UE_LOG(LogSmartFoundations, Display, TEXT("║       HiddenInGame=%d CastShadow=%d"),
+                UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("║       HiddenInGame=%d CastShadow=%d"),
                     MeshComp->bHiddenInGame ? 1 : 0,
                     MeshComp->CastShadow ? 1 : 0);
             }
         }
     }
-    
+
     // ALL SCENE COMPONENTS - for understanding hierarchy
     TArray<USceneComponent*> AllSceneComps;
     Hologram->GetComponents<USceneComponent>(AllSceneComps);
-    UE_LOG(LogSmartFoundations, Display, TEXT("╠═══════════════════════════════════════════════════════════════════════════════"));
-    UE_LOG(LogSmartFoundations, Display, TEXT("║ ═══ COMPONENT HIERARCHY (%d scene components) ═══"), AllSceneComps.Num());
+    UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("╠═══════════════════════════════════════════════════════════════════════════════"));
+    UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("║ ═══ COMPONENT HIERARCHY (%d scene components) ═══"), AllSceneComps.Num());
     for (USceneComponent* Comp : AllSceneComps)
     {
         if (Comp)
         {
             FString ParentName = Comp->GetAttachParent() ? Comp->GetAttachParent()->GetName() : TEXT("ROOT");
-            UE_LOG(LogSmartFoundations, Display, TEXT("║   %s (%s) -> Parent: %s"),
+            UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("║   %s (%s) -> Parent: %s"),
                 *Comp->GetName(), *Comp->GetClass()->GetName(), *ParentName);
         }
     }
-    
+
     // Hologram children (mChildren array)
     const TArray<AFGHologram*>& HologramChildren = Hologram->GetHologramChildren();
     if (HologramChildren.Num() > 0)
     {
-        UE_LOG(LogSmartFoundations, Display, TEXT("╠═══════════════════════════════════════════════════════════════════════════════"));
-        UE_LOG(LogSmartFoundations, Display, TEXT("║ ═══ HOLOGRAM CHILDREN (mChildren: %d) ═══"), HologramChildren.Num());
+        UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("╠═══════════════════════════════════════════════════════════════════════════════"));
+        UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("║ ═══ HOLOGRAM CHILDREN (mChildren: %d) ═══"), HologramChildren.Num());
         for (int32 i = 0; i < HologramChildren.Num(); i++)
         {
             AFGHologram* Child = HologramChildren[i];
             if (IsValid(Child))
             {
-                UE_LOG(LogSmartFoundations, Display, TEXT("║   [%d] %s (%s) at %s"),
+                UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("║   [%d] %s (%s) at %s"),
                     i, *Child->GetName(), *Child->GetClass()->GetName(), *Child->GetActorLocation().ToString());
-                UE_LOG(LogSmartFoundations, Display, TEXT("║       MaterialState: %d | Hidden: %d"),
+                UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("║       MaterialState: %d | Hidden: %d"),
                     (int32)Child->GetHologramMaterialState(), Child->IsHidden() ? 1 : 0);
             }
             else
             {
-                UE_LOG(LogSmartFoundations, Display, TEXT("║   [%d] INVALID/NULL"), i);
+                UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("║   [%d] INVALID/NULL"), i);
             }
         }
     }
-    
+
     // Attached actors (different from mChildren)
     TArray<AActor*> AttachedActors;
     Hologram->GetAttachedActors(AttachedActors);
     if (AttachedActors.Num() > 0)
     {
-        UE_LOG(LogSmartFoundations, Display, TEXT("╠═══════════════════════════════════════════════════════════════════════════════"));
-        UE_LOG(LogSmartFoundations, Display, TEXT("║ ═══ ATTACHED ACTORS (%d) ═══"), AttachedActors.Num());
+        UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("╠═══════════════════════════════════════════════════════════════════════════════"));
+        UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("║ ═══ ATTACHED ACTORS (%d) ═══"), AttachedActors.Num());
         for (AActor* Child : AttachedActors)
         {
             if (IsValid(Child))
             {
-                UE_LOG(LogSmartFoundations, Display, TEXT("║   %s (%s) at %s"),
+                UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("║   %s (%s) at %s"),
                     *Child->GetName(), *Child->GetClass()->GetName(), *Child->GetActorLocation().ToString());
             }
         }
     }
-    
+
     // Actor tags
     if (Hologram->Tags.Num() > 0)
     {
-        UE_LOG(LogSmartFoundations, Display, TEXT("╠═══════════════════════════════════════════════════════════════════════════════"));
-        UE_LOG(LogSmartFoundations, Display, TEXT("║ ═══ ACTOR TAGS (%d) ═══"), Hologram->Tags.Num());
+        UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("╠═══════════════════════════════════════════════════════════════════════════════"));
+        UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("║ ═══ ACTOR TAGS (%d) ═══"), Hologram->Tags.Num());
         for (const FName& Tag : Hologram->Tags)
         {
-            UE_LOG(LogSmartFoundations, Display, TEXT("║   %s"), *Tag.ToString());
+            UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("║   %s"), *Tag.ToString());
         }
     }
-    
-    UE_LOG(LogSmartFoundations, Display, TEXT("╚═══════════════════════════════════════════════════════════════════════════════"));
-    UE_LOG(LogSmartFoundations, Display, TEXT(""));
+
+    UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("╚═══════════════════════════════════════════════════════════════════════════════"));
+    UE_LOG(LogSmartFoundations, VeryVerbose, TEXT(""));
 }
 
 void USFRadarPulseService::InspectAllHologramsInRadius(float Radius)
@@ -1169,7 +1169,7 @@ void USFRadarPulseService::InspectAllHologramsInRadius(float Radius)
     }
 
     UWorld* World = Subsystem->GetWorld();
-    
+
     // Get player location
     APlayerController* PC = World->GetFirstPlayerController();
     if (!PC || !PC->GetPawn())
@@ -1179,11 +1179,11 @@ void USFRadarPulseService::InspectAllHologramsInRadius(float Radius)
     }
 
     FVector PlayerLocation = PC->GetPawn()->GetActorLocation();
-    
+
     // Get all holograms in range
     TArray<AActor*> AllHolograms;
     UGameplayStatics::GetAllActorsOfClass(World, AFGHologram::StaticClass(), AllHolograms);
-    
+
     // Filter by distance
     TArray<AFGHologram*> NearbyHolograms;
     for (AActor* Actor : AllHolograms)
@@ -1201,15 +1201,15 @@ void USFRadarPulseService::InspectAllHologramsInRadius(float Radius)
         }
     }
 
-    UE_LOG(LogSmartFoundations, Display, TEXT(""));
-    UE_LOG(LogSmartFoundations, Display, TEXT("╔═══════════════════════════════════════════════════════════════════════════════"));
-    UE_LOG(LogSmartFoundations, Display, TEXT("║ 📡 HOLOGRAM RADIUS SCAN - Found %d holograms within %.0fm"), NearbyHolograms.Num(), Radius / 100.0f);
-    UE_LOG(LogSmartFoundations, Display, TEXT("║ Player Location: %s"), *PlayerLocation.ToString());
-    UE_LOG(LogSmartFoundations, Display, TEXT("╚═══════════════════════════════════════════════════════════════════════════════"));
+    UE_LOG(LogSmartFoundations, VeryVerbose, TEXT(""));
+    UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("╔═══════════════════════════════════════════════════════════════════════════════"));
+    UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("║ 📡 HOLOGRAM RADIUS SCAN - Found %d holograms within %.0fm"), NearbyHolograms.Num(), Radius / 100.0f);
+    UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("║ Player Location: %s"), *PlayerLocation.ToString());
+    UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("╚═══════════════════════════════════════════════════════════════════════════════"));
 
     if (NearbyHolograms.Num() == 0)
     {
-        UE_LOG(LogSmartFoundations, Display, TEXT("  No holograms found in range."));
+        UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("  No holograms found in range."));
         return;
     }
 
@@ -1228,8 +1228,8 @@ void USFRadarPulseService::InspectAllHologramsInRadius(float Radius)
         InspectHologram(Hologram, Label);
     }
 
-    UE_LOG(LogSmartFoundations, Display, TEXT(""));
-    UE_LOG(LogSmartFoundations, Display, TEXT("📡 Hologram scan complete - inspected %d holograms"), NearbyHolograms.Num());
+    UE_LOG(LogSmartFoundations, VeryVerbose, TEXT(""));
+    UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("📡 Hologram scan complete - inspected %d holograms"), NearbyHolograms.Num());
 }
 
 // ==================== LOGGING ====================
@@ -1243,17 +1243,17 @@ void USFRadarPulseService::LogSnapshotFiltered(const FSFRadarPulseSnapshot& Snap
 {
     LogSummaryHeader(FString::Printf(TEXT("RADAR PULSE SNAPSHOT: %s"), *Snapshot.SnapshotLabel));
 
-    UE_LOG(LogSmartFoundations, Display, TEXT("║ Capture Time: %s"), *Snapshot.CaptureTime.ToString());
-    UE_LOG(LogSmartFoundations, Display, TEXT("║ Origin: X=%.0f Y=%.0f Z=%.0f"),
+    UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("║ Capture Time: %s"), *Snapshot.CaptureTime.ToString());
+    UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("║ Origin: X=%.0f Y=%.0f Z=%.0f"),
         Snapshot.CaptureOrigin.X, Snapshot.CaptureOrigin.Y, Snapshot.CaptureOrigin.Z);
-    UE_LOG(LogSmartFoundations, Display, TEXT("║ Radius: %.0fm (%.0f cm)"),
+    UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("║ Radius: %.0fm (%.0f cm)"),
         Snapshot.CaptureRadius / 100.0f, Snapshot.CaptureRadius);
-    UE_LOG(LogSmartFoundations, Display, TEXT("║ Total Objects: %d"), Snapshot.TotalObjects);
-    UE_LOG(LogSmartFoundations, Display, TEXT("╠═══════════════════════════════════════════════════════════════════╣"));
+    UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("║ Total Objects: %d"), Snapshot.TotalObjects);
+    UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("╠═══════════════════════════════════════════════════════════════════╣"));
 
     LogCategorySummary(Snapshot.CountByCategory, Snapshot.ExtendSourceCount);
 
-    UE_LOG(LogSmartFoundations, Display, TEXT("╚═══════════════════════════════════════════════════════════════════╝"));
+    UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("╚═══════════════════════════════════════════════════════════════════╝"));
 
     if (bVerbose)
     {
@@ -1279,24 +1279,24 @@ void USFRadarPulseService::LogSnapshotFiltered(const FSFRadarPulseSnapshot& Snap
             EnumerateCount = Snapshot.Objects.Num();
         }
 
-        UE_LOG(LogSmartFoundations, Display, TEXT(""));
-        UE_LOG(LogSmartFoundations, Display, TEXT("╔═══════════════════════════════════════════════════════════════════╗"));
+        UE_LOG(LogSmartFoundations, VeryVerbose, TEXT(""));
+        UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("╔═══════════════════════════════════════════════════════════════════╗"));
         if (bHasFilter)
         {
-            UE_LOG(LogSmartFoundations, Display, TEXT("║       ENUMERATION: FILTERED OBJECTS (%d of %d total)          ║"), 
+            UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("║       ENUMERATION: FILTERED OBJECTS (%d of %d total)          ║"),
                 EnumerateCount, Snapshot.TotalObjects);
         }
         else
         {
-            UE_LOG(LogSmartFoundations, Display, TEXT("║            FULL ENUMERATION: ALL OBJECTS (%d total)            ║"), Snapshot.TotalObjects);
+            UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("║            FULL ENUMERATION: ALL OBJECTS (%d total)            ║"), Snapshot.TotalObjects);
         }
-        UE_LOG(LogSmartFoundations, Display, TEXT("╚═══════════════════════════════════════════════════════════════════╝"));
+        UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("╚═══════════════════════════════════════════════════════════════════╝"));
 
         int32 DisplayIndex = 0;
         for (int32 i = 0; i < Snapshot.Objects.Num(); ++i)
         {
             const FSFPulseCapturedObject& Obj = Snapshot.Objects[i];
-            
+
             // Skip if not in filter (when filter is active)
             if (bHasFilter && !FilterSet.Contains(Obj.Category))
             {
@@ -1317,11 +1317,11 @@ void USFRadarPulseService::LogDiffFiltered(const FSFSnapshotDiff& Diff, bool bVe
 {
     LogSummaryHeader(TEXT("RADAR PULSE DIFF"));
 
-    UE_LOG(LogSmartFoundations, Display, TEXT("║ Before: %s (%d objects)"), *Diff.BeforeLabel, Diff.BeforeTotal);
-    UE_LOG(LogSmartFoundations, Display, TEXT("║ After:  %s (%d objects)"), *Diff.AfterLabel, Diff.AfterTotal);
-    UE_LOG(LogSmartFoundations, Display, TEXT("╠═══════════════════════════════════════════════════════════════════╣"));
-    UE_LOG(LogSmartFoundations, Display, TEXT("║ Category        │ Before │ After  │ New    │ Removed │ Modified  ║"));
-    UE_LOG(LogSmartFoundations, Display, TEXT("╟─────────────────┼────────┼────────┼────────┼─────────┼───────────╢"));
+    UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("║ Before: %s (%d objects)"), *Diff.BeforeLabel, Diff.BeforeTotal);
+    UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("║ After:  %s (%d objects)"), *Diff.AfterLabel, Diff.AfterTotal);
+    UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("╠═══════════════════════════════════════════════════════════════════╣"));
+    UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("║ Category        │ Before │ After  │ New    │ Removed │ Modified  ║"));
+    UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("╟─────────────────┼────────┼────────┼────────┼─────────┼───────────╢"));
 
     // Collect all categories
     TSet<FString> AllCategories;
@@ -1335,14 +1335,14 @@ void USFRadarPulseService::LogDiffFiltered(const FSFSnapshotDiff& Diff, bool bVe
         int32 RemovedCount = Diff.RemovedByCategory.Contains(Category) ? Diff.RemovedByCategory[Category] : 0;
         int32 ModifiedCount = Diff.ModifiedByCategory.Contains(Category) ? Diff.ModifiedByCategory[Category] : 0;
 
-        UE_LOG(LogSmartFoundations, Display, TEXT("║ %-15s │ %6s │ %6s │ %6d │ %7d │ %9d ║"),
+        UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("║ %-15s │ %6s │ %6s │ %6d │ %7d │ %9d ║"),
             *Category, TEXT("-"), TEXT("-"), NewCount, RemovedCount, ModifiedCount);
     }
 
-    UE_LOG(LogSmartFoundations, Display, TEXT("╠═══════════════════════════════════════════════════════════════════╣"));
-    UE_LOG(LogSmartFoundations, Display, TEXT("║ TOTAL           │ %6d │ %6d │ %6d │ %7d │ %9d ║"),
+    UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("╠═══════════════════════════════════════════════════════════════════╣"));
+    UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("║ TOTAL           │ %6d │ %6d │ %6d │ %7d │ %9d ║"),
         Diff.BeforeTotal, Diff.AfterTotal, Diff.NewObjects.Num(), Diff.RemovedObjects.Num(), Diff.ModifiedObjects.Num());
-    UE_LOG(LogSmartFoundations, Display, TEXT("╚═══════════════════════════════════════════════════════════════════╝"));
+    UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("╚═══════════════════════════════════════════════════════════════════╝"));
 
     // Build filter set for enumeration (empty = no filtering)
     TSet<FString> FilterSet;
@@ -1366,17 +1366,17 @@ void USFRadarPulseService::LogDiffFiltered(const FSFSnapshotDiff& Diff, bool bVe
 
         if (FilteredCount > 0)
         {
-            UE_LOG(LogSmartFoundations, Display, TEXT(""));
-            UE_LOG(LogSmartFoundations, Display, TEXT("╔═══════════════════════════════════════════════════════════════════╗"));
+            UE_LOG(LogSmartFoundations, VeryVerbose, TEXT(""));
+            UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("╔═══════════════════════════════════════════════════════════════════╗"));
             if (bHasFilter)
             {
-                UE_LOG(LogSmartFoundations, Display, TEXT("║       ENUMERATION: NEW OBJECTS (%d of %d filtered)           ║"), FilteredCount, Diff.NewObjects.Num());
+                UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("║       ENUMERATION: NEW OBJECTS (%d of %d filtered)           ║"), FilteredCount, Diff.NewObjects.Num());
             }
             else
             {
-                UE_LOG(LogSmartFoundations, Display, TEXT("║            FULL ENUMERATION: NEW OBJECTS (%d total)            ║"), Diff.NewObjects.Num());
+                UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("║            FULL ENUMERATION: NEW OBJECTS (%d total)            ║"), Diff.NewObjects.Num());
             }
-            UE_LOG(LogSmartFoundations, Display, TEXT("╚═══════════════════════════════════════════════════════════════════╝"));
+            UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("╚═══════════════════════════════════════════════════════════════════╝"));
 
             int32 DisplayIndex = 0;
             for (int32 i = 0; i < Diff.NewObjects.Num(); ++i)
@@ -1397,17 +1397,17 @@ void USFRadarPulseService::LogDiffFiltered(const FSFSnapshotDiff& Diff, bool bVe
 
         if (FilteredCount > 0)
         {
-            UE_LOG(LogSmartFoundations, Display, TEXT(""));
-            UE_LOG(LogSmartFoundations, Display, TEXT("╔═══════════════════════════════════════════════════════════════════╗"));
+            UE_LOG(LogSmartFoundations, VeryVerbose, TEXT(""));
+            UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("╔═══════════════════════════════════════════════════════════════════╗"));
             if (bHasFilter)
             {
-                UE_LOG(LogSmartFoundations, Display, TEXT("║     ENUMERATION: REMOVED OBJECTS (%d of %d filtered)          ║"), FilteredCount, Diff.RemovedObjects.Num());
+                UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("║     ENUMERATION: REMOVED OBJECTS (%d of %d filtered)          ║"), FilteredCount, Diff.RemovedObjects.Num());
             }
             else
             {
-                UE_LOG(LogSmartFoundations, Display, TEXT("║          FULL ENUMERATION: REMOVED OBJECTS (%d total)          ║"), Diff.RemovedObjects.Num());
+                UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("║          FULL ENUMERATION: REMOVED OBJECTS (%d total)          ║"), Diff.RemovedObjects.Num());
             }
-            UE_LOG(LogSmartFoundations, Display, TEXT("╚═══════════════════════════════════════════════════════════════════╝"));
+            UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("╚═══════════════════════════════════════════════════════════════════╝"));
 
             int32 DisplayIndex = 0;
             for (int32 i = 0; i < Diff.RemovedObjects.Num(); ++i)
@@ -1422,21 +1422,21 @@ void USFRadarPulseService::LogDiffFiltered(const FSFSnapshotDiff& Diff, bool bVe
 
     if (bVerbose && Diff.ModifiedObjects.Num() > 0)
     {
-        UE_LOG(LogSmartFoundations, Display, TEXT(""));
-        UE_LOG(LogSmartFoundations, Display, TEXT("╔═══════════════════════════════════════════════════════════════════╗"));
-        UE_LOG(LogSmartFoundations, Display, TEXT("║         FULL ENUMERATION: MODIFIED OBJECTS (%d total)          ║"), Diff.ModifiedObjects.Num());
-        UE_LOG(LogSmartFoundations, Display, TEXT("╚═══════════════════════════════════════════════════════════════════╝"));
+        UE_LOG(LogSmartFoundations, VeryVerbose, TEXT(""));
+        UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("╔═══════════════════════════════════════════════════════════════════╗"));
+        UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("║         FULL ENUMERATION: MODIFIED OBJECTS (%d total)          ║"), Diff.ModifiedObjects.Num());
+        UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("╚═══════════════════════════════════════════════════════════════════╝"));
 
         for (int32 i = 0; i < Diff.ModifiedObjects.Num(); ++i)
         {
             const FSFObjectModification& Mod = Diff.ModifiedObjects[i];
             // Note: Modified objects don't store Category, so we can't filter them
-            UE_LOG(LogSmartFoundations, Display, TEXT(""));
-            UE_LOG(LogSmartFoundations, Display, TEXT("┌─────────────────────────────────────────────────────────────────────"));
-            UE_LOG(LogSmartFoundations, Display, TEXT("│ [%d] %s (MODIFIED)"), i, *Mod.ActorName);
-            UE_LOG(LogSmartFoundations, Display, TEXT("├─────────────────────────────────────────────────────────────────────"));
-            UE_LOG(LogSmartFoundations, Display, TEXT("│ Changed: %s"), *FString::Join(Mod.ChangedProperties, TEXT(", ")));
-            UE_LOG(LogSmartFoundations, Display, TEXT("└─────────────────────────────────────────────────────────────────────"));
+            UE_LOG(LogSmartFoundations, VeryVerbose, TEXT(""));
+            UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("┌─────────────────────────────────────────────────────────────────────"));
+            UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("│ [%d] %s (MODIFIED)"), i, *Mod.ActorName);
+            UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("├─────────────────────────────────────────────────────────────────────"));
+            UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("│ Changed: %s"), *FString::Join(Mod.ChangedProperties, TEXT(", ")));
+            UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("└─────────────────────────────────────────────────────────────────────"));
         }
     }
 }
@@ -1464,7 +1464,7 @@ void USFRadarPulseService::LogFlaggedObjects(const FSFRadarPulseSnapshot& Snapsh
         }
     }
 
-    UE_LOG(LogSmartFoundations, Display, TEXT(""));
+    UE_LOG(LogSmartFoundations, VeryVerbose, TEXT(""));
     LogSummaryHeader(FString::Printf(TEXT("FLAGGED OBJECTS: %s (%d)"), *FlagName, FlaggedObjects.Num()));
 
     // Group by role if EXTEND
@@ -1479,16 +1479,16 @@ void USFRadarPulseService::LogFlaggedObjects(const FSFRadarPulseSnapshot& Snapsh
 
         for (const auto& Pair : ByRole)
         {
-            UE_LOG(LogSmartFoundations, Display, TEXT("║   %-20s: %3d"), *Pair.Key, Pair.Value);
+            UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("║   %-20s: %3d"), *Pair.Key, Pair.Value);
         }
     }
 
-    UE_LOG(LogSmartFoundations, Display, TEXT("╚═══════════════════════════════════════════════════════════════════╝"));
+    UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("╚═══════════════════════════════════════════════════════════════════╝"));
 
     if (bVerbose)
     {
-        UE_LOG(LogSmartFoundations, Display, TEXT(""));
-        UE_LOG(LogSmartFoundations, Display, TEXT("📊 %s DETAILS:"), *FlagName.ToUpper());
+        UE_LOG(LogSmartFoundations, VeryVerbose, TEXT(""));
+        UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("📊 %s DETAILS:"), *FlagName.ToUpper());
 
         for (int32 i = 0; i < FlaggedObjects.Num(); ++i)
         {
@@ -1499,46 +1499,46 @@ void USFRadarPulseService::LogFlaggedObjects(const FSFRadarPulseSnapshot& Snapsh
 
 void USFRadarPulseService::LogObjectDetails(const FSFPulseCapturedObject& Object, int32 Index)
 {
-    UE_LOG(LogSmartFoundations, Display, TEXT(""));
-    UE_LOG(LogSmartFoundations, Display, TEXT("┌─────────────────────────────────────────────────────────────────────"));
+    UE_LOG(LogSmartFoundations, VeryVerbose, TEXT(""));
+    UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("┌─────────────────────────────────────────────────────────────────────"));
 
     // Header with EXTEND badge if applicable
     if (Object.bIsExtendSource)
     {
-        UE_LOG(LogSmartFoundations, Display, TEXT("│ [%d] %s ★ [%s]"), Index, *Object.ActorName, *Object.ExtendRole);
+        UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("│ [%d] %s ★ [%s]"), Index, *Object.ActorName, *Object.ExtendRole);
     }
     else
     {
-        UE_LOG(LogSmartFoundations, Display, TEXT("│ [%d] %s"), Index, *Object.ActorName);
+        UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("│ [%d] %s"), Index, *Object.ActorName);
     }
 
-    UE_LOG(LogSmartFoundations, Display, TEXT("├─────────────────────────────────────────────────────────────────────"));
-    UE_LOG(LogSmartFoundations, Display, TEXT("│ Category: %s | Class: %s"), *Object.Category, *Object.ClassName);
-    UE_LOG(LogSmartFoundations, Display, TEXT("│ Location: X=%.3f Y=%.3f Z=%.3f"), Object.Location.X, Object.Location.Y, Object.Location.Z);
-    UE_LOG(LogSmartFoundations, Display, TEXT("│ Rotation: P=%.3f Y=%.3f R=%.3f"), Object.Rotation.Pitch, Object.Rotation.Yaw, Object.Rotation.Roll);
-    UE_LOG(LogSmartFoundations, Display, TEXT("│ Scale: X=%.3f Y=%.3f Z=%.3f"), Object.Scale.X, Object.Scale.Y, Object.Scale.Z);
-    UE_LOG(LogSmartFoundations, Display, TEXT("│ Bounds: Min=(%.1f,%.1f,%.1f) Max=(%.1f,%.1f,%.1f)"),
+    UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("├─────────────────────────────────────────────────────────────────────"));
+    UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("│ Category: %s | Class: %s"), *Object.Category, *Object.ClassName);
+    UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("│ Location: X=%.3f Y=%.3f Z=%.3f"), Object.Location.X, Object.Location.Y, Object.Location.Z);
+    UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("│ Rotation: P=%.3f Y=%.3f R=%.3f"), Object.Rotation.Pitch, Object.Rotation.Yaw, Object.Rotation.Roll);
+    UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("│ Scale: X=%.3f Y=%.3f Z=%.3f"), Object.Scale.X, Object.Scale.Y, Object.Scale.Z);
+    UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("│ Bounds: Min=(%.1f,%.1f,%.1f) Max=(%.1f,%.1f,%.1f)"),
         Object.BoundsMin.X, Object.BoundsMin.Y, Object.BoundsMin.Z,
         Object.BoundsMax.X, Object.BoundsMax.Y, Object.BoundsMax.Z);
-    UE_LOG(LogSmartFoundations, Display, TEXT("│ State: Hidden=%d PendingKill=%d BegunPlay=%d"),
+    UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("│ State: Hidden=%d PendingKill=%d BegunPlay=%d"),
         Object.bIsHidden, Object.bIsPendingKill, Object.bHasBegunPlay);
 
     // Factory connections
     if (Object.FactoryConnections.Num() > 0)
     {
-        UE_LOG(LogSmartFoundations, Display, TEXT("│ ═══ FACTORY CONNECTIONS (%d) ═══"), Object.FactoryConnections.Num());
+        UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("│ ═══ FACTORY CONNECTIONS (%d) ═══"), Object.FactoryConnections.Num());
         for (const FSFPulseCapturedConnection& Conn : Object.FactoryConnections)
         {
             if (Conn.bIsConnected)
             {
-                UE_LOG(LogSmartFoundations, Display, TEXT("│   %s [Dir=%d] @ (%.1f,%.1f,%.1f) -> %s.%s"),
+                UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("│   %s [Dir=%d] @ (%.1f,%.1f,%.1f) -> %s.%s"),
                     *Conn.ConnectorName, Conn.ConnectionDirection,
                     Conn.WorldLocation.X, Conn.WorldLocation.Y, Conn.WorldLocation.Z,
                     *Conn.ConnectedToActor, *Conn.ConnectedToConnector);
             }
             else
             {
-                UE_LOG(LogSmartFoundations, Display, TEXT("│   %s [Dir=%d] @ (%.1f,%.1f,%.1f) (not connected)"),
+                UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("│   %s [Dir=%d] @ (%.1f,%.1f,%.1f) (not connected)"),
                     *Conn.ConnectorName, Conn.ConnectionDirection,
                     Conn.WorldLocation.X, Conn.WorldLocation.Y, Conn.WorldLocation.Z);
             }
@@ -1548,19 +1548,19 @@ void USFRadarPulseService::LogObjectDetails(const FSFPulseCapturedObject& Object
     // Pipe connections
     if (Object.PipeConnections.Num() > 0)
     {
-        UE_LOG(LogSmartFoundations, Display, TEXT("│ ═══ PIPE CONNECTIONS (%d) ═══"), Object.PipeConnections.Num());
+        UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("│ ═══ PIPE CONNECTIONS (%d) ═══"), Object.PipeConnections.Num());
         for (const FSFPulseCapturedConnection& Conn : Object.PipeConnections)
         {
             if (Conn.bIsConnected)
             {
-                UE_LOG(LogSmartFoundations, Display, TEXT("│   %s [Type=%d] @ (%.1f,%.1f,%.1f) -> %s.%s"),
+                UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("│   %s [Type=%d] @ (%.1f,%.1f,%.1f) -> %s.%s"),
                     *Conn.ConnectorName, Conn.PipeConnectionType,
                     Conn.WorldLocation.X, Conn.WorldLocation.Y, Conn.WorldLocation.Z,
                     *Conn.ConnectedToActor, *Conn.ConnectedToConnector);
             }
             else
             {
-                UE_LOG(LogSmartFoundations, Display, TEXT("│   %s [Type=%d] @ (%.1f,%.1f,%.1f) (not connected)"),
+                UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("│   %s [Type=%d] @ (%.1f,%.1f,%.1f) (not connected)"),
                     *Conn.ConnectorName, Conn.PipeConnectionType,
                     Conn.WorldLocation.X, Conn.WorldLocation.Y, Conn.WorldLocation.Z);
             }
@@ -1570,12 +1570,12 @@ void USFRadarPulseService::LogObjectDetails(const FSFPulseCapturedObject& Object
     // Belt data
     if (Object.Category == TEXT("Belt") && Object.SplinePoints.Num() > 0)
     {
-        UE_LOG(LogSmartFoundations, Display, TEXT("│ ═══ BELT DATA ═══"));
-        UE_LOG(LogSmartFoundations, Display, TEXT("│ Speed: %.1f | SplineLength: %.1fcm | SplinePoints: %d"),
+        UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("│ ═══ BELT DATA ═══"));
+        UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("│ Speed: %.1f | SplineLength: %.1fcm | SplinePoints: %d"),
             Object.BeltSpeed, Object.SplineLength, Object.SplinePoints.Num());
         for (const FSFPulseCapturedSplinePoint& SP : Object.SplinePoints)
         {
-            UE_LOG(LogSmartFoundations, Display, TEXT("│   [Point %d] Local=(%.1f,%.1f,%.1f) World=(%.1f,%.1f,%.1f)"),
+            UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("│   [Point %d] Local=(%.1f,%.1f,%.1f) World=(%.1f,%.1f,%.1f)"),
                 SP.PointIndex, SP.LocalPosition.X, SP.LocalPosition.Y, SP.LocalPosition.Z,
                 SP.WorldPosition.X, SP.WorldPosition.Y, SP.WorldPosition.Z);
         }
@@ -1584,9 +1584,9 @@ void USFRadarPulseService::LogObjectDetails(const FSFPulseCapturedObject& Object
     // Lift data
     if (Object.Category == TEXT("Lift"))
     {
-        UE_LOG(LogSmartFoundations, Display, TEXT("│ ═══ LIFT DATA ═══"));
-        UE_LOG(LogSmartFoundations, Display, TEXT("│ Height: %.1fcm | Reversed: %d"), Object.LiftHeight, Object.bLiftIsReversed);
-        UE_LOG(LogSmartFoundations, Display, TEXT("│ Bottom: (%.1f,%.1f,%.1f) Top: (%.1f,%.1f,%.1f)"),
+        UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("│ ═══ LIFT DATA ═══"));
+        UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("│ Height: %.1fcm | Reversed: %d"), Object.LiftHeight, Object.bLiftIsReversed);
+        UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("│ Bottom: (%.1f,%.1f,%.1f) Top: (%.1f,%.1f,%.1f)"),
             Object.LiftBottomLocation.X, Object.LiftBottomLocation.Y, Object.LiftBottomLocation.Z,
             Object.LiftTopLocation.X, Object.LiftTopLocation.Y, Object.LiftTopLocation.Z);
     }
@@ -1594,11 +1594,11 @@ void USFRadarPulseService::LogObjectDetails(const FSFPulseCapturedObject& Object
     // Pipe data
     if (Object.Category == TEXT("Pipe") && Object.SplinePoints.Num() > 0)
     {
-        UE_LOG(LogSmartFoundations, Display, TEXT("│ ═══ PIPE DATA ═══"));
-        UE_LOG(LogSmartFoundations, Display, TEXT("│ SplineLength: %.1fcm | SplinePoints: %d"), Object.SplineLength, Object.SplinePoints.Num());
+        UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("│ ═══ PIPE DATA ═══"));
+        UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("│ SplineLength: %.1fcm | SplinePoints: %d"), Object.SplineLength, Object.SplinePoints.Num());
         for (const FSFPulseCapturedSplinePoint& SP : Object.SplinePoints)
         {
-            UE_LOG(LogSmartFoundations, Display, TEXT("│   [Point %d] Local=(%.1f,%.1f,%.1f) World=(%.1f,%.1f,%.1f)"),
+            UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("│   [Point %d] Local=(%.1f,%.1f,%.1f) World=(%.1f,%.1f,%.1f)"),
                 SP.PointIndex, SP.LocalPosition.X, SP.LocalPosition.Y, SP.LocalPosition.Z,
                 SP.WorldPosition.X, SP.WorldPosition.Y, SP.WorldPosition.Z);
         }
@@ -1607,56 +1607,56 @@ void USFRadarPulseService::LogObjectDetails(const FSFPulseCapturedObject& Object
     // Factory data
     if (Object.Category == TEXT("Factory") && !Object.CurrentRecipe.IsEmpty())
     {
-        UE_LOG(LogSmartFoundations, Display, TEXT("│ ═══ FACTORY DATA ═══"));
-        UE_LOG(LogSmartFoundations, Display, TEXT("│ Recipe: %s | Progress: %.1f%% | Producing: %d | Paused: %d"),
+        UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("│ ═══ FACTORY DATA ═══"));
+        UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("│ Recipe: %s | Progress: %.1f%% | Producing: %d | Paused: %d"),
             *Object.CurrentRecipe, Object.ProductionProgress * 100.0f, Object.bIsProducing, Object.bIsPaused);
     }
 
     // Stackable pole data
     if (Object.Category == TEXT("StackablePipePole") || Object.Category == TEXT("StackableBeltPole"))
     {
-        UE_LOG(LogSmartFoundations, Display, TEXT("│ ═══ STACKABLE POLE DATA ═══"));
-        UE_LOG(LogSmartFoundations, Display, TEXT("│ Type: %s"), 
+        UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("│ ═══ STACKABLE POLE DATA ═══"));
+        UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("│ Type: %s"),
             Object.Category == TEXT("StackablePipePole") ? TEXT("Pipeline Support") : TEXT("Conveyor Pole"));
-        UE_LOG(LogSmartFoundations, Display, TEXT("│ PipeConnections: %d | FactoryConnections: %d"),
+        UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("│ PipeConnections: %d | FactoryConnections: %d"),
             Object.PipeConnections.Num(), Object.FactoryConnections.Num());
     }
 
     // Custom properties
     if (Object.Properties.Num() > 0)
     {
-        UE_LOG(LogSmartFoundations, Display, TEXT("│ ═══ PROPERTIES (%d) ═══"), Object.Properties.Num());
+        UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("│ ═══ PROPERTIES (%d) ═══"), Object.Properties.Num());
         for (const auto& Pair : Object.Properties)
         {
-            UE_LOG(LogSmartFoundations, Display, TEXT("│   %s: %s"), *Pair.Key, *Pair.Value);
+            UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("│   %s: %s"), *Pair.Key, *Pair.Value);
         }
     }
 
-    UE_LOG(LogSmartFoundations, Display, TEXT("└─────────────────────────────────────────────────────────────────────"));
+    UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("└─────────────────────────────────────────────────────────────────────"));
 }
 
 void USFRadarPulseService::LogSummaryHeader(const FString& Title)
 {
-    UE_LOG(LogSmartFoundations, Display, TEXT(""));
-    UE_LOG(LogSmartFoundations, Display, TEXT("╔═══════════════════════════════════════════════════════════════════╗"));
-    UE_LOG(LogSmartFoundations, Display, TEXT("║ %s"), *Title.Left(65).RightPad(65));
-    UE_LOG(LogSmartFoundations, Display, TEXT("╠═══════════════════════════════════════════════════════════════════╣"));
+    UE_LOG(LogSmartFoundations, VeryVerbose, TEXT(""));
+    UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("╔═══════════════════════════════════════════════════════════════════╗"));
+    UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("║ %s"), *Title.Left(65).RightPad(65));
+    UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("╠═══════════════════════════════════════════════════════════════════╣"));
 }
 
 void USFRadarPulseService::LogCategorySummary(const TMap<FString, int32>& CountByCategory, int32 ExtendSourceCount)
 {
-    UE_LOG(LogSmartFoundations, Display, TEXT("║ Category        │ Count  │ ExtendSource │"));
-    UE_LOG(LogSmartFoundations, Display, TEXT("╟─────────────────┼────────┼──────────────┼"));
+    UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("║ Category        │ Count  │ ExtendSource │"));
+    UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("╟─────────────────┼────────┼──────────────┼"));
 
     int32 Total = 0;
     for (const auto& Pair : CountByCategory)
     {
         Total += Pair.Value;
-        UE_LOG(LogSmartFoundations, Display, TEXT("║ %-15s │ %6d │              │"), *Pair.Key, Pair.Value);
+        UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("║ %-15s │ %6d │              │"), *Pair.Key, Pair.Value);
     }
 
-    UE_LOG(LogSmartFoundations, Display, TEXT("╟─────────────────┼────────┼──────────────┼"));
-    UE_LOG(LogSmartFoundations, Display, TEXT("║ TOTAL           │ %6d │ %12d │"), Total, ExtendSourceCount);
+    UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("╟─────────────────┼────────┼──────────────┼"));
+    UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("║ TOTAL           │ %6d │ %12d │"), Total, ExtendSourceCount);
 }
 
 // ==================== CHAIN ACTOR SCANNING ====================
@@ -1670,7 +1670,7 @@ void USFRadarPulseService::ScanChainActors(float Radius)
     }
 
     UWorld* World = Subsystem->GetWorld();
-    
+
     // Get player location
     APlayerController* PC = World->GetFirstPlayerController();
     if (!PC || !PC->GetPawn())
@@ -1678,14 +1678,14 @@ void USFRadarPulseService::ScanChainActors(float Radius)
         UE_LOG(LogSmartFoundations, Warning, TEXT("📡 ScanChainActors: Cannot scan - no valid player"));
         return;
     }
-    
+
     FVector PlayerLocation = PC->GetPawn()->GetActorLocation();
-    
+
     // Find all conveyors (belts and lifts) in radius
     TArray<AFGBuildableConveyorBase*> Conveyors;
     TArray<AActor*> AllConveyors;
     UGameplayStatics::GetAllActorsOfClass(World, AFGBuildableConveyorBase::StaticClass(), AllConveyors);
-    
+
     for (AActor* Actor : AllConveyors)
     {
         if (!IsValid(Actor)) continue;
@@ -1698,11 +1698,11 @@ void USFRadarPulseService::ScanChainActors(float Radius)
             }
         }
     }
-    
+
     // Collect unique chain actors and their members
     TMap<AFGConveyorChainActor*, TArray<AFGBuildableConveyorBase*>> ChainToConveyors;
     int32 NullChainCount = 0;
-    
+
     for (AFGBuildableConveyorBase* Conveyor : Conveyors)
     {
         AFGConveyorChainActor* ChainActor = Conveyor->GetConveyorChainActor();
@@ -1715,35 +1715,35 @@ void USFRadarPulseService::ScanChainActors(float Radius)
             NullChainCount++;
         }
     }
-    
+
     // Log results
     LogSummaryHeader(FString::Printf(TEXT("CHAIN ACTOR SCAN (%.0fm radius)"), Radius / 100.0f));
-    
-    UE_LOG(LogSmartFoundations, Display, TEXT("║ Found %d conveyors, %d unique chain actors, %d with NULL chain"),
+
+    UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("║ Found %d conveyors, %d unique chain actors, %d with NULL chain"),
         Conveyors.Num(), ChainToConveyors.Num(), NullChainCount);
-    UE_LOG(LogSmartFoundations, Display, TEXT("╠═══════════════════════════════════════════════════════════════════╣"));
-    
+    UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("╠═══════════════════════════════════════════════════════════════════╣"));
+
     int32 ChainIndex = 0;
     for (auto& Pair : ChainToConveyors)
     {
         AFGConveyorChainActor* Chain = Pair.Key;
         TArray<AFGBuildableConveyorBase*>& Members = Pair.Value;
-        
-        UE_LOG(LogSmartFoundations, Display, TEXT("║"));
-        UE_LOG(LogSmartFoundations, Display, TEXT("║ ═══ CHAIN[%d]: %s (ptr=0x%p) ═══"), 
+
+        UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("║"));
+        UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("║ ═══ CHAIN[%d]: %s (ptr=0x%p) ═══"),
             ChainIndex, *Chain->GetName(), Chain);
-        UE_LOG(LogSmartFoundations, Display, TEXT("║   Members in radius: %d, Total segments: %d"), 
+        UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("║   Members in radius: %d, Total segments: %d"),
             Members.Num(), Chain->GetNumChainSegments());
-        
+
         // Log each member with connection info
         for (AFGBuildableConveyorBase* Member : Members)
         {
             UFGFactoryConnectionComponent* Conn0 = Member->GetConnection0();
             UFGFactoryConnectionComponent* Conn1 = Member->GetConnection1();
-            
+
             FString Conn0Info = TEXT("unconnected");
             FString Conn1Info = TEXT("unconnected");
-            
+
             if (Conn0 && Conn0->IsConnected())
             {
                 UFGFactoryConnectionComponent* Connected = Cast<UFGFactoryConnectionComponent>(Conn0->GetConnection());
@@ -1756,7 +1756,7 @@ void USFRadarPulseService::ScanChainActors(float Radius)
                     Conn0Info = TEXT("→ (connected but null ref)");
                 }
             }
-            
+
             if (Conn1 && Conn1->IsConnected())
             {
                 UFGFactoryConnectionComponent* Connected = Cast<UFGFactoryConnectionComponent>(Conn1->GetConnection());
@@ -1769,37 +1769,37 @@ void USFRadarPulseService::ScanChainActors(float Radius)
                     Conn1Info = TEXT("→ (connected but null ref)");
                 }
             }
-            
+
             // Determine type
             FString TypeStr = TEXT("Belt");
             if (Cast<AFGBuildableConveyorLift>(Member))
             {
                 TypeStr = TEXT("Lift");
             }
-            
-            UE_LOG(LogSmartFoundations, Display, TEXT("║   • %s %s"),
+
+            UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("║   • %s %s"),
                 *TypeStr, *Member->GetName());
-            UE_LOG(LogSmartFoundations, Display, TEXT("║       Conn0: %s"), *Conn0Info);
-            UE_LOG(LogSmartFoundations, Display, TEXT("║       Conn1: %s"), *Conn1Info);
+            UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("║       Conn0: %s"), *Conn0Info);
+            UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("║       Conn1: %s"), *Conn1Info);
         }
-        
+
         ChainIndex++;
     }
-    
+
     // Log conveyors with NULL chain actors
     if (NullChainCount > 0)
     {
-        UE_LOG(LogSmartFoundations, Display, TEXT("║"));
-        UE_LOG(LogSmartFoundations, Display, TEXT("║ ═══ CONVEYORS WITH NULL CHAIN ACTOR (%d) ═══"), NullChainCount);
+        UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("║"));
+        UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("║ ═══ CONVEYORS WITH NULL CHAIN ACTOR (%d) ═══"), NullChainCount);
         for (AFGBuildableConveyorBase* Conveyor : Conveyors)
         {
             if (!Conveyor->GetConveyorChainActor())
             {
                 FString TypeStr = Cast<AFGBuildableConveyorLift>(Conveyor) ? TEXT("Lift") : TEXT("Belt");
-                UE_LOG(LogSmartFoundations, Display, TEXT("║   • %s %s"), *TypeStr, *Conveyor->GetName());
+                UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("║   • %s %s"), *TypeStr, *Conveyor->GetName());
             }
         }
     }
-    
-    UE_LOG(LogSmartFoundations, Display, TEXT("╚═══════════════════════════════════════════════════════════════════╝"));
+
+    UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("╚═══════════════════════════════════════════════════════════════════╝"));
 }

--- a/Source/SmartFoundations/Private/Services/SFChainActorService.cpp
+++ b/Source/SmartFoundations/Private/Services/SFChainActorService.cpp
@@ -974,7 +974,7 @@ int32 USFChainActorService::RepairOrphanedBelts(FSFChainRepairResult* OutResult)
 		ReportPath = FPaths::ProjectLogDir() / FString::Printf(TEXT("SmartUpgrade_OrphanTickGroups_%s.json"), *Stamp);
 		if (FFileHelper::SaveStringToFile(OrphanReport, *ReportPath))
 		{
-			UE_LOG(LogSmartFoundations, Display,
+			UE_LOG(LogSmartFoundations, VeryVerbose,
 				TEXT("ChainActorService: orphan tick group report written -> %s"), *ReportPath);
 		}
 		else
@@ -993,7 +993,7 @@ int32 USFChainActorService::RepairOrphanedBelts(FSFChainRepairResult* OutResult)
 		QueuedGroups = ReRegisterAndQueueVanillaRebuildForBelts(BeltsToReRegister, {});
 	}
 
-	UE_LOG(LogSmartFoundations, Display,
+	UE_LOG(LogSmartFoundations, VeryVerbose,
 		TEXT("ChainActorService: RepairOrphanedBelts TRIAGE — orphaned_tgs=%d empty_tgs=%d live_belts=%d candidate_belts=%d reregistered_belts=%d queued_groups=%d report=%s. Save/reload and re-run Detect after repair."),
 		OrphanedTGs, EmptyTGs, BeltsAcrossTGs, CandidateBelts, ReRegisteredBelts, QueuedGroups, ReportPath.IsEmpty() ? TEXT("none") : *ReportPath);
 
@@ -1030,7 +1030,7 @@ void USFChainActorService::RunPostLoadRepair()
 
 	if (Result.HasIssues())
 	{
-		UE_LOG(LogSmartFoundations, Warning,
+		UE_LOG(LogSmartFoundations, VeryVerbose,
 			TEXT("ChainActorService: Post-load chain diagnostic found issues but did not mutate conveyor state — zombies=%d split_chains=%d orphaned_tgs=%d tg_backptr_mismatches=%d. Use Smart Upgrade Triage or targeted tooling after the world is stable."),
 			Result.ZombieChainCount,
 			Result.SplitChainCount,
@@ -1039,7 +1039,7 @@ void USFChainActorService::RunPostLoadRepair()
 	}
 	else
 	{
-		UE_LOG(LogSmartFoundations, Log,
+		UE_LOG(LogSmartFoundations, VeryVerbose,
 			TEXT("ChainActorService: Post-load chain diagnostic complete — no issues detected."));
 	}
 }
@@ -1455,7 +1455,7 @@ int32 USFChainActorService::InvalidateAndQueueVanillaRebuildForBelts(
 		++FinalQueuedGroups;
 	}
 
-	UE_LOG(LogSmartFoundations, Display,
+	UE_LOG(LogSmartFoundations, VeryVerbose,
 		TEXT("ChainActorService: queued vanilla conveyor rebuild - belts=%d chains=%d groups=%d final_groups=%d cleared=%d detached_chains=%d mismatched_backptrs=%d cleared_backptrs=%d coalesced_groups=%d coalesced_belts=%d multi_groups=%d sorted_groups=%d unsorted_groups=%d lift_belts=%d normalized_buckets=%d"),
 		Belts.Num(), AffectedChains.Num(), GroupsToQueue.Num(), FinalQueuedGroups, ClearedGroups, DetachedChains, QueuedGroupBackPointerMismatches, ClearedBackPointers,
 		CoalescedGroups, CoalescedBelts, MultiConveyorGroups, SortedGroups, UnsortedGroups, LiftBeltsInQueuedGroups, NormalizedBucketAssignments);
@@ -1585,7 +1585,7 @@ int32 USFChainActorService::ReRegisterAndQueueVanillaRebuildForBelts(
 	}
 
 	const int32 PendingGroups = BuildableSub->mConveyorGroupsPendingChainActors.Num();
-	UE_LOG(LogSmartFoundations, Display,
+	UE_LOG(LogSmartFoundations, VeryVerbose,
 		TEXT("ChainActorService: vanilla re-registration queued rebuild - belts=%d removed=%d added=%d groups_cleared=%d chains=%d detached_chains=%d pending_cleared=%d pending_groups=%d"),
 		UniqueBelts.Num(), RemovedBelts, AddedBelts, ClearedGroups, AffectedChains.Num(), DetachedChains, ClearedPendingGroups, PendingGroups);
 
@@ -1627,13 +1627,13 @@ void USFChainActorService::ScheduleDeferredZombiePurge(float DelaySeconds)
 
 		if (Purged > 0)
 		{
-			UE_LOG(LogSmartFoundations, Display,
+			UE_LOG(LogSmartFoundations, VeryVerbose,
 				TEXT("ChainActorService: Deferred post-upgrade cleanup — %d zombie(s) purged. If belts still appear stalled, wait for settling, run Triage > Detect, then save/reload before any orphan recovery."),
 				Purged);
 		}
 		else
 		{
-			UE_LOG(LogSmartFoundations, Log,
+			UE_LOG(LogSmartFoundations, VeryVerbose,
 				TEXT("ChainActorService: Deferred post-upgrade cleanup — no zombies detected."));
 		}
 	}), DelaySeconds, /*bLoop*/ false);
@@ -1746,7 +1746,7 @@ void USFChainActorService::DumpFailingTickGroupToJson(
 
 	if (FFileHelper::SaveStringToFile(J, *Path))
 	{
-		UE_LOG(LogSmartFoundations, Display,
+		UE_LOG(LogSmartFoundations, VeryVerbose,
 			TEXT("ChainActorService: topology dump written → %s"), *Path);
 	}
 	else
@@ -1910,7 +1910,7 @@ FSFChainDiagnosticResult USFChainActorService::DetectChainActorIssues() const
 		}
 	}
 
-	UE_LOG(LogSmartFoundations, Log,
+	UE_LOG(LogSmartFoundations, VeryVerbose,
 		TEXT("ChainActorService: DetectChainActorIssues — zombies=%d split_chains=%d orphaned_belts=%d orphaned_tgs=%d empty_orphaned_tgs=%d live_orphaned_belts=%d orphaned_belt_candidates=%d tg_backptr_mismatches=%d"),
 		Result.ZombieChainCount,
 		Result.SplitChainCount,
@@ -1948,7 +1948,7 @@ FSFChainRepairResult USFChainActorService::RepairAllChainActorIssues()
 	RepairOrphanedBelts(&Result);
 	Result.ZombiesPurged        += PurgeZombieChainActors();
 
-	UE_LOG(LogSmartFoundations, Display,
+	UE_LOG(LogSmartFoundations, VeryVerbose,
 		TEXT("ChainActorService: RepairAllChainActorIssues complete — zombies_purged=%d split_groups_rebuilt=%d orphaned_tgs=%d empty_orphaned_tgs=%d live_orphaned_belts=%d orphaned_belt_candidates=%d orphaned_belts_requeued=%d"),
 		Result.ZombiesPurged,
 		Result.SplitGroupsRebuilt,

--- a/Source/SmartFoundations/Private/Services/SFGridSpawnerService.cpp
+++ b/Source/SmartFoundations/Private/Services/SFGridSpawnerService.cpp
@@ -61,7 +61,7 @@ void USFGridSpawnerService::RegenerateChildHologramGrid()
             FSFCounterState NewState = SS->GetCounterState();
             NewState.GridCounters = SS->GetGridCounters();
             SS->UpdateCounterState(NewState);
-            
+
             // CRITICAL: Update positions AFTER grid sync so CounterState has correct dimensions
             UpdateChildPositions();
 
@@ -142,12 +142,12 @@ void USFGridSpawnerService::UpdateChildPositions()
         UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("UpdateChildPositions: Early return - No active hologram"));
         return;
     }
-    
+
     // CRITICAL: Even if there are no children, we must trigger the orchestrator to clean up orphaned previews
     if (SpawnedChildren.Num() == 0)
     {
         UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("UpdateChildPositions: No children - triggering orchestrator for cleanup"));
-        
+
         if (AFGHologram* Parent = SS->GetActiveHologram())
         {
             if (USFAutoConnectOrchestrator* Orchestrator = SS->GetOrCreateOrchestrator(Parent))
@@ -229,7 +229,7 @@ void USFGridSpawnerService::UpdateChildPositions()
     FVector ParentLocation = ParentHologram->GetActorLocation();
     FRotator ParentRotation = ParentHologram->GetActorRotation();
     FVector ParentNudgeOffset = ParentHologram->GetHologramNudgeOffset();
-    
+
     // DEBUG: Log parent state including nudge offset
     FVector ParentAnchorOffset = SS->GetCachedAnchorOffset();
     UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("   🔍 PARENT STATE: Location=%s, NudgeOffset=%s, AnchorOffset=%s"),
@@ -241,7 +241,7 @@ void USFGridSpawnerService::UpdateChildPositions()
     if (!ItemSize.Equals(SS->GetLastLoggedItemSize(), 0.5f))
     {
         SS->SetLastLoggedItemSize(ItemSize);
-        UE_LOG(LogSmartFoundations, Display, TEXT("ITEM SIZE USED FOR SPACING: %s (CachedBuildingSize=%s)"),
+        UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("ITEM SIZE USED FOR SPACING: %s (CachedBuildingSize=%s)"),
             *ItemSize.ToString(), *SS->GetCachedBuildingSize().ToString());
     }
 
@@ -331,7 +331,7 @@ void USFGridSpawnerService::UpdateChildPositions()
             GridIndex.ChildArrayIndex, GridIndex.X, GridIndex.Y, GridIndex.Z);
 
         // CRITICAL FIX: DO NOT pass AnchorOffset to CalculateChildPosition
-        // 
+        //
         // DISCOVERY: CalculateChildPosition adds AnchorOffset to the returned position,
         // but SetHologramLocationAndRotation() ALSO applies AnchorOffset compensation.
         // Passing AnchorOffset to both causes double-compensation.
@@ -344,7 +344,7 @@ void USFGridSpawnerService::UpdateChildPositions()
         // SOLUTION: Pass FVector::ZeroVector to CalculateChildPosition and let
         // SetHologramLocationAndRotation handle the AnchorOffset compensation.
         // We then counteract the API's behavior in the AdjustedPosition calculation above.
-        
+
         // Calculate position using PositionCalculator (NO AnchorOffset - handled by hologram API)
         FVector ChildPosition = ParentLocation;
         if (FSFPositionCalculator* PosCalc = SS->GetPositionCalculator())
@@ -366,12 +366,12 @@ void USFGridSpawnerService::UpdateChildPositions()
         FVector OldPosition = ChildHologram->GetActorLocation();
         const bool bParentWasLocked = ParentHologram->IsHologramLocked();
         const bool bChildWasLocked = ChildHologram->IsHologramLocked();
-        
+
         UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("   ╔═══ CHILD %d POSITIONING START ═══"), GridIndex.ChildArrayIndex);
         UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("   ║ OldPos: %s"), *OldPosition.ToString());
         UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("   ║ CalcPos: %s (from PositionCalculator)"), *ChildPosition.ToString());
         UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("   ║ ParentLocked: %d  ChildLocked: %d"), bParentWasLocked ? 1 : 0, bChildWasLocked ? 1 : 0);
-        
+
         // Get AnchorOffset for diagnostics
         FVector ChildAnchorOffset = FVector::ZeroVector;
         if (AFGBuildableHologram* BuildableChild = Cast<AFGBuildableHologram>(ChildHologram))
@@ -384,7 +384,7 @@ void USFGridSpawnerService::UpdateChildPositions()
                 UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("   ║ ChildAnchorOffset: %s (from registry)"), *ChildAnchorOffset.ToString());
             }
         }
-        
+
         // Delegate lock management to HologramHelperService
         HologramHelper->TemporarilyUnlockChild(ChildHologram, bParentWasLocked);
         const bool bChildUnlockedByHelper = !ChildHologram->IsHologramLocked() && bChildWasLocked;
@@ -402,7 +402,7 @@ void USFGridSpawnerService::UpdateChildPositions()
         // SetActorLocation doesn't apply AnchorOffset (the old compensation was specifically
         // to counteract SetHologramLocationAndRotation's implicit AnchorOffset addition).
         ChildHologram->SetActorLocation(ChildPosition);
-        
+
         // Calculate child rotation - includes arc rotation if radial transform is active
         FRotator ChildRotation = ParentRotation;
         const FSFCounterState& Counter = SS->GetCounterState();
@@ -413,22 +413,22 @@ void USFGridSpawnerService::UpdateChildPositions()
             // The rotation matches the arc direction - positive RotationZ = clockwise arc = clockwise building rotation
             float ChildYawOffset = GridIndex.X * Counter.RotationZ;
             ChildRotation.Yaw += ChildYawOffset;
-            
-            UE_LOG(LogSmartFoundations, Verbose, 
+
+            UE_LOG(LogSmartFoundations, Verbose,
                 TEXT("🔄 Spawn Child[%d] X=%d: ParentYaw=%.1f° + Offset=%.1f° = FinalYaw=%.1f°"),
                 GridIndex.ChildArrayIndex, GridIndex.X, ParentRotation.Yaw, ChildYawOffset, ChildRotation.Yaw);
         }
         ChildHologram->SetActorRotation(ChildRotation);
-        
+
         // Check position AFTER API call
         FVector NewPosition = ChildHologram->GetActorLocation();
         float DeltaZ = NewPosition.Z - OldPosition.Z;
         float OffsetFromCalc = NewPosition.Z - ChildPosition.Z;
-        
+
         UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("   ║ NewPos: %s (after SetHologramLocationAndRotation)"), *NewPosition.ToString());
         UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("   ║ Delta Z: %.1f cm (NewPos - OldPos)"), DeltaZ);
         UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("   ║ Offset from CalcPos: %.1f cm (NewPos - CalcPos)"), OffsetFromCalc);
-        
+
         // Check if offset matches AnchorOffset
         if (FMath::Abs(OffsetFromCalc - ChildAnchorOffset.Z) < 1.0f)
         {
@@ -442,7 +442,7 @@ void USFGridSpawnerService::UpdateChildPositions()
         {
             UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("   ║ ❓ UNEXPECTED OFFSET - Doesn't match AnchorOffset or zero."));
         }
-        
+
         UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("   ╚═══════════════════════════════════"));
 
         // Delegate floor validation to ValidationService
@@ -492,7 +492,7 @@ void USFGridSpawnerService::UpdateChildPositions()
         // Special logging for water extractors
         if (ChildHologram->IsA(ASFWaterPumpChildHologram::StaticClass()))
         {
-            UE_LOG(LogSmartFoundations, Display, TEXT("  [WATER EXTRACTOR] Child %s moved from %s to %s (Grid[%d,%d,%d])"),
+            UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("  [WATER EXTRACTOR] Child %s moved from %s to %s (Grid[%d,%d,%d])"),
                 *ChildHologram->GetName(), *OldPosition.ToString(), *ChildPosition.ToString(),
                 GridIndex.X, GridIndex.Y, GridIndex.Z);
         }
@@ -547,7 +547,7 @@ void USFGridSpawnerService::UpdateChildPositions()
                 {
                     Orchestrator->OnFloorHolePipesChanged();
                 }
-                
+
                 UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("   🎯 Orchestrator: Grid updates triggered in CompletionCallback"));
             }
         }
@@ -670,7 +670,7 @@ void USFGridSpawnerService::UpdateChildrenForCurrentTransform()
                         {
                             Orchestrator->OnFloorHolePipesChanged();
                         }
-                        
+
                         UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("   🎯 Orchestrator: Movement updates triggered (next tick)"));
                     }
                 }

--- a/Source/SmartFoundations/Private/Services/SFHudService.cpp
+++ b/Source/SmartFoundations/Private/Services/SFHudService.cpp
@@ -152,7 +152,7 @@ void USFHudService::CreateHudWidget()
     if (HudWidget)
     {
         HudWidget->SetVisibility(ESlateVisibility::Collapsed);
-        UE_LOG(LogSmartFoundations, Log, TEXT("SFHudService: Created UMG HUD widget"));
+        UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("SFHudService: Created UMG HUD widget"));
     }
 }
 
@@ -218,7 +218,7 @@ void USFHudService::EnsureHUDBinding()
 void USFHudService::CleanupWidgets()
 {
 	DestroyHudWidget();
-	
+
 	if (AHUD* HUD = CachedHUD.Get())
 	{
 		HUD->OnHUDPostRender.RemoveAll(this);
@@ -249,7 +249,7 @@ TPair<FString, FString> USFHudService::BuildCounterDisplayLines() const
 			Lines.Add(LOCTEXT("HUD_ZoopActive", "*Zoop Active - Scaling Disabled").ToString());
 		}
 	}
-	
+
 	// Issue #198 + #257: Smart disable warning display
 	if (Subsystem->IsSmartDisabledForCurrentAction() || Subsystem->IsExtendDisabled())
 	{
@@ -285,7 +285,7 @@ TPair<FString, FString> USFHudService::BuildCounterDisplayLines() const
 		{
 			int32 CloneCount = ExtendSvc->GetExtendCloneCount();
 			int32 RowCount = ExtendSvc->GetExtendRowCount();
-			
+
 			if (CloneCount > 0 || RowCount > 1)
 			{
 				// Show Scaled Extend mode with clone count
@@ -352,7 +352,7 @@ TPair<FString, FString> USFHudService::BuildCounterDisplayLines() const
 		int32 TotalRecipes = 0;
 		Subsystem->GetRecipeDisplayInfo(CurrentIndex, TotalRecipes);
 		TSubclassOf<UFGRecipe> ActiveRecipe = Subsystem->GetActiveRecipe();
-		
+
 		// CRITICAL FIX: Only show recipe if it is compatible with the CURRENT hologram
 		// This prevents stale recipes from persisting on the HUD when switching between incompatible buildings
 		bool bIsCompatible = true;
@@ -384,21 +384,21 @@ TPair<FString, FString> USFHudService::BuildCounterDisplayLines() const
 	// Only show settings if the current hologram supports auto-connect
 	{
 		const bool bAutoConnectActive = Subsystem->IsAutoConnectSettingsModeActive();
-		
+
 		// Only fetch and display dirty settings if we're in settings mode OR
 		// if the current hologram is an auto-connect type (distributor, pipe junction, power pole, stackable support)
 		// This prevents stale settings from showing on non-auto-connect holograms
 		const bool bIsAutoConnectHologram = Subsystem->IsCurrentHologramAutoConnectCapable();
-		
+
 		if (bIsAutoConnectHologram)
 		{
 			const TArray<FString> DirtySettings = Subsystem->GetDirtyAutoConnectSettings();
-			
+
 			if (bAutoConnectActive)
 			{
 				const FString CurrentSetting = Subsystem->GetAutoConnectSettingDisplayString();
 				bool bRenderedCurrentInDirtyList = false;
-				
+
 				// First, render all dirty settings, highlighting the active one
 				for (const FString& Setting : DirtySettings)
 				{
@@ -410,7 +410,7 @@ TPair<FString, FString> USFHudService::BuildCounterDisplayLines() const
 					Lines.Add(FText::Format(LOCTEXT("HUD_SettingsActive", "Settings: {0}{1}"),
 						FText::FromString(Setting), FText::FromString(bIsCurrent ? TEXT("*") : TEXT(""))).ToString());
 				}
-				
+
 				// If the current setting is not dirty (matches config), still show it as active
 				if (!bRenderedCurrentInDirtyList)
 				{
@@ -550,17 +550,17 @@ TPair<FString, FString> USFHudService::BuildCounterDisplayLines() const
 	if (bShowRotationZ)
 	{
 		const bool bIsActive = (bRotationActive && RotationAxis == ESFScaleAxis::Z);
-		
+
 		// DESIGN DECISION: Show degrees + abbreviated calculated info
 		// Calculate radius and buildings-per-circle for user reference
 		float RotationStepRad = FMath::Abs(FMath::DegreesToRadians(State.RotationZ));
-		float Radius = (RotationStepRad > KINDA_SMALL_NUMBER) 
+		float Radius = (RotationStepRad > KINDA_SMALL_NUMBER)
 			? (State.SpacingX / RotationStepRad) / 100.0f  // Convert cm to m
 			: 0.0f;
 		int32 BuildingsPerCircle = (FMath::Abs(State.RotationZ) > KINDA_SMALL_NUMBER)
 			? FMath::RoundToInt(360.0f / FMath::Abs(State.RotationZ))
 			: 0;
-		
+
 		if (Radius > 0.0f && BuildingsPerCircle > 0)
 		{
 			Lines.Add(FText::Format(LOCTEXT("HUD_RotationZFull", "Rotation [Z]{0}: {1}\u00B0 (R={2}m, {3}/circle)"),
@@ -645,18 +645,18 @@ void USFHudService::ResetState()
 	CurrentBeltCostText.Empty();
 	CurrentPipeCostText.Empty();
 	CurrentPowerCostText.Empty();
-	
+
 	// Clear all cached cost arrays
 	CachedBeltAvailability.Empty();
 	CachedPipeCosts.Empty();
 	CachedPipeAvailability.Empty();
 	CachedPowerCosts.Empty();
 	CachedPowerAvailability.Empty();
-	
+
 	// Clear lift height
 	CachedLiftHeight = 0.0f;
 	CachedWorldHeight = 0.0f;
-	
+
 	UE_LOG(LogSmartFoundations, Log, TEXT("HUD state reset for new hologram"));
 }
 

--- a/Source/SmartFoundations/Private/Services/SFRecipeManagementService.cpp
+++ b/Source/SmartFoundations/Private/Services/SFRecipeManagementService.cpp
@@ -60,13 +60,13 @@ void USFRecipeManagementService::Cleanup()
 void USFRecipeManagementService::ActivateRecipeMode()
 {
 	bRecipeModeActive = true;
-	UE_LOG(LogSmartFoundations, Log, TEXT("🍽️ Recipe mode activated"));
+	UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("🍽️ Recipe mode activated"));
 }
 
 void USFRecipeManagementService::DeactivateRecipeMode()
 {
 	bRecipeModeActive = false;
-	UE_LOG(LogSmartFoundations, Log, TEXT("🍽️ Recipe mode deactivated"));
+	UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("🍽️ Recipe mode deactivated"));
 }
 
 // ========================================
@@ -197,7 +197,7 @@ void USFRecipeManagementService::SetActiveRecipeByIndex(int32 Index)
 					0.2f,  // 200ms debounce
 					false
 				);
-				UE_LOG(LogSmartFoundations, Log, TEXT("🍽️ Recipe changed - scheduled child regeneration in 200ms"));
+				UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("🍽️ Recipe changed - scheduled child regeneration in 200ms"));
 			}
 		}
 	}
@@ -207,7 +207,7 @@ void USFRecipeManagementService::SetActiveRecipeByIndex(int32 Index)
 		Subsystem->UpdateCounterDisplay();
 	}
 	
-	UE_LOG(LogSmartFoundations, Log, TEXT("🍽️ Active recipe set: %s [%d/%d]"), 
+	UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("🍽️ Active recipe set: %s [%d/%d]"), 
 		*StoredRecipeDisplayName, Index + 1, SortedFilteredRecipes.Num());
 }
 
@@ -220,7 +220,7 @@ void USFRecipeManagementService::AddRecipeToUnlocked(TSubclassOf<UFGRecipe> Reci
 	
 	// Add to unlocked recipes
 	UnlockedRecipes.Add(Recipe);
-	UE_LOG(LogSmartFoundations, Log, TEXT("🍽️ Recipe unlocked: %s (%d total)"), 
+	UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("🍽️ Recipe unlocked: %s (%d total)"), 
 		*GetRecipeDisplayName(Recipe), UnlockedRecipes.Num());
 }
 
@@ -228,7 +228,7 @@ TArray<TSubclassOf<UFGRecipe>> USFRecipeManagementService::GetFilteredRecipesFor
 {
 	if (!Subsystem || !Subsystem->GetActiveHologram()) 
 	{
-		UE_LOG(LogSmartFoundations, Log, TEXT("🍽️ No active hologram for recipe filtering"));
+		UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("🍽️ No active hologram for recipe filtering"));
 		SortedFilteredRecipes.Empty();
 		return TArray<TSubclassOf<UFGRecipe>>();
 	}
@@ -295,7 +295,7 @@ void USFRecipeManagementService::ClearAllRecipes()
 		Subsystem->UpdateCounterDisplay();
 	}
 	
-	UE_LOG(LogSmartFoundations, Log, TEXT("🍽️ All recipes and unlocked list cleared"));
+	UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("🍽️ All recipes and unlocked list cleared"));
 }
 
 // ========================================
@@ -316,7 +316,7 @@ void USFRecipeManagementService::StoreProductionRecipeFromBuilding(AFGBuildable*
 	// Check if this is a production building that supports recipes
 	if (!IsProductionBuilding(SourceBuilding))
 	{
-		UE_LOG(LogSmartFoundations, Log, TEXT("🍽️ Building is not a production building, skipping recipe storage"));
+		UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("🍽️ Building is not a production building, skipping recipe storage"));
 		return;
 	}
 	
@@ -363,11 +363,11 @@ void USFRecipeManagementService::StoreProductionRecipeFromBuilding(AFGBuildable*
 			Subsystem->UpdateCounterDisplay();
 		}
 		
-		UE_LOG(LogSmartFoundations, Log, TEXT("🍽️ Stored recipe from building: %s"), *StoredRecipeDisplayName);
+		UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("🍽️ Stored recipe from building: %s"), *StoredRecipeDisplayName);
 	}
 	else
 	{
-		UE_LOG(LogSmartFoundations, Log, TEXT("🍽️ Building %s has no recipe set"), *SourceBuilding->GetName());
+		UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("🍽️ Building %s has no recipe set"), *SourceBuilding->GetName());
 	}
 	
 	// Issue #208/#209: Capture Power Shard and Somersloop state from source building
@@ -399,12 +399,12 @@ void USFRecipeManagementService::StoreProductionRecipeFromBuilding(AFGBuildable*
 						StoredOverclockShardClass = ShardClass;
 					}
 					StoredOverclockShardCount += Stack.NumItems;
-					UE_LOG(LogSmartFoundations, Log, TEXT("⚡ Captured overclock shard: %s x%d (total: %d)"), *ShardClass->GetName(), Stack.NumItems, StoredOverclockShardCount);
+					UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("⚡ Captured overclock shard: %s x%d (total: %d)"), *ShardClass->GetName(), Stack.NumItems, StoredOverclockShardCount);
 				}
 				else if (ShardType == EPowerShardType::PST_ProductionBoost && !StoredProductionBoostShardClass)
 				{
 					StoredProductionBoostShardClass = ShardClass;
-					UE_LOG(LogSmartFoundations, Log, TEXT("🔮 Captured production boost shard class: %s"), *ShardClass->GetName());
+					UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("🔮 Captured production boost shard class: %s"), *ShardClass->GetName());
 				}
 			}
 		}
@@ -414,7 +414,7 @@ void USFRecipeManagementService::StoreProductionRecipeFromBuilding(AFGBuildable*
 		{
 			StoredPotential = SourcePotential;
 			bHasStoredPotential = true;
-			UE_LOG(LogSmartFoundations, Log, TEXT("⚡ Stored overclock potential: %.0f%% from %s (shard class: %s)"), 
+			UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("⚡ Stored overclock potential: %.0f%% from %s (shard class: %s)"), 
 				SourcePotential * 100.0f, *SourceBuilding->GetName(), *StoredOverclockShardClass->GetName());
 		}
 		else
@@ -428,7 +428,7 @@ void USFRecipeManagementService::StoreProductionRecipeFromBuilding(AFGBuildable*
 		{
 			StoredProductionBoost = SourceBoost;
 			bHasStoredProductionBoost = true;
-			UE_LOG(LogSmartFoundations, Log, TEXT("🔮 Stored production boost: %.0f%% from %s (shard class: %s)"), 
+			UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("🔮 Stored production boost: %.0f%% from %s (shard class: %s)"), 
 				SourceBoost * 100.0f, *SourceBuilding->GetName(), *StoredProductionBoostShardClass->GetName());
 		}
 		else
@@ -445,7 +445,7 @@ void USFRecipeManagementService::StoreProductionRecipeFromBuilding(AFGBuildable*
 			++CurrentBuildSessionId;
 			ShardSessionId = CurrentBuildSessionId;
 			ShardSourceBuildClass = SourceBuilding->GetClass();
-			UE_LOG(LogSmartFoundations, Log, TEXT("🏷️ Tagged shard state with session ID=%d, source class=%s"), 
+			UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("🏷️ Tagged shard state with session ID=%d, source class=%s"), 
 				ShardSessionId, *GetNameSafe(ShardSourceBuildClass));
 		}
 	}
@@ -456,7 +456,7 @@ void USFRecipeManagementService::OnRecipeModeChanged(const FInputActionValue& Va
 	// Toggle recipe mode state
 	bRecipeModeActive = Value.Get<bool>();
 	
-	UE_LOG(LogSmartFoundations, Log, TEXT("🍽️ Recipe mode %s"), 
+	UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("🍽️ Recipe mode %s"), 
 		bRecipeModeActive ? TEXT("activated") : TEXT("deactivated"));
 }
 
@@ -477,7 +477,7 @@ void USFRecipeManagementService::ApplyStoredProductionRecipeToBuilding(AFGBuilda
 	if (Manufacturer)
 	{
 		Manufacturer->SetRecipe(StoredProductionRecipe);
-		UE_LOG(LogSmartFoundations, Log, TEXT("🍽️ Applied stored recipe %s to building %s"), 
+		UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("🍽️ Applied stored recipe %s to building %s"), 
 			*StoredRecipeDisplayName, *TargetBuilding->GetName());
 	}
 }
@@ -527,7 +527,7 @@ void USFRecipeManagementService::OnBuildGunRecipeSampled(TSubclassOf<UFGRecipe> 
 
 void USFRecipeManagementService::ClearStoredProductionRecipe()
 {
-	UE_LOG(LogSmartFoundations, Log, TEXT("🧹 ClearStoredProductionRecipe: bHasStoredPotential=%s, bHasStoredProductionBoost=%s, ShardCount=%d"),
+	UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("🧹 ClearStoredProductionRecipe: bHasStoredPotential=%s, bHasStoredProductionBoost=%s, ShardCount=%d"),
 		bHasStoredPotential ? TEXT("true") : TEXT("false"),
 		bHasStoredProductionBoost ? TEXT("true") : TEXT("false"),
 		StoredOverclockShardCount);
@@ -582,7 +582,7 @@ void USFRecipeManagementService::ClearStoredProductionRecipe()
 		Subsystem->UpdateCounterDisplay();
 	}
 	
-	UE_LOG(LogSmartFoundations, Log, TEXT("🍽️ Cleared stored production recipe"));
+	UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("🍽️ Cleared stored production recipe"));
 }
 
 // ========================================
@@ -622,12 +622,12 @@ void USFRecipeManagementService::ApplyRecipeToParentHologram()
 		
 		if (ActiveRecipe != nullptr)
 		{
-			UE_LOG(LogSmartFoundations, Log, TEXT("🍽️ Updated parent hologram %s data registry with recipe %s"), 
+			UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("🍽️ Updated parent hologram %s data registry with recipe %s"), 
 				*ParentHologram->GetName(), *GetRecipeDisplayName(ActiveRecipe));
 		}
 		else
 		{
-			UE_LOG(LogSmartFoundations, Log, TEXT("🍽️ Cleared parent hologram %s data registry (recipe cleared)"), 
+			UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("🍽️ Cleared parent hologram %s data registry (recipe cleared)"), 
 				*ParentHologram->GetName());
 		}
 	}

--- a/Source/SmartFoundations/Private/Subsystem/SFHologramHelperService.cpp
+++ b/Source/SmartFoundations/Private/Subsystem/SFHologramHelperService.cpp
@@ -84,54 +84,54 @@ void FSFHologramHelperService::Shutdown()
 {
 	// Clean up all children
 	DestroyAllChildren();
-	
+
 	// Clear state
 	ActiveHologram.Reset();
 	WorldContext.Reset();
-	
+
 	UE_LOG(LogSmartFoundations, Log, TEXT("HologramHelperService: Shutdown complete"));
 }
 
 void FSFHologramHelperService::RegisterActiveHologram(AFGHologram* Hologram)
 {
 	// TODO: Extract from SFSubsystem::RegisterActiveHologram
-	
+
 	if (!Hologram || !IsValid(Hologram))
 	{
 		UE_LOG(LogSmartFoundations, Warning, TEXT("HologramHelperService: Cannot register invalid hologram"));
 		return;
 	}
-	
+
 	// Unregister previous hologram if any
 	if (ActiveHologram.IsValid() && ActiveHologram.Get() != Hologram)
 	{
 		UnregisterActiveHologram(ActiveHologram.Get());
 	}
-	
+
 	ActiveHologram = Hologram;
-	
-	UE_LOG(LogSmartFoundations, Log, TEXT("HologramHelperService: Registered hologram %s"), *Hologram->GetName());
+
+	UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("HologramHelperService: Registered hologram %s"), *Hologram->GetName());
 }
 
 void FSFHologramHelperService::UnregisterActiveHologram(AFGHologram* Hologram)
 {
 	// TODO: Extract from SFSubsystem::UnregisterActiveHologram
-	
+
 	if (!Hologram || !ActiveHologram.IsValid() || ActiveHologram.Get() != Hologram)
 	{
 		return;
 	}
-	
+
 	// Clean up children
 	DestroyAllChildren();
-	
+
 	// Issue #160: Clear Zoop flag when hologram is unregistered
 	bZoopActive = false;
-	
+
 	// Clear active hologram
 	ActiveHologram.Reset();
-	
-	UE_LOG(LogSmartFoundations, Log, TEXT("HologramHelperService: Unregistered hologram"));
+
+	UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("HologramHelperService: Unregistered hologram"));
 }
 
 void FSFHologramHelperService::PollForActiveHologram()
@@ -152,7 +152,7 @@ void FSFHologramHelperService::RegenerateChildHologramGrid(
 {
 	// Extracted from SFSubsystem.cpp lines 1541-1790 (Phase 2 - Task #61.6)
 	// Full grid regeneration logic moved to HologramHelperService
-	
+
 	if (!ParentHologram || !IsValid(ParentHologram))
 	{
 		return;
@@ -172,20 +172,20 @@ void FSFHologramHelperService::RegenerateChildHologramGrid(
 			if (!bZoopActive)
 			{
 				bZoopActive = true;
-				UE_LOG(LogSmartFoundations, Warning, 
+				UE_LOG(LogSmartFoundations, Warning,
 					TEXT("⚠️ Zoop detected (%d instances) - Smart! scaling disabled to prevent overlap."),
 					ZoopTransforms.Num());
 			}
-			
+
 			// Force grid to 1x1x1 to let Zoop handle the scaling
 			if (GridCounters.X != 1 || GridCounters.Y != 1 || GridCounters.Z != 1)
 			{
 				GridCounters = FIntVector(1, 1, 1);
-				
+
 				// Clear any existing Smart! children since Zoop is handling placement
 				if (SpawnedChildren.Num() > 0)
 				{
-					UE_LOG(LogSmartFoundations, Log, TEXT("   Clearing %d Smart! children - Zoop takes priority"), SpawnedChildren.Num());
+					UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("   Clearing %d Smart! children - Zoop takes priority"), SpawnedChildren.Num());
 					while (SpawnedChildren.Num() > 0)
 					{
 						TWeakObjectPtr<AFGHologram> ChildToRemove = SpawnedChildren.Pop();
@@ -216,10 +216,10 @@ void FSFHologramHelperService::RegenerateChildHologramGrid(
 		// Clear any existing children if features disabled
 		if (SpawnedChildren.Num() > 0)
 		{
-			UE_LOG(LogSmartFoundations, Log, 
+			UE_LOG(LogSmartFoundations, VeryVerbose,
 				TEXT("Clearing grid for unsupported hologram type %s - destroying %d children"),
 				*CurrentAdapter->GetAdapterTypeName(), SpawnedChildren.Num());
-			
+
 			// Queue all children for destruction
 			while (SpawnedChildren.Num() > 0)
 			{
@@ -235,7 +235,7 @@ void FSFHologramHelperService::RegenerateChildHologramGrid(
 
 	// Task 38: Log parent lock state during grid regeneration
 	const bool bParentLocked = ParentHologram->IsHologramLocked();
-	
+
 	// Phase 0: Forward grid size validation to ValidationService (Task #61.6)
 	int32 ChildrenNeeded = 0;
 	if (ValidationService)
@@ -251,22 +251,22 @@ void FSFHologramHelperService::RegenerateChildHologramGrid(
 		int32 TotalItems = FMath::Abs(GridCounters.X) * FMath::Abs(GridCounters.Y) * FMath::Abs(GridCounters.Z);
 		ChildrenNeeded = FMath::Max(0, TotalItems - 1);
 	}
-	
+
 	int32 TotalItems = FMath::Abs(GridCounters.X) * FMath::Abs(GridCounters.Y) * FMath::Abs(GridCounters.Z);
 	UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("RegenerateChildHologramGrid: Grid[%d,%d,%d] = %d items, %d children needed | Parent Locked=%s"),
 		GridCounters.X, GridCounters.Y, GridCounters.Z, TotalItems, ChildrenNeeded,
 		bParentLocked ? TEXT("YES") : TEXT("NO"));
-	
+
 	// PERFORMANCE PROFILING: Log UObject stats for large grids
 	if (ChildrenNeeded >= LARGE_GRID_WARNING_THRESHOLD || SpawnedChildren.Num() >= LARGE_GRID_WARNING_THRESHOLD)
 	{
-		FSFHologramPerformanceProfiler::LogUObjectStats(FString::Printf(TEXT("Grid %dx%dx%d (%d children)"), 
+		FSFHologramPerformanceProfiler::LogUObjectStats(FString::Printf(TEXT("Grid %dx%dx%d (%d children)"),
 			GridCounters.X, GridCounters.Y, GridCounters.Z, ChildrenNeeded));
 	}
-	
+
 	// Phase 5: UObject Warning System - Check for memory limits
 	EUObjectWarningLevel WarningLevel = CheckUObjectUtilization(ChildrenNeeded, GridCounters);
-	
+
 	// CRITICAL: Cap grid size if approaching engine limit
 	if (WarningLevel == EUObjectWarningLevel::Critical)
 	{
@@ -281,16 +281,16 @@ void FSFHologramHelperService::RegenerateChildHologramGrid(
 			GridCounters.X = FMath::Max(1, FMath::RoundToInt(GridCounters.X * ScaleFactor));
 			GridCounters.Y = FMath::Max(1, FMath::RoundToInt(GridCounters.Y * ScaleFactor));
 			GridCounters.Z = FMath::Max(1, FMath::RoundToInt(GridCounters.Z * ScaleFactor));
-			
+
 			// Recalculate children needed with capped dimensions
 			ChildrenNeeded = FMath::Max(0, (FMath::Abs(GridCounters.X) * FMath::Abs(GridCounters.Y) * FMath::Abs(GridCounters.Z)) - 1);
-			
-			UE_LOG(LogSmartFoundations, Warning, 
-				TEXT("   Grid adjusted to %dx%dx%d = %d children"), 
+
+			UE_LOG(LogSmartFoundations, Warning,
+				TEXT("   Grid adjusted to %dx%dx%d = %d children"),
 				GridCounters.X, GridCounters.Y, GridCounters.Z, ChildrenNeeded);
 		}
 	}
-	
+
 	// Clean up invalid weak pointers
 	SpawnedChildren.RemoveAll([](const TWeakObjectPtr<AFGHologram>& Child) {
 		return !Child.IsValid();
@@ -328,7 +328,7 @@ void FSFHologramHelperService::RegenerateChildHologramGrid(
 		{
 			UWorld* World = WorldContext.Get();
 			const double TSR = World ? World->GetTimeSeconds() : 0.0;
-			UE_LOG(LogSmartFoundations, Log, TEXT("[Frame=%llu t=%.3f] Resync SpawnedChildren from parent: ours=%d parentAlive=%d"),
+			UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("[Frame=%llu t=%.3f] Resync SpawnedChildren from parent: ours=%d parentAlive=%d"),
 				(unsigned long long)GFrameCounter, TSR, OurSet.Num(), ParentAlive);
 			SpawnedChildren.Empty();
 			for (AFGHologram* P : ParentChildrenNow)
@@ -345,26 +345,26 @@ void FSFHologramHelperService::RegenerateChildHologramGrid(
 			}
 		}
 	}
-	
+
 	int32 CurrentChildren = SpawnedChildren.Num();
-	
+
 	// Track if grid changed for belt preview cleanup
 	int32 ToSpawn = 0;
 	int32 ToRemove = 0;
-	
+
 	// Spawn or remove children as needed (incremental approach like original Smart!)
 	if (ChildrenNeeded > CurrentChildren)
 	{
 		// Need to spawn more children
 		ToSpawn = ChildrenNeeded - CurrentChildren;
-		
+
 		TSubclassOf<UFGRecipe> Recipe = ParentHologram->GetRecipe();
 		if (!Recipe)
 		{
 			UE_LOG(LogSmartFoundations, Error, TEXT("RegenerateChildHologramGrid: Parent hologram has no recipe!"));
 			return;
 		}
-		
+
 		AActor* HologramOwner = ParentHologram->GetOwner();
 		UWorld* World = WorldContext.Get();
 		if (!World)
@@ -372,17 +372,17 @@ void FSFHologramHelperService::RegenerateChildHologramGrid(
 			UE_LOG(LogSmartFoundations, Error, TEXT("RegenerateChildHologramGrid: No world context!"));
 			return;
 		}
-		
+
 		// Spawn at parent location initially (UpdateChildPositions will place them correctly)
 		// NOTE: We don't adjust for anchor offsets here - UpdateChildPositions handles all positioning
 		// with proper pivot compensation based on whether parent and child have same/different types
 		FVector SpawnLocation = ParentHologram->GetActorLocation();
-		
+
 		UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("RegenerateChildHologramGrid: Spawning %d new children..."), ToSpawn);
-		
+
 		// PERFORMANCE PROFILING: Track spawn performance
 		FSFHologramPerformanceProfiler::BeginSpawnProfile("RegenerateChildHologramGrid", ToSpawn);
-		
+
 		// Set baseline height if this is the first time spawning children (for nudge delta tracking)
 		const bool bFirstSpawn = (SpawnedChildren.Num() == 0);
 		if (bFirstSpawn)
@@ -390,15 +390,15 @@ void FSFHologramHelperService::RegenerateChildHologramGrid(
 			BaselineHeightZ = SpawnLocation.Z;
 			UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("   📍 Baseline height set: %.2f cm (first child spawn)"), BaselineHeightZ);
 		}
-		
+
 		// Check if this is a water extractor for extra logging
 		bool bIsWaterExtractor = ParentHologram->IsA(AFGWaterPumpHologram::StaticClass());
-		
+
 		for (int32 i = 0; i < ToSpawn; ++i)
 		{
 			// Use global counter for unique names (prevents collisions when children are destroyed and respawned)
 			FName ChildName = FName(*FString::Printf(TEXT("GridChild_%d"), ChildSpawnCounter++));
-			
+
 			// Issue #187: For passthrough holograms, spawn custom ASFPassthroughChildHologram
 			// using the same pattern as ASFConveyorAttachmentChildHologram in Extend:
 			// 1. SpawnActor (deferred) → 2. SetBuildClass + SetRecipe → 3. FinishSpawning
@@ -414,29 +414,29 @@ void FSFHologramHelperService::RegenerateChildHologramGrid(
 					SpawnParams.Owner = ParentHologram->GetOwner();
 					SpawnParams.SpawnCollisionHandlingOverride = ESpawnActorCollisionHandlingMethod::AlwaysSpawn;
 					SpawnParams.bDeferConstruction = true;
-					
+
 					ASFPassthroughChildHologram* PassthroughChild = SpawnWorld->SpawnActor<ASFPassthroughChildHologram>(
 						ASFPassthroughChildHologram::StaticClass(),
 						SpawnLocation,
 						FRotator::ZeroRotator,
 						SpawnParams);
-					
+
 					if (PassthroughChild)
 					{
 						// Match working EXTEND code order exactly:
 						// SetBuildClass + SetRecipe BEFORE FinishSpawning (triggers mesh/visual creation)
 						PassthroughChild->SetBuildClass(ParentHologram->GetBuildClass());
 						PassthroughChild->SetRecipe(Recipe);
-						
+
 						PassthroughChild->FinishSpawning(FTransform(FRotator::ZeroRotator, SpawnLocation));
-						
+
 						// Add as child IMMEDIATELY after FinishSpawning (matches working EXTEND code)
 						ParentHologram->AddChild(PassthroughChild, ChildName);
-						
+
 						// Disable validation AFTER AddChild (data structure approach)
 						USFHologramDataService::DisableValidation(PassthroughChild);
 						USFHologramDataService::MarkAsChild(PassthroughChild, ParentHologram, ESFChildHologramType::ScalingGrid);
-						
+
 						// Configure visibility
 						if (PassthroughChild->IsHologramLocked())
 						{
@@ -444,7 +444,7 @@ void FSFHologramHelperService::RegenerateChildHologramGrid(
 						}
 						PassthroughChild->SetActorHiddenInGame(false);
 						PassthroughChild->SetActorEnableCollision(false);
-						
+
 						// Disable collision on ALL primitive components (not just BoxComponents)
 						TArray<UPrimitiveComponent*> Primitives;
 						PassthroughChild->GetComponents<UPrimitiveComponent>(Primitives);
@@ -452,14 +452,14 @@ void FSFHologramHelperService::RegenerateChildHologramGrid(
 						{
 							PrimComp->SetCollisionEnabled(ECollisionEnabled::NoCollision);
 						}
-						
+
 						// Disable tick to prevent validation from running
 						PassthroughChild->SetActorTickEnabled(false);
 						PassthroughChild->RegisterAllComponents();
 						PassthroughChild->SetPlacementMaterialState(EHologramMaterialState::HMS_OK);
-						
+
 						PassthroughChild->Tags.AddUnique(FName(TEXT("SF_GridChild")));
-						
+
 						// Issue #187: Propagate parent's foundation thickness to child.
 						// mSnappedBuildingThickness is protected, so read via UE reflection.
 						// Without this, children default to 200cm (shortest) instead of matching
@@ -471,8 +471,8 @@ void FSFHologramHelperService::RegenerateChildHologramGrid(
 							float ParentThickness = ThickProp->GetPropertyValue_InContainer(ParentHologram);
 							PassthroughChild->SetSnappedThickness(ParentThickness);
 						}
-						
-						UE_LOG(LogSmartFoundations, Log, TEXT("  PASSTHROUGH: Spawned child %s at %s (recipe=%s, buildClass=%s)"),
+
+						UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("  PASSTHROUGH: Spawned child %s at %s (recipe=%s, buildClass=%s)"),
 							*ChildName.ToString(), *SpawnLocation.ToString(),
 							*Recipe->GetName(), *ParentHologram->GetBuildClass()->GetName());
 					}
@@ -491,43 +491,43 @@ void FSFHologramHelperService::RegenerateChildHologramGrid(
 					SpawnParams.Owner = ParentHologram->GetOwner();
 					SpawnParams.SpawnCollisionHandlingOverride = ESpawnActorCollisionHandlingMethod::AlwaysSpawn;
 					SpawnParams.bDeferConstruction = true;
-					
+
 					ASFBuildableChildHologram* BuildableChild = SpawnWorld->SpawnActor<ASFBuildableChildHologram>(
 						ASFBuildableChildHologram::StaticClass(),
 						SpawnLocation,
 						FRotator::ZeroRotator,
 						SpawnParams);
-					
+
 					if (BuildableChild)
 					{
 						BuildableChild->SetChildBuildClass(ParentHologram->GetBuildClass());
 						BuildableChild->SetRecipe(Recipe);
 						BuildableChild->FinishSpawning(FTransform(FRotator::ZeroRotator, SpawnLocation));
 						ParentHologram->AddChild(BuildableChild, ChildName);
-						
+
 						USFHologramDataService::DisableValidation(BuildableChild);
 						USFHologramDataService::MarkAsChild(BuildableChild, ParentHologram, ESFChildHologramType::ScalingGrid);
-						
+
 						if (BuildableChild->IsHologramLocked())
 						{
 							BuildableChild->LockHologramPosition(false);
 						}
 						BuildableChild->SetActorHiddenInGame(false);
 						BuildableChild->SetActorEnableCollision(false);
-						
+
 						TArray<UPrimitiveComponent*> Primitives;
 						BuildableChild->GetComponents<UPrimitiveComponent>(Primitives);
 						for (UPrimitiveComponent* PrimComp : Primitives)
 						{
 							PrimComp->SetCollisionEnabled(ECollisionEnabled::NoCollision);
 						}
-						
+
 						BuildableChild->SetActorTickEnabled(false);
 						BuildableChild->RegisterAllComponents();
 						BuildableChild->SetPlacementMaterialState(EHologramMaterialState::HMS_OK);
 						BuildableChild->Tags.AddUnique(FName(TEXT("SF_GridChild")));
-						
-						UE_LOG(LogSmartFoundations, Log, TEXT("  BUILDABLE CHILD: Spawned %s at %s (recipe=%s, buildClass=%s)"),
+
+						UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("  BUILDABLE CHILD: Spawned %s at %s (recipe=%s, buildClass=%s)"),
 							*ChildName.ToString(), *SpawnLocation.ToString(),
 							*Recipe->GetName(), *ParentHologram->GetBuildClass()->GetName());
 					}
@@ -547,43 +547,43 @@ void FSFHologramHelperService::RegenerateChildHologramGrid(
 					SpawnParams.Owner = ParentHologram->GetOwner();
 					SpawnParams.SpawnCollisionHandlingOverride = ESpawnActorCollisionHandlingMethod::AlwaysSpawn;
 					SpawnParams.bDeferConstruction = true;
-					
+
 					ASFFloodlightChildHologram* FloodlightChild = SpawnWorld->SpawnActor<ASFFloodlightChildHologram>(
 						ASFFloodlightChildHologram::StaticClass(),
 						SpawnLocation,
 						FRotator::ZeroRotator,
 						SpawnParams);
-					
+
 					if (FloodlightChild)
 					{
 						FloodlightChild->SetChildBuildClass(ParentHologram->GetBuildClass());
 						FloodlightChild->SetRecipe(Recipe);
 						FloodlightChild->FinishSpawning(FTransform(FRotator::ZeroRotator, SpawnLocation));
 						ParentHologram->AddChild(FloodlightChild, ChildName);
-						
+
 						USFHologramDataService::DisableValidation(FloodlightChild);
 						USFHologramDataService::MarkAsChild(FloodlightChild, ParentHologram, ESFChildHologramType::ScalingGrid);
-						
+
 						if (FloodlightChild->IsHologramLocked())
 						{
 							FloodlightChild->LockHologramPosition(false);
 						}
 						FloodlightChild->SetActorHiddenInGame(false);
 						FloodlightChild->SetActorEnableCollision(false);
-						
+
 						TArray<UPrimitiveComponent*> Primitives;
 						FloodlightChild->GetComponents<UPrimitiveComponent>(Primitives);
 						for (UPrimitiveComponent* PrimComp : Primitives)
 						{
 							PrimComp->SetCollisionEnabled(ECollisionEnabled::NoCollision);
 						}
-						
+
 						FloodlightChild->SetActorTickEnabled(false);
 						FloodlightChild->RegisterAllComponents();
 						FloodlightChild->SetPlacementMaterialState(EHologramMaterialState::HMS_OK);
 						FloodlightChild->Tags.AddUnique(FName(TEXT("SF_GridChild")));
-						
-						UE_LOG(LogSmartFoundations, Log, TEXT("  FLOODLIGHT CHILD: Spawned %s at %s (recipe=%s, buildClass=%s)"),
+
+						UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("  FLOODLIGHT CHILD: Spawned %s at %s (recipe=%s, buildClass=%s)"),
 							*ChildName.ToString(), *SpawnLocation.ToString(),
 							*Recipe->GetName(), *ParentHologram->GetBuildClass()->GetName());
 					}
@@ -603,19 +603,19 @@ void FSFHologramHelperService::RegenerateChildHologramGrid(
 					SpawnParams.Owner = ParentHologram->GetOwner();
 					SpawnParams.SpawnCollisionHandlingOverride = ESpawnActorCollisionHandlingMethod::AlwaysSpawn;
 					SpawnParams.bDeferConstruction = true;
-					
+
 					ASFStandaloneSignChildHologram* SignChild = SpawnWorld->SpawnActor<ASFStandaloneSignChildHologram>(
 						ASFStandaloneSignChildHologram::StaticClass(),
 						SpawnLocation,
 						FRotator::ZeroRotator,
 						SpawnParams);
-					
+
 					if (SignChild)
 					{
 						SignChild->SetChildBuildClass(ParentHologram->GetBuildClass());
 						SignChild->SetRecipe(Recipe);
 						SignChild->FinishSpawning(FTransform(FRotator::ZeroRotator, SpawnLocation));
-						
+
 						// Issue #192: Sign pole/stand for children — KNOWN LIMITATION
 						// Children do not get pole holograms. Built buildings also don't get poles
 						// from vanilla's construction system for grid children.
@@ -634,32 +634,32 @@ void FSFHologramHelperService::RegenerateChildHologramGrid(
 						// Future fix: may require a custom sign pole child hologram class
 						// (like ASFFloodlightChildHologram) or post-construction pole spawning
 						// via OnActorSpawned hook.
-						
+
 						ParentHologram->AddChild(SignChild, ChildName);
-						
+
 						USFHologramDataService::DisableValidation(SignChild);
 						USFHologramDataService::MarkAsChild(SignChild, ParentHologram, ESFChildHologramType::ScalingGrid);
-						
+
 						if (SignChild->IsHologramLocked())
 						{
 							SignChild->LockHologramPosition(false);
 						}
 						SignChild->SetActorHiddenInGame(false);
 						SignChild->SetActorEnableCollision(false);
-						
+
 						TArray<UPrimitiveComponent*> Primitives;
 						SignChild->GetComponents<UPrimitiveComponent>(Primitives);
 						for (UPrimitiveComponent* PrimComp : Primitives)
 						{
 							PrimComp->SetCollisionEnabled(ECollisionEnabled::NoCollision);
 						}
-						
+
 						SignChild->SetActorTickEnabled(false);
 						SignChild->RegisterAllComponents();
 						SignChild->SetPlacementMaterialState(EHologramMaterialState::HMS_OK);
 						SignChild->Tags.AddUnique(FName(TEXT("SF_GridChild")));
-						
-						UE_LOG(LogSmartFoundations, Log, TEXT("  SIGN CHILD: Spawned %s at %s (recipe=%s, buildClass=%s)"),
+
+						UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("  SIGN CHILD: Spawned %s at %s (recipe=%s, buildClass=%s)"),
 							*ChildName.ToString(), *SpawnLocation.ToString(),
 							*Recipe->GetName(), *ParentHologram->GetBuildClass()->GetName());
 					}
@@ -679,43 +679,43 @@ void FSFHologramHelperService::RegenerateChildHologramGrid(
 					SpawnParams.Owner = ParentHologram->GetOwner();
 					SpawnParams.SpawnCollisionHandlingOverride = ESpawnActorCollisionHandlingMethod::AlwaysSpawn;
 					SpawnParams.bDeferConstruction = true;
-					
+
 					ASFBuildableChildHologram* BuildableChild = SpawnWorld->SpawnActor<ASFBuildableChildHologram>(
 						ASFBuildableChildHologram::StaticClass(),
 						SpawnLocation,
 						FRotator::ZeroRotator,
 						SpawnParams);
-					
+
 					if (BuildableChild)
 					{
 						BuildableChild->SetChildBuildClass(ParentHologram->GetBuildClass());
 						BuildableChild->SetRecipe(Recipe);
 						BuildableChild->FinishSpawning(FTransform(FRotator::ZeroRotator, SpawnLocation));
 						ParentHologram->AddChild(BuildableChild, ChildName);
-						
+
 						USFHologramDataService::DisableValidation(BuildableChild);
 						USFHologramDataService::MarkAsChild(BuildableChild, ParentHologram, ESFChildHologramType::ScalingGrid);
-						
+
 						if (BuildableChild->IsHologramLocked())
 						{
 							BuildableChild->LockHologramPosition(false);
 						}
 						BuildableChild->SetActorHiddenInGame(false);
 						BuildableChild->SetActorEnableCollision(false);
-						
+
 						TArray<UPrimitiveComponent*> Primitives;
 						BuildableChild->GetComponents<UPrimitiveComponent>(Primitives);
 						for (UPrimitiveComponent* PrimComp : Primitives)
 						{
 							PrimComp->SetCollisionEnabled(ECollisionEnabled::NoCollision);
 						}
-						
+
 						BuildableChild->SetActorTickEnabled(false);
 						BuildableChild->RegisterAllComponents();
 						BuildableChild->SetPlacementMaterialState(EHologramMaterialState::HMS_OK);
 						BuildableChild->Tags.AddUnique(FName(TEXT("SF_GridChild")));
-						
-						UE_LOG(LogSmartFoundations, Log, TEXT("  WALL ATTACHMENT CHILD: Spawned %s at %s (recipe=%s, buildClass=%s)"),
+
+						UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("  WALL ATTACHMENT CHILD: Spawned %s at %s (recipe=%s, buildClass=%s)"),
 							*ChildName.ToString(), *SpawnLocation.ToString(),
 							*Recipe->GetName(), *ParentHologram->GetBuildClass()->GetName());
 					}
@@ -737,43 +737,43 @@ void FSFHologramHelperService::RegenerateChildHologramGrid(
 					SpawnParams.Owner = ParentHologram->GetOwner();
 					SpawnParams.SpawnCollisionHandlingOverride = ESpawnActorCollisionHandlingMethod::AlwaysSpawn;
 					SpawnParams.bDeferConstruction = true;
-					
+
 					ASFWaterPumpChildHologram* WaterPumpChild = SpawnWorld->SpawnActor<ASFWaterPumpChildHologram>(
 						ASFWaterPumpChildHologram::StaticClass(),
 						SpawnLocation,
 						FRotator::ZeroRotator,
 						SpawnParams);
-					
+
 					if (WaterPumpChild)
 					{
 						WaterPumpChild->SetChildBuildClass(ParentHologram->GetBuildClass());
 						WaterPumpChild->SetRecipe(Recipe);
 						WaterPumpChild->FinishSpawning(FTransform(FRotator::ZeroRotator, SpawnLocation));
 						ParentHologram->AddChild(WaterPumpChild, ChildName);
-						
+
 						// DO NOT call DisableValidation — we WANT CheckValidPlacement() to run
 						USFHologramDataService::MarkAsChild(WaterPumpChild, ParentHologram, ESFChildHologramType::ScalingGrid);
-						
+
 						if (WaterPumpChild->IsHologramLocked())
 						{
 							WaterPumpChild->LockHologramPosition(false);
 						}
 						WaterPumpChild->SetActorHiddenInGame(false);
 						WaterPumpChild->SetActorEnableCollision(false);
-						
+
 						TArray<UPrimitiveComponent*> Primitives;
 						WaterPumpChild->GetComponents<UPrimitiveComponent>(Primitives);
 						for (UPrimitiveComponent* PrimComp : Primitives)
 						{
 							PrimComp->SetCollisionEnabled(ECollisionEnabled::NoCollision);
 						}
-						
+
 						// DO NOT disable tick — CheckValidPlacement() must run per-frame for water validation
 						WaterPumpChild->RegisterAllComponents();
 						// DO NOT force HMS_OK — let CheckValidPlacement() determine material state
 						WaterPumpChild->Tags.AddUnique(FName(TEXT("SF_GridChild")));
-						
-						UE_LOG(LogSmartFoundations, Log, TEXT("  WATER PUMP CHILD: Spawned %s at %s (recipe=%s, buildClass=%s)"),
+
+						UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("  WATER PUMP CHILD: Spawned %s at %s (recipe=%s, buildClass=%s)"),
 							*ChildName.ToString(), *SpawnLocation.ToString(),
 							*Recipe->GetName(), *ParentHologram->GetBuildClass()->GetName());
 					}
@@ -785,7 +785,7 @@ void FSFHologramHelperService::RegenerateChildHologramGrid(
 				// Normal spawn for non-passthrough holograms
 				ChildHologram = SpawnChildHologram(ParentHologram, ChildName, SpawnLocation, FRotator::ZeroRotator);
 			}
-			
+
 			if (ChildHologram)
 			{
 				// Issue #187/#200/#197: Passthrough, buildable, and water pump children are fully configured during
@@ -796,7 +796,7 @@ void FSFHologramHelperService::RegenerateChildHologramGrid(
 					|| ParentHologram->IsA(AFGFloodlightHologram::StaticClass())
 					|| ParentHologram->IsA(AFGWallAttachmentHologram::StaticClass())
 					|| ParentHologram->IsA(AFGWaterPumpHologram::StaticClass());
-				
+
 				if (!bIsCustomChild)
 				{
 					// Tag for Smart! ownership to aid future resync/cleanup
@@ -808,7 +808,7 @@ void FSFHologramHelperService::RegenerateChildHologramGrid(
 					// Force components to register and become visible
 					ChildHologram->RegisterAllComponents();
 				}
-				
+
 				// Phase 4 CRITICAL FIX: Disable ticking for locked children to eliminate per-frame validation overhead
 				// With 3000+ children, per-frame Tick() causes FPS to drop from 60 to 3-4 FPS
 				// Locked holograms don't need validation, so we can safely disable their tick
@@ -816,17 +816,17 @@ void FSFHologramHelperService::RegenerateChildHologramGrid(
 				{
 					ChildHologram->SetActorTickEnabled(false);
 				}
-				
+
 				SpawnedChildren.Add(ChildHologram);
-				
+
 				// Log child hologram lock state for Task 38 diagnostics
 				const bool bChildLocked = ChildHologram->IsHologramLocked();
 				const bool bChildCanLock = ChildHologram->CanLockHologram();
-				
+
 				if (bIsWaterExtractor)
 				{
-					UE_LOG(LogSmartFoundations, Display, TEXT("  [WATER EXTRACTOR] Spawned child %s at %s - Type: %s | Parent Locked=%s, Child Locked=%s, Child CanLock=%s"), 
-						*ChildName.ToString(), 
+					UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("  [WATER EXTRACTOR] Spawned child %s at %s - Type: %s | Parent Locked=%s, Child Locked=%s, Child CanLock=%s"),
+						*ChildName.ToString(),
 						*SpawnLocation.ToString(),
 						*ChildHologram->GetClass()->GetName(),
 						bParentLocked ? TEXT("YES") : TEXT("NO"),
@@ -835,7 +835,7 @@ void FSFHologramHelperService::RegenerateChildHologramGrid(
 				}
 				else
 				{
-					UE_LOG(LogSmartFoundations, Verbose, TEXT("  Spawned child %s | Parent Locked=%s, Child Locked=%s, Child CanLock=%s"), 
+					UE_LOG(LogSmartFoundations, Verbose, TEXT("  Spawned child %s | Parent Locked=%s, Child Locked=%s, Child CanLock=%s"),
 						*ChildName.ToString(),
 						bParentLocked ? TEXT("YES") : TEXT("NO"),
 						bChildLocked ? TEXT("YES") : TEXT("NO"),
@@ -847,26 +847,26 @@ void FSFHologramHelperService::RegenerateChildHologramGrid(
 				UE_LOG(LogSmartFoundations, Error, TEXT("  FAILED to spawn child %s!"), *ChildName.ToString());
 			}
 		}
-		
+
 		// PERFORMANCE PROFILING: End spawn tracking
 		FSFHologramPerformanceProfiler::EndSpawnProfile();
-		
+
 		// Log component breakdown for first child to understand overhead
 		if (SpawnedChildren.Num() > 0 && SpawnedChildren[0].IsValid())
 		{
 			FSFHologramPerformanceProfiler::LogHologramComponents(SpawnedChildren[0].Get());
 		}
-		
-		UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("RegenerateChildHologramGrid: Spawned %d children, total now: %d"), 
+
+		UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("RegenerateChildHologramGrid: Spawned %d children, total now: %d"),
 			ToSpawn, SpawnedChildren.Num());
 	}
 	else if (ChildrenNeeded < CurrentChildren)
 	{
 		// Need to remove excess children
 		ToRemove = CurrentChildren - ChildrenNeeded;
-		
+
 		UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("RegenerateChildHologramGrid: Removing %d excess children..."), ToRemove);
-		
+
 		for (int32 i = 0; i < ToRemove; ++i)
 		{
 			if (SpawnedChildren.Num() > 0)
@@ -879,10 +879,10 @@ void FSFHologramHelperService::RegenerateChildHologramGrid(
 				}
 			}
 		}
-		
-		UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("RegenerateChildHologramGrid: Removed %d children, total now: %d"), 
+
+		UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("RegenerateChildHologramGrid: Removed %d children, total now: %d"),
 			ToRemove, SpawnedChildren.Num());
-		
+
 		// Clean up cached belt costs for removed children and trigger parent HUD update
 		if (USFSubsystem* Subsystem = USFSubsystem::Get(ParentHologram->GetWorld()))
 		{
@@ -897,14 +897,14 @@ void FSFHologramHelperService::RegenerateChildHologramGrid(
 						AutoConnect->ClearBeltCostsForDistributor(RemovedChild.Get());
 					}
 				}
-				
+
 				// Force parent to re-aggregate costs without the removed children
 				// This updates the HUD to reflect the reduced belt costs
 				if (AFGConveyorAttachmentHologram* ParentDistributor = Cast<AFGConveyorAttachmentHologram>(ParentHologram))
 				{
 					// Trigger re-aggregation by clearing parent's cache and recalculating
 					AutoConnect->ClearBeltCostsForDistributor(ParentDistributor);
-					
+
 					// Re-store belt previews for parent (will aggregate from remaining children)
 					const TArray<TSharedPtr<FBeltPreviewHelper>>* ParentPreviews = AutoConnect->GetBeltPreviews(ParentDistributor);
 					if (ParentPreviews && ParentPreviews->Num() > 0)
@@ -916,13 +916,13 @@ void FSFHologramHelperService::RegenerateChildHologramGrid(
 						// and causes crashes (Access Violation) if the map reallocates or invalidates the reference.
 						TArray<TSharedPtr<FBeltPreviewHelper>> PreviewsCopy = *ParentPreviews;
 						AutoConnect->StoreBeltPreviews(ParentDistributor, PreviewsCopy);
-						UE_LOG(LogSmartFoundations, Log, TEXT("   💰 HUD updated: Re-aggregated costs after removing %d children"), ToRemove);
+						UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("   💰 HUD updated: Re-aggregated costs after removing %d children"), ToRemove);
 					}
 				}
 			}
 		}
 	}
-	
+
 	// CRITICAL: Notify orchestrator of grid change (Refactor: Orchestrator)
 	// This triggers full re-evaluation with shared input reservation
 	if (ToSpawn > 0 || ToRemove > 0)
@@ -933,12 +933,12 @@ void FSFHologramHelperService::RegenerateChildHologramGrid(
 			{
 				// Defer orchestration to after children are positioned to avoid evaluating with stale transforms.
 				// GridSpawnerService::RegenerateChildHologramGrid will trigger OnGridChanged() after UpdateChildPositions().
-				UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("   🎯 Orchestrator: Grid changed detected (%d spawned, %d removed) - deferring evaluation until after positioning"), 
+				UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("   🎯 Orchestrator: Grid changed detected (%d spawned, %d removed) - deferring evaluation until after positioning"),
 					ToSpawn, ToRemove);
 			}
 		}
 	}
-	
+
 	// Update positions immediately so build gun validation sees correct state
 	if (UpdateChildPositionsCallback)
 	{
@@ -961,12 +961,12 @@ void FSFHologramHelperService::RegenerateChildHologramGrid(
 					Child->LockHologramPosition(false);
 				}
 				Child->SetActorHiddenInGame(false);
-				
+
 				// Phase 4 FIX: DO NOT re-enable ticking when parent is locked!
 				// Ticking is disabled during spawn (line 306) to eliminate per-frame validation overhead
 				// Re-enabling here would undo the performance fix and cause 3-4 FPS with large grids
 				// Child->SetActorTickEnabled(true);  // REMOVED - causes massive FPS drop
-				
+
 				Child->SetPlacementMaterialState(ParentHologram->GetHologramMaterialState());
 			}
 		}
@@ -1010,7 +1010,7 @@ void FSFHologramHelperService::RegenerateChildHologramGrid(
 			}
 		}
 	}
-	
+
 	// CRITICAL: Update hologram registry recipes for all existing children
 	// This ensures recipe inheritance works correctly when RegenerateChildHologramGrid
 	// is triggered by recipe changes (not just scaling)
@@ -1028,10 +1028,10 @@ void FSFHologramHelperService::RegenerateChildHologramGrid(
 				UpdatedChildren++;
 			}
 		}
-		
+
 		if (UpdatedChildren > 0)
 		{
-			UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("🍽️ Updated hologram registry recipes for %d children with %s"), 
+			UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("🍽️ Updated hologram registry recipes for %d children with %s"),
 				UpdatedChildren, *ParentStoredRecipe->GetName());
 		}
 	}
@@ -1048,10 +1048,10 @@ void FSFHologramHelperService::RegenerateChildHologramGrid(
 				ClearedChildren++;
 			}
 		}
-		
+
 		if (ClearedChildren > 0)
 		{
-			UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("🍽️ Cleared hologram registry recipes for %d children (recipe cleared)"), 
+			UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("🍽️ Cleared hologram registry recipes for %d children (recipe cleared)"),
 				ClearedChildren);
 		}
 	}
@@ -1066,25 +1066,25 @@ void FSFHologramHelperService::ApplyScalingDelta(
 {
 	// Extracted from SFSubsystem::ApplyScalingToHologram (Refactor: Phase 1)
 	// Applies scaling delta and triggers child grid regeneration
-	
+
 	if (!Hologram || !IsValid(Hologram))
 	{
 		UE_LOG(LogSmartFoundations, Warning, TEXT("ApplyScalingDelta: Invalid hologram"));
 		return;
 	}
-	
+
 	// Store old transform for logging
 	const FTransform OldTransform = Hologram->GetTransform();
 	const FVector OldLocation = OldTransform.GetLocation();
-	
+
 	// Update scaling offset (diagnostic tracking only)
 	CurrentScalingOffset += ScalingDelta;
-	
+
 	// Let the Build Gun own the parent transform; only regenerate Smart! children
 	const FVector NewLocation = OldLocation; // unchanged parent location for logging
-	UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("SCALING APPLIED: Delta=%s | Old=%s | New=%s | TotalOffset=%s"), 
+	UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("SCALING APPLIED: Delta=%s | Old=%s | New=%s | TotalOffset=%s"),
 		*ScalingDelta.ToString(), *OldLocation.ToString(), *NewLocation.ToString(), *CurrentScalingOffset.ToString());
-	
+
 	// Trigger child hologram grid regeneration via callback
 	if (RegenerateGridCallback)
 	{
@@ -1096,15 +1096,15 @@ void FSFHologramHelperService::QueueChildForDestroy(AFGHologram* Child)
 {
 	// Extracted from SFSubsystem::QueueChildForDestroy (Phase 2 - Task #61.6)
 	// Deferred destruction to avoid mid-validation invalidation
-	
+
 	if (!Child || !IsValid(Child))
 	{
 		return;
 	}
-	
+
 	// Mark as pending removal for resync filters
 	Child->Tags.AddUnique(FName(TEXT("SF_GridChild_PendingDestroy")));
-	
+
 	// Clean up auto-connect belt previews for this child BEFORE destruction
 	if (USFSubsystem* Subsystem = USFSubsystem::Get(Child->GetWorld()))
 	{
@@ -1113,10 +1113,10 @@ void FSFHologramHelperService::QueueChildForDestroy(AFGHologram* Child)
 			AutoConnectService->CleanupDistributorPreviews(Child);
 		}
 	}
-	
+
 	// Remove from active children tracking
 	SpawnedChildren.Remove(Child);
-	
+
 	// CRITICAL: Remove from parent's mChildren array IMMEDIATELY (not deferred)
 	// This prevents desync between HologramHelper and parent's array
 	// Build Gun iterates parent's array → must stay in sync with our tracking
@@ -1131,9 +1131,9 @@ void FSFHologramHelperService::QueueChildForDestroy(AFGHologram* Child)
 			}
 		}
 	}
-	
+
 	PendingDestroyChildren.AddUnique(Child);
-	
+
 	if (!bPendingDestroyScheduled && WorldContext.IsValid())
 	{
 		bPendingDestroyScheduled = true;
@@ -1151,14 +1151,14 @@ void FSFHologramHelperService::FlushPendingDestroy()
 {
 	// Extracted from SFSubsystem::FlushPendingDestroy (Phase 3 - Task #61.6)
 	// Deferred destruction implementation with partial/full destroy logic
-	
+
 	// PERFORMANCE PROFILING: Track destroy performance
 	const int32 PendingCount = PendingDestroyChildren.Num();
 	if (PendingCount > 0)
 	{
 		FSFHologramPerformanceProfiler::BeginDestroyProfile("FlushPendingDestroy", PendingCount);
 	}
-	
+
 	const UWorld* World = WorldContext.IsValid() ? WorldContext.Get() : nullptr;
 	const double TS = World ? World->GetTimeSeconds() : 0.0;
 	int32 DestroyedCount = 0;
@@ -1180,7 +1180,7 @@ void FSFHologramHelperService::FlushPendingDestroy()
 		{
 			UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("[Frame=%llu t=%.3f] Destroying queued child: %s"),
 				(unsigned long long)GFrameCounter, TS, *H->GetName());
-			
+
 			// NOTE: Child already removed from parent's mChildren in QueueChildForDestroy
 			// This Remove call is redundant but harmless (TArray::Remove handles not-found gracefully)
 			// Kept for safety in case child was added back to parent's array somehow
@@ -1195,7 +1195,7 @@ void FSFHologramHelperService::FlushPendingDestroy()
 					}
 				}
 			}
-			
+
 			H->Destroy();
 			DestroyedCount++;
 			PendingDestroyChildren.RemoveAtSwap(i);
@@ -1217,15 +1217,15 @@ void FSFHologramHelperService::FlushPendingDestroy()
 	}
 	if (DeferredCount > 0)
 	{
-		UE_LOG(LogSmartFoundations, Log, TEXT("Deferred destroys due to active hologram: %d"), DeferredCount);
+		UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("Deferred destroys due to active hologram: %d"), DeferredCount);
 	}
-	
+
 	// PERFORMANCE PROFILING: End destroy tracking
 	if (PendingCount > 0 && DestroyedCount > 0)
 	{
 		FSFHologramPerformanceProfiler::EndDestroyProfile();
 	}
-	
+
 	bPendingDestroyScheduled = false;
 	bSuppressChildUpdates = false;
 }
@@ -1234,7 +1234,7 @@ void FSFHologramHelperService::ForceDestroyPendingChildren()
 {
 	// Extracted from SFSubsystem::ForceDestroyPendingChildren (Phase 3 - Task #61.6)
 	// Emergency force-destroy when can't defer anymore
-	
+
 	const UWorld* World = WorldContext.IsValid() ? WorldContext.Get() : nullptr;
 	const double TS = World ? World->GetTimeSeconds() : 0.0;
 	int32 DestroyedCount = 0;
@@ -1248,9 +1248,9 @@ void FSFHologramHelperService::ForceDestroyPendingChildren()
 			continue;
 		}
 		AFGHologram* H = Entry.Get();
-		UE_LOG(LogSmartFoundations, Log, TEXT("[Frame=%llu t=%.3f] Force-destroying pending child: %s"),
+		UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("[Frame=%llu t=%.3f] Force-destroying pending child: %s"),
 			(unsigned long long)GFrameCounter, TS, *H->GetName());
-		
+
 		// CRITICAL: Remove from parent's mChildren array before destroying
 		if (AFGHologram* Parent = H->GetParentHologram())
 		{
@@ -1264,14 +1264,14 @@ void FSFHologramHelperService::ForceDestroyPendingChildren()
 				}
 			}
 		}
-		
+
 		H->Destroy();
 		DestroyedCount++;
 		PendingDestroyChildren.RemoveAtSwap(i);
 	}
 	if (DestroyedCount > 0)
 	{
-		UE_LOG(LogSmartFoundations, Log, TEXT("Force destroyed pending children: %d"), DestroyedCount);
+		UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("Force destroyed pending children: %d"), DestroyedCount);
 	}
 	bSuppressChildUpdates = false;
 }
@@ -1292,7 +1292,7 @@ bool FSFHologramHelperService::OnChildHologramDestroyed(AActor* DestroyedActor, 
 {
 	// Extracted from SFSubsystem::OnChildHologramDestroyed (Phase 3 - Task #61.6)
 	// Child destruction callback with mass destruction detection
-	
+
 	AFGHologram* DestroyedHologram = Cast<AFGHologram>(DestroyedActor);
 	if (!DestroyedHologram)
 	{
@@ -1313,21 +1313,21 @@ bool FSFHologramHelperService::OnChildHologramDestroyed(AActor* DestroyedActor, 
 	//
 	// Solution: Set persistent flag on first detection, clear only when all children gone
 	const bool bLargeGridDestruction = SpawnedChildren.Num() >= LARGE_GRID_WARNING_THRESHOLD;
-	
+
 	// Detect start of mass destruction
 	if (bLargeGridDestruction && !bInMassDestruction)
 	{
 		bInMassDestruction = true;
 		UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("Mass destruction started (%d children) - suppressing updates until complete"), SpawnedChildren.Num());
 	}
-	
+
 	// Clear flag when all children destroyed
 	if (SpawnedChildren.Num() == 0 && bInMassDestruction)
 	{
 		bInMassDestruction = false;
 		UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("Mass destruction complete - updates re-enabled"));
 	}
-	
+
 	// Suppress updates during entire mass destruction sequence
 	if (!bSuppressChildUpdates && !bInMassDestruction)
 	{
@@ -1337,7 +1337,7 @@ bool FSFHologramHelperService::OnChildHologramDestroyed(AActor* DestroyedActor, 
 			return true; // Callback was invoked
 		}
 	}
-	
+
 	return false; // Callback was not invoked
 }
 
@@ -1345,7 +1345,7 @@ void FSFHologramHelperService::OnParentHologramDestroyed(AActor* DestroyedActor)
 {
 	// Extracted from SFSubsystem::OnParentHologramDestroyed (Phase 3 - Task #61.6)
 	// Parent hologram destruction cleanup
-	
+
 	AFGHologram* DestroyedHologram = Cast<AFGHologram>(DestroyedActor);
 	if (!DestroyedHologram)
 	{
@@ -1355,44 +1355,44 @@ void FSFHologramHelperService::OnParentHologramDestroyed(AActor* DestroyedActor)
 	// If the destroyed hologram is our active hologram, clean up
 	if (ActiveHologram.Get() == DestroyedHologram)
 	{
-		UE_LOG(LogSmartFoundations, Log, TEXT("Parent hologram destroyed (building placed): %s - Clearing children"), 
+		UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("Parent hologram destroyed (building placed): %s - Clearing children"),
 			*DestroyedHologram->GetName());
-		
+
 		// ========================================
 		// Recipe Application System - Apply stored recipes to all constructed buildings
 		// ========================================
-		
+
 		// TODO: Building registration needs to happen in ConfigureActor() override
 		// See original Smart: ASFFactoryHologram::ConfigureActor stores inBuildable reference
 		// For now, we're missing building references so recipe application won't work yet
-		// 
+		//
 		// Next steps:
 		// 1. Create custom hologram classes (e.g., ASFFactoryHologram)
 		// 2. Override ConfigureActor() to call Subsystem->RegisterSmartBuilding(inBuildable, Index, bIsParent)
 		// 3. This hook will capture building references as they're constructed
 		// 4. Then ApplyRecipesToCurrentPlacement() will work correctly
-		
+
 		USFSubsystem* Subsystem = USFSubsystem::Get(DestroyedHologram->GetWorld());
 		if (Subsystem && Subsystem->bHasStoredProductionRecipe)
 		{
-			UE_LOG(LogSmartFoundations, Log, 
+			UE_LOG(LogSmartFoundations, VeryVerbose,
 				TEXT("RECIPE APPLICATION: Parent hologram destroyed - attempting to apply recipes to placement group %d"),
 				Subsystem->CurrentPlacementGroupID);
-			
+
 			// Apply recipes to all buildings registered during this placement
 			Subsystem->ApplyRecipesToCurrentPlacement();
 		}
-		
+
 		// CRITICAL: Suppress updates during cleanup to prevent UObject exhaustion
 		bSuppressChildUpdates = true;
-		
+
 		// Clean up all children without calling UnregisterActiveHologram to avoid accessing destroyed hologram
 		SpawnedChildren.Empty();
-		
+
 		// Re-enable updates and clear mass destruction flag
 		bSuppressChildUpdates = false;
 		bInMassDestruction = false;
-		
+
 		ActiveHologram.Reset();
 	}
 }
@@ -1408,7 +1408,7 @@ void FSFHologramHelperService::UpdateChildrenForParentTransform(
 {
 	// Extracted from SFSubsystem::UpdateChildrenForCurrentTransform (Phase 3 - Task #61.6)
 	// Transform change detection and child update coordination
-	
+
 	if (!ParentHologram || !IsValid(ParentHologram))
 	{
 		return;
@@ -1417,10 +1417,10 @@ void FSFHologramHelperService::UpdateChildrenForParentTransform(
 	const float DeltaZ = NewTransform.GetLocation().Z - OldTransform.GetLocation().Z;
 	const float CurrentHeight = NewTransform.GetLocation().Z;
 	const float DeltaFromBaseline = CurrentHeight - BaselineHeightZ;
-	
+
 	// Check if parent has nudge offset (vanilla vertical nudge system)
 	const FVector ParentNudgeOffset = ParentHologram->GetHologramNudgeOffset();
-	
+
 	// CRITICAL FIX: Clean up invalid children before counting/repositioning
 	// Optimization passes left stale weak pointers in SpawnedChildren array
 	// This caused "2 total → 0 active (removed 0 disabled, 2 invalid)" filtering
@@ -1430,29 +1430,29 @@ void FSFHologramHelperService::UpdateChildrenForParentTransform(
 		return !Child.IsValid() || (Child.IsValid() && Child->IsDisabled());
 	});
 	int32 AfterCleanup = SpawnedChildren.Num();
-	
+
 	if (BeforeCleanup != AfterCleanup)
 	{
-		UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("   Cleaned up stale children: %d → %d valid"), 
+		UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("   Cleaned up stale children: %d → %d valid"),
 			BeforeCleanup, AfterCleanup);
 	}
-	
+
 	// Only log transform changes with meaningful movement (>1cm threshold) for tester diagnostics
 	// Prevents log spam from sub-centimeter floating point drift
 	const bool bMeaningfulChange = FMath::Abs(DeltaZ) > 1.0f || FMath::Abs(DeltaFromBaseline) > 1.0f;
-	
+
 	if (bMeaningfulChange)
 	{
-		UE_LOG(LogSmartFoundations, Log, TEXT("🔄 PARENT NUDGED: DeltaZ=%.1f cm, Baseline=%.1f cm, Children=%d"), 
+		UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("🔄 PARENT NUDGED: DeltaZ=%.1f cm, Baseline=%.1f cm, Children=%d"),
 			DeltaZ, DeltaFromBaseline, AfterCleanup);
-		
+
 		// CRITICAL: Update belt previews during parent movement for dynamic tracking
 		// Belt previews need to update their spline endpoints as parent hologram moves
 		if (USFSubsystem* Subsystem = USFSubsystem::Get(ParentHologram->GetWorld()))
 		{
 			Subsystem->OnDistributorHologramUpdated(ParentHologram);
 		}
-		
+
 		// Pipe previews need to update when junction hologram moves
 		FString ClassName = ParentHologram->GetClass()->GetName();
 		if (ClassName.Contains(TEXT("PipelineJunction")))
@@ -1485,7 +1485,7 @@ void FSFHologramHelperService::UpdateChildrenForParentTransform(
 	{
 		UpdateChildPositionsCallback();
 	}
-	
+
 	// CRITICAL FIX: Validate children after repositioning (Bug: nudge invalidation)
 	// When parent is nudged vertically, children are repositioned but not validated
 	// Build Gun then finds children in "invalid" state → "Surface is too uneven" error
@@ -1504,14 +1504,14 @@ void FSFHologramHelperService::UpdateChildrenForParentTransform(
 TSharedPtr<ISFHologramAdapter> FSFHologramHelperService::CreateHologramAdapter(AFGHologram* Hologram)
 {
 	// TODO: Extract from SFSubsystem::CreateHologramAdapter
-	
+
 	if (!Hologram || !IsValid(Hologram))
 	{
 		return nullptr;
 	}
-	
+
 	// Factory pattern: detect hologram type and create appropriate adapter
-	
+
 	if (Cast<AFGFoundationHologram>(Hologram))
 	{
 		return TSharedPtr<ISFHologramAdapter>(MakeShared<FSFGenericAdapter>(Hologram, TEXT("Foundation")));
@@ -1578,7 +1578,7 @@ TSharedPtr<ISFHologramAdapter> FSFHologramHelperService::CreateHologramAdapter(A
 		FString TypeName = Hologram->GetClass()->GetName();
 		return TSharedPtr<ISFHologramAdapter>(MakeShared<FSFUnsupportedAdapter>(Hologram, TypeName));
 	}
-	
+
 	// Default: unsupported
 	FString TypeName = Hologram->GetClass()->GetName();
 	return TSharedPtr<ISFHologramAdapter>(MakeShared<FSFUnsupportedAdapter>(Hologram, TypeName));
@@ -1598,12 +1598,12 @@ bool FSFHologramHelperService::TemporarilyUnlockChild(AFGHologram* ChildHologram
 	// CRITICAL FIX for UObject exhaustion: Skip locking during mass updates
 	// LockHologramPosition() creates UI widgets. With 700+ children, each lock
 	// creates widgets, hitting UObject limit. Only lock when not suppressed.
-	
+
 	if (!ChildHologram || !IsValid(ChildHologram))
 	{
 		return false;
 	}
-	
+
 	// Only unlock if:
 	// 1. Parent is locked (lock state needs management)
 	// 2. Child updates not suppressed (avoid UI widget creation)
@@ -1613,7 +1613,7 @@ bool FSFHologramHelperService::TemporarilyUnlockChild(AFGHologram* ChildHologram
 		ChildHologram->LockHologramPosition(false);
 		return true;  // Unlocked - needs restore later
 	}
-	
+
 	return false;  // Not unlocked - no restore needed
 }
 
@@ -1621,12 +1621,12 @@ void FSFHologramHelperService::RestoreChildLock(AFGHologram* ChildHologram, bool
 {
 	// Extracted from SFSubsystem.cpp lines 2113-2117 (Phase 1 extraction)
 	// Restore lock state if parent is locked (skip if suppressed)
-	
+
 	if (!ChildHologram || !IsValid(ChildHologram))
 	{
 		return;
 	}
-	
+
 	// CRITICAL FIX: Children MUST match parent's lock state for visibility.
 	// Empirical testing shows Satisfactory hides children whose lock state differs from
 	// their parent. Do not remove this call unless the engine behavior changes and the
@@ -1652,11 +1652,11 @@ void FSFHologramHelperService::BeginRepositionChildren()
 	// Suppress cascading validation during batch reposition to eliminate O(n²) scaling
 	// Each child's SetActorLocation/Rotation would normally trigger validation cascades
 	// By setting this flag, we signal that validation should be deferred until batch complete
-	
+
 	bInBatchReposition = true;
 	BatchRepositionStartTime = FPlatformTime::Seconds();
-	
-	UE_LOG(LogSmartFoundations, Log, TEXT("🔒 BeginRepositionChildren: Transform guard ENABLED"));
+
+	UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("🔒 BeginRepositionChildren: Transform guard ENABLED"));
 }
 
 void FSFHologramHelperService::EndRepositionChildren()
@@ -1664,20 +1664,20 @@ void FSFHologramHelperService::EndRepositionChildren()
 	// Phase 2 Performance Optimization: Transform-Ignore Guard
 	// Restore normal transform behavior after batch complete
 	// Log elapsed time for performance profiling
-	
+
 	if (!bInBatchReposition)
 	{
 		UE_LOG(LogSmartFoundations, Warning, TEXT("EndRepositionChildren called without matching Begin"));
 		return;
 	}
-	
+
 	const double ElapsedSeconds = FPlatformTime::Seconds() - BatchRepositionStartTime;
 	const double ElapsedMs = ElapsedSeconds * 1000.0;
-	
+
 	bInBatchReposition = false;
 	BatchRepositionStartTime = 0.0;
-	
-	UE_LOG(LogSmartFoundations, Log, TEXT("🔓 EndRepositionChildren: Transform guard DISABLED (elapsed: %.2f ms)"), ElapsedMs);
+
+	UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("🔓 EndRepositionChildren: Transform guard DISABLED (elapsed: %.2f ms)"), ElapsedMs);
 }
 
 // ========================================
@@ -1694,14 +1694,14 @@ void FSFHologramHelperService::BeginProgressiveBatchReposition(
 	// Phase 4 Performance Optimization: Progressive Batching
 	// Spread child positioning across multiple frames to eliminate freezes
 	// Process 200 children per frame to maintain 60 FPS
-	
+
 	// Cancel any existing batch
 	if (bProgressiveBatchActive)
 	{
 		UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("BeginProgressiveBatchReposition: Cancelling existing batch"));
 		CancelProgressiveBatchReposition();
 	}
-	
+
 	// Initialize batch state
 	BatchState.Reset();
 	BatchState.GridIndices = GridIndices;
@@ -1712,12 +1712,12 @@ void FSFHologramHelperService::BeginProgressiveBatchReposition(
 	BatchState.ParentHologram = ParentHologram;
 	BatchState.StartTime = FPlatformTime::Seconds();
 	BatchState.FrameCount = 0;
-	
+
 	bProgressiveBatchActive = true;
-	
-	UE_LOG(LogSmartFoundations, Verbose, 
+
+	UE_LOG(LogSmartFoundations, Verbose,
 		TEXT("🔄 BeginProgressiveBatchReposition: %d children, %d per frame (est. %d frames)"),
-		BatchState.TotalChildren, 
+		BatchState.TotalChildren,
 		BatchState.ChildrenPerFrame,
 		FMath::CeilToInt((float)BatchState.TotalChildren / BatchState.ChildrenPerFrame));
 }
@@ -1726,29 +1726,29 @@ void FSFHologramHelperService::TickProgressiveBatchReposition(float DeltaTime)
 {
 	// Phase 4 Performance Optimization: Progressive Batching
 	// Process one batch of children per frame
-	
+
 	if (!bProgressiveBatchActive)
 	{
 		return;
 	}
-	
+
 	// Validate parent hologram still exists
 	if (!BatchState.ParentHologram.IsValid())
 	{
-		UE_LOG(LogSmartFoundations, Warning, 
+		UE_LOG(LogSmartFoundations, Warning,
 			TEXT("TickProgressiveBatchReposition: Parent hologram destroyed, cancelling batch"));
 		CancelProgressiveBatchReposition();
 		return;
 	}
-	
+
 	BatchState.FrameCount++;
-	
+
 	const int32 StartIndex = BatchState.CurrentIndex;
 	const int32 EndIndex = FMath::Min(
 		StartIndex + BatchState.ChildrenPerFrame,
 		BatchState.TotalChildren
 	);
-	
+
 	// Process this frame's batch
 	for (int32 i = StartIndex; i < EndIndex; ++i)
 	{
@@ -1757,15 +1757,15 @@ void FSFHologramHelperService::TickProgressiveBatchReposition(float DeltaTime)
 			BatchState.UpdateCallback(i);
 		}
 	}
-	
+
 	BatchState.CurrentIndex = EndIndex;
-	
+
 	// Log progress (verbose to avoid spam)
 	const float Progress = (float)EndIndex / BatchState.TotalChildren * 100.0f;
 	UE_LOG(LogSmartFoundations, Verbose,
 		TEXT("  📊 Batch Frame %d: Positioned %d-%d/%d (%.1f%%)"),
 		BatchState.FrameCount, StartIndex, EndIndex, BatchState.TotalChildren, Progress);
-	
+
 	// Check if batch complete
 	if (BatchState.CurrentIndex >= BatchState.TotalChildren)
 	{
@@ -1777,16 +1777,16 @@ void FSFHologramHelperService::CancelProgressiveBatchReposition()
 {
 	// Phase 4 Performance Optimization: Progressive Batching
 	// Cancel batch operation (parent destroyed or error)
-	
+
 	if (!bProgressiveBatchActive)
 	{
 		return;
 	}
-	
+
 	UE_LOG(LogSmartFoundations, VeryVerbose,
 		TEXT("❌ ProgressiveBatchReposition CANCELLED at %d/%d children (frame %d)"),
 		BatchState.CurrentIndex, BatchState.TotalChildren, BatchState.FrameCount);
-	
+
 	bProgressiveBatchActive = false;
 	BatchState.Reset();
 }
@@ -1795,22 +1795,22 @@ void FSFHologramHelperService::CompleteBatchReposition()
 {
 	// Phase 4 Performance Optimization: Progressive Batching
 	// Batch complete - log results and fire completion callback
-	
+
 	const double ElapsedSeconds = FPlatformTime::Seconds() - BatchState.StartTime;
 	const double ElapsedMs = ElapsedSeconds * 1000.0;
 	const double MsPerFrame = BatchState.FrameCount > 0 ? ElapsedMs / BatchState.FrameCount : 0.0;
 	const double MsPerChild = BatchState.TotalChildren > 0 ? ElapsedMs / BatchState.TotalChildren : 0.0;
-	
+
 	UE_LOG(LogSmartFoundations, VeryVerbose,
 		TEXT("✅ ProgressiveBatchReposition COMPLETE: %d children in %.2f ms across %d frames (%.2f ms/frame avg, %.3f ms/child)"),
 		BatchState.TotalChildren, ElapsedMs, BatchState.FrameCount, MsPerFrame, MsPerChild);
-	
+
 	// Fire completion callback
 	if (BatchState.CompletionCallback)
 	{
 		BatchState.CompletionCallback();
 	}
-	
+
 	// Cleanup
 	bProgressiveBatchActive = false;
 	BatchState.Reset();
@@ -1820,12 +1820,12 @@ float FSFHologramHelperService::GetProgressiveBatchProgress() const
 {
 	// Phase 4 Performance Optimization: Progressive Batching
 	// Return progress from 0.0 to 1.0
-	
+
 	if (!bProgressiveBatchActive || BatchState.TotalChildren == 0)
 	{
 		return 0.0f;
 	}
-	
+
 	return (float)BatchState.CurrentIndex / BatchState.TotalChildren;
 }
 
@@ -1833,7 +1833,7 @@ const FSFHologramHelperService::FGridIndex& FSFHologramHelperService::GetBatchGr
 {
 	// Phase 4 Performance Optimization: Progressive Batching
 	// Access grid index during batch callback
-	
+
 	check(IndexInBatch >= 0 && IndexInBatch < BatchState.GridIndices.Num());
 	return BatchState.GridIndices[IndexInBatch];
 }
@@ -1847,21 +1847,21 @@ FSFHologramHelperService::EUObjectWarningLevel FSFHologramHelperService::CheckUO
 	// Phase 5: Progressive UObject Warning System
 	// Check if we're approaching Unreal Engine's UObject limit
 	// Engine crashes at 2,162,688 UObjects (hardcoded in FChunkedFixedUObjectArray)
-	
+
 	// UObject thresholds (based on crash analysis)
 	const int32 ENGINE_LIMIT = 2162688;
 	const float YELLOW_THRESHOLD = 0.50f;   // 50% headroom used
-	const float ORANGE_THRESHOLD = 0.75f;   // 75% headroom used  
+	const float ORANGE_THRESHOLD = 0.75f;   // 75% headroom used
 	const float RED_THRESHOLD = 0.90f;      // 90% headroom used
 	const float CRITICAL_THRESHOLD = 0.95f; // 95% headroom used
-	
+
 	// Get current UObject count
 	const int32 CurrentUObjects = GUObjectArray.GetObjectArrayNum();
-	
+
 	// Calculate headroom utilization
 	// Note: We assume the game starts with ~200k UObjects, so available headroom is ENGINE_LIMIT - starting count
 	const float Utilization = static_cast<float>(CurrentUObjects) / ENGINE_LIMIT;
-	
+
 	// Determine warning level
 	EUObjectWarningLevel WarningLevel = EUObjectWarningLevel::None;
 	if (Utilization >= CRITICAL_THRESHOLD)
@@ -1880,13 +1880,13 @@ FSFHologramHelperService::EUObjectWarningLevel FSFHologramHelperService::CheckUO
 	{
 		WarningLevel = EUObjectWarningLevel::Yellow;
 	}
-	
+
 	// Only show warning if:
 	// 1. Warning level changed, OR
 	// 2. Grid size increased significantly (50+ children) since last warning
-	const bool bShouldShowWarning = (WarningLevel != CurrentWarningLevel) || 
+	const bool bShouldShowWarning = (WarningLevel != CurrentWarningLevel) ||
 	                                (ChildCount > LastWarningGridSize + 50);
-	
+
 	if (bShouldShowWarning && WarningLevel != EUObjectWarningLevel::None)
 	{
 		// Log warning with appropriate severity
@@ -1897,7 +1897,7 @@ FSFHologramHelperService::EUObjectWarningLevel FSFHologramHelperService::CheckUO
 			CurrentUObjects,
 			Utilization * 100.0f
 		);
-		
+
 		switch (WarningLevel)
 		{
 			case EUObjectWarningLevel::Critical:
@@ -1915,12 +1915,12 @@ FSFHologramHelperService::EUObjectWarningLevel FSFHologramHelperService::CheckUO
 			default:
 				break;
 		}
-		
+
 		// Update tracking state
 		CurrentWarningLevel = WarningLevel;
 		LastWarningGridSize = ChildCount;
 	}
-	
+
 	return WarningLevel;
 }
 
@@ -1967,23 +1967,23 @@ AFGHologram* FSFHologramHelperService::SpawnChildHologram(
 {
 	// Extracted from SFSubsystem::RegenerateChildHologramGrid (Phase 2 - Task #61.6)
 	// Spawn a single child hologram from parent's recipe
-	
+
 	if (!ParentHologram || !IsValid(ParentHologram))
 	{
 		return nullptr;
 	}
-	
+
 	TSubclassOf<UFGRecipe> Recipe = ParentHologram->GetRecipe();
 	if (!Recipe)
 	{
 		return nullptr;
 	}
-	
+
 	AActor* HologramOwner = ParentHologram->GetOwner();
-	
-	UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("SpawnChildHologram: Creating child %s for parent %s"), 
+
+	UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("SpawnChildHologram: Creating child %s for parent %s"),
 		*ChildName.ToString(), *ParentHologram->GetName());
-	
+
 	// ALEX'S ORIGINAL APPROACH: Use vanilla holograms + data structure control
 	// This works reliably - children may appear red but still place correctly
 	AFGHologram* ChildHologram = AFGHologram::SpawnChildHologramFromRecipe(
@@ -1994,19 +1994,19 @@ AFGHologram* FSFHologramHelperService::SpawnChildHologram(
 		Position,                                       // Spawn location
 		nullptr                                         // Callback - not needed
 	);
-	
+
 	if (!ChildHologram)
 	{
-		UE_LOG(LogSmartFoundations, Error, TEXT("SpawnChildHologram: Failed to spawn child from recipe %s"), 
+		UE_LOG(LogSmartFoundations, Error, TEXT("SpawnChildHologram: Failed to spawn child from recipe %s"),
 			*Recipe->GetName());
 		return nullptr;
 	}
-	
+
 	// Apply Smart data structure control to vanilla child
 	// Note: Children may appear red (validation failed) but still place correctly
 	USFHologramDataService::DisableValidation(ChildHologram);
 	USFHologramDataService::MarkAsChild(ChildHologram, ParentHologram, ESFChildHologramType::ScalingGrid);
-	
+
 	// Copy parent's STORED recipe to child (not parent's current recipe)
 	// Get stored recipe from subsystem (where StoreProductionRecipeFromBuilding stores it)
 	USFSubsystem* Subsystem = USFSubsystem::Get(ParentHologram->GetWorld());
@@ -2015,24 +2015,24 @@ AFGHologram* FSFHologramHelperService::SpawnChildHologram(
 	{
 		ParentStoredRecipe = Subsystem->StoredProductionRecipe;
 	}
-	
+
 	if (ParentStoredRecipe)
 	{
 		USFHologramDataService::StoreRecipe(ChildHologram, ParentStoredRecipe);
-		UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("SpawnChildHologram: Copied parent's stored recipe %s to child %s"), 
+		UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("SpawnChildHologram: Copied parent's stored recipe %s to child %s"),
 			*ParentStoredRecipe->GetName(), *ChildHologram->GetName());
 	}
 	else
 	{
 		// Fallback: use parent's current recipe if no stored recipe exists
 		USFHologramDataService::StoreRecipe(ChildHologram, ParentHologram->GetRecipe());
-		UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("SpawnChildHologram: No stored recipe found, used parent's current recipe %s for child %s"), 
+		UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("SpawnChildHologram: No stored recipe found, used parent's current recipe %s for child %s"),
 			*ParentHologram->GetRecipe()->GetName(), *ChildHologram->GetName());
 	}
-	
-	UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("SpawnChildHologram: Created vanilla child %s with data structure control"), 
+
+	UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("SpawnChildHologram: Created vanilla child %s with data structure control"),
 		*ChildName.ToString());
-	
+
 	// Final check: Log material state before returning
 	if (ChildHologram)
 	{
@@ -2040,27 +2040,27 @@ AFGHologram* FSFHologramHelperService::SpawnChildHologram(
 		const TCHAR* FinalStateStr = (FinalState == EHologramMaterialState::HMS_OK) ? TEXT("OK") :
 		                            (FinalState == EHologramMaterialState::HMS_WARNING) ? TEXT("WARNING") :
 		                            TEXT("ERROR");
-		UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("SpawnChildHologram: Final material state for child %s: %s"), 
+		UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("SpawnChildHologram: Final material state for child %s: %s"),
 			*ChildHologram->GetName(), FinalStateStr);
 	}
-	
+
 	return ChildHologram;
 }
 
 void FSFHologramHelperService::DestroyAllChildren()
 {
 	bSuppressChildUpdates = true;
-	
+
 	// Detect mass destruction
 	if (SpawnedChildren.Num() > LARGE_GRID_WARNING_THRESHOLD)
 	{
 		bInMassDestruction = true;
-		UE_LOG(LogSmartFoundations, Warning, 
+		UE_LOG(LogSmartFoundations, Warning,
 			TEXT("HologramHelperService: Mass destruction of %d children detected"),
 			SpawnedChildren.Num()
 		);
 	}
-	
+
 	for (TWeakObjectPtr<AFGHologram>& ChildPtr : SpawnedChildren)
 	{
 		if (AFGHologram* Child = ChildPtr.Get())
@@ -2071,10 +2071,10 @@ void FSFHologramHelperService::DestroyAllChildren()
 			}
 		}
 	}
-	
+
 	SpawnedChildren.Empty();
 	PendingDestroyChildren.Empty();
-	
+
 	bInMassDestruction = false;
 	bSuppressChildUpdates = false;
 }

--- a/Source/SmartFoundations/Private/Subsystem/SFHologramPerformanceProfiler.cpp
+++ b/Source/SmartFoundations/Private/Subsystem/SFHologramPerformanceProfiler.cpp
@@ -15,19 +15,19 @@ void FSFHologramPerformanceProfiler::BeginSpawnProfile(const FString& OperationN
 		UE_LOG(LogSmartFoundations, Warning, TEXT("⚠️ BeginSpawnProfile called while already profiling!"));
 		return;
 	}
-	
+
 	bIsProfiling = true;
 	CurrentProfile.OperationName = OperationName;
 	CurrentProfile.ChildCount = ChildCount;
 	CurrentProfile.UObjectsBefore = GUObjectArray.GetObjectArrayNum();
 	CurrentProfile.TimeStart = FPlatformTime::Seconds();
-	
+
 	FPlatformMemoryStats MemStats = FPlatformMemory::GetStats();
 	CurrentProfile.MemoryBefore = MemStats.UsedPhysical;
-	
+
 	// Tester-friendly log: simple spawn count
-	UE_LOG(LogSmartFoundations, Log, TEXT("📊 Spawning %d children..."), ChildCount);
-	
+	UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("📊 Spawning %d children..."), ChildCount);
+
 	// Detailed profiling data at Verbose for performance analysis
 	UE_LOG(LogSmartFoundations, Verbose, TEXT("📊 SPAWN PROFILE START: %s (spawning %d children)"), *OperationName, ChildCount);
 	UE_LOG(LogSmartFoundations, Verbose, TEXT("   UObjects Before: %d"), CurrentProfile.UObjectsBefore);
@@ -41,18 +41,18 @@ void FSFHologramPerformanceProfiler::EndSpawnProfile()
 		UE_LOG(LogSmartFoundations, Warning, TEXT("⚠️ EndSpawnProfile called without BeginSpawnProfile!"));
 		return;
 	}
-	
+
 	const int32 UObjectsAfter = GUObjectArray.GetObjectArrayNum();
 	const int32 UObjectDelta = UObjectsAfter - CurrentProfile.UObjectsBefore;
 	const double TimeElapsed = FPlatformTime::Seconds() - CurrentProfile.TimeStart;
-	
+
 	FPlatformMemoryStats MemStats = FPlatformMemory::GetStats();
 	const SIZE_T MemoryAfter = MemStats.UsedPhysical;
 	const int64 MemoryDelta = static_cast<int64>(MemoryAfter) - static_cast<int64>(CurrentProfile.MemoryBefore);
-	
+
 	// Tester-friendly log: simple completion with time
-	UE_LOG(LogSmartFoundations, Log, TEXT("✅ Spawned %d children in %.1f ms"), CurrentProfile.ChildCount, TimeElapsed * 1000.0);
-	
+	UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("✅ Spawned %d children in %.1f ms"), CurrentProfile.ChildCount, TimeElapsed * 1000.0);
+
 	// Detailed profiling data at Verbose for performance analysis
 	UE_LOG(LogSmartFoundations, Verbose, TEXT("📊 SPAWN PROFILE END: %s"), *CurrentProfile.OperationName);
 	UE_LOG(LogSmartFoundations, Verbose, TEXT("   Children Spawned: %d"), CurrentProfile.ChildCount);
@@ -61,7 +61,7 @@ void FSFHologramPerformanceProfiler::EndSpawnProfile()
 	UE_LOG(LogSmartFoundations, Verbose, TEXT("   Memory After: %.2f MB (delta: %.2f MB)"), MemoryAfter / (1024.0 * 1024.0), MemoryDelta / (1024.0 * 1024.0));
 	UE_LOG(LogSmartFoundations, Verbose, TEXT("   Memory Per Child: %.2f KB"), CurrentProfile.ChildCount > 0 ? (MemoryDelta / 1024.0) / CurrentProfile.ChildCount : 0.0f);
 	UE_LOG(LogSmartFoundations, Verbose, TEXT("   Time Elapsed: %.3f ms (%.3f ms per child)"), TimeElapsed * 1000.0, CurrentProfile.ChildCount > 0 ? (TimeElapsed * 1000.0) / CurrentProfile.ChildCount : 0.0f);
-	
+
 	bIsProfiling = false;
 }
 
@@ -72,16 +72,16 @@ void FSFHologramPerformanceProfiler::BeginDestroyProfile(const FString& Operatio
 		UE_LOG(LogSmartFoundations, Warning, TEXT("⚠️ BeginDestroyProfile called while already profiling!"));
 		return;
 	}
-	
+
 	bIsProfiling = true;
 	CurrentProfile.OperationName = OperationName;
 	CurrentProfile.ChildCount = ChildCount;
 	CurrentProfile.UObjectsBefore = GUObjectArray.GetObjectArrayNum();
 	CurrentProfile.TimeStart = FPlatformTime::Seconds();
-	
+
 	FPlatformMemoryStats MemStats = FPlatformMemory::GetStats();
 	CurrentProfile.MemoryBefore = MemStats.UsedPhysical;
-	
+
 	// Detailed profiling at Verbose - testers don't need this
 	UE_LOG(LogSmartFoundations, Verbose, TEXT("📊 DESTROY PROFILE START: %s (destroying %d children)"), *OperationName, ChildCount);
 	UE_LOG(LogSmartFoundations, Verbose, TEXT("   UObjects Before: %d"), CurrentProfile.UObjectsBefore);
@@ -95,15 +95,15 @@ void FSFHologramPerformanceProfiler::EndDestroyProfile()
 		UE_LOG(LogSmartFoundations, Warning, TEXT("⚠️ EndDestroyProfile called without BeginDestroyProfile!"));
 		return;
 	}
-	
+
 	const int32 UObjectsAfter = GUObjectArray.GetObjectArrayNum();
 	const int32 UObjectDelta = UObjectsAfter - CurrentProfile.UObjectsBefore;
 	const double TimeElapsed = FPlatformTime::Seconds() - CurrentProfile.TimeStart;
-	
+
 	FPlatformMemoryStats MemStats = FPlatformMemory::GetStats();
 	const SIZE_T MemoryAfter = MemStats.UsedPhysical;
 	const int64 MemoryDelta = static_cast<int64>(MemoryAfter) - static_cast<int64>(CurrentProfile.MemoryBefore);
-	
+
 	UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("📊 DESTROY PROFILE END: %s"), *CurrentProfile.OperationName);
 	UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("   Children Destroyed: %d"), CurrentProfile.ChildCount);
 	UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("   UObjects After: %d (delta: %d)"), UObjectsAfter, UObjectDelta);
@@ -111,7 +111,7 @@ void FSFHologramPerformanceProfiler::EndDestroyProfile()
 	UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("   Memory After: %.2f MB (delta: %.2f MB)"), MemoryAfter / (1024.0 * 1024.0), MemoryDelta / (1024.0 * 1024.0));
 	UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("   Memory Freed Per Child: %.2f KB"), CurrentProfile.ChildCount > 0 ? (-MemoryDelta / 1024.0) / CurrentProfile.ChildCount : 0.0f);
 	UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("   Time Elapsed: %.3f ms (%.3f ms per child)"), TimeElapsed * 1000.0, CurrentProfile.ChildCount > 0 ? (TimeElapsed * 1000.0) / CurrentProfile.ChildCount : 0.0f);
-	
+
 	bIsProfiling = false;
 }
 
@@ -122,16 +122,16 @@ void FSFHologramPerformanceProfiler::BeginRepositionProfile(const FString& Opera
 		UE_LOG(LogSmartFoundations, Warning, TEXT("⚠️ BeginRepositionProfile called while already profiling!"));
 		return;
 	}
-	
+
 	bIsProfiling = true;
 	CurrentProfile.OperationName = OperationName;
 	CurrentProfile.ChildCount = ChildCount;
 	CurrentProfile.UObjectsBefore = GUObjectArray.GetObjectArrayNum();
 	CurrentProfile.TimeStart = FPlatformTime::Seconds();
-	
+
 	FPlatformMemoryStats MemStats = FPlatformMemory::GetStats();
 	CurrentProfile.MemoryBefore = MemStats.UsedPhysical;
-	
+
 	UE_LOG(LogSmartFoundations, Warning, TEXT("📊 REPOSITION PROFILE START: %s (repositioning %d children)"), *OperationName, ChildCount);
 	UE_LOG(LogSmartFoundations, Warning, TEXT("   UObjects Before: %d"), CurrentProfile.UObjectsBefore);
 	UE_LOG(LogSmartFoundations, Warning, TEXT("   Memory Before: %.2f MB"), CurrentProfile.MemoryBefore / (1024.0 * 1024.0));
@@ -144,15 +144,15 @@ void FSFHologramPerformanceProfiler::EndRepositionProfile(int32 TransformCalls, 
 		UE_LOG(LogSmartFoundations, Warning, TEXT("⚠️ EndRepositionProfile called without BeginRepositionProfile!"));
 		return;
 	}
-	
+
 	const int32 UObjectsAfter = GUObjectArray.GetObjectArrayNum();
 	const int32 UObjectDelta = UObjectsAfter - CurrentProfile.UObjectsBefore;
 	const double TimeElapsed = FPlatformTime::Seconds() - CurrentProfile.TimeStart;
-	
+
 	FPlatformMemoryStats MemStats = FPlatformMemory::GetStats();
 	const SIZE_T MemoryAfter = MemStats.UsedPhysical;
 	const int64 MemoryDelta = static_cast<int64>(MemoryAfter) - static_cast<int64>(CurrentProfile.MemoryBefore);
-	
+
 	UE_LOG(LogSmartFoundations, Warning, TEXT("📊 REPOSITION PROFILE END: %s"), *CurrentProfile.OperationName);
 	UE_LOG(LogSmartFoundations, Warning, TEXT("   Children Repositioned: %d"), CurrentProfile.ChildCount);
 	UE_LOG(LogSmartFoundations, Warning, TEXT("   Transform Calls: %d"), TransformCalls);
@@ -160,7 +160,7 @@ void FSFHologramPerformanceProfiler::EndRepositionProfile(int32 TransformCalls, 
 	UE_LOG(LogSmartFoundations, Warning, TEXT("   UObjects After: %d (delta: %d)"), UObjectsAfter, UObjectDelta);
 	UE_LOG(LogSmartFoundations, Warning, TEXT("   Memory After: %.2f MB (delta: %.2f MB)"), MemoryAfter / (1024.0 * 1024.0), MemoryDelta / (1024.0 * 1024.0));
 	UE_LOG(LogSmartFoundations, Warning, TEXT("   Time Elapsed: %.3f ms (%.3f ms per child)"), TimeElapsed * 1000.0, CurrentProfile.ChildCount > 0 ? (TimeElapsed * 1000.0) / CurrentProfile.ChildCount : 0.0f);
-	
+
 	bIsProfiling = false;
 }
 
@@ -171,11 +171,11 @@ void FSFHologramPerformanceProfiler::BeginValidationProfile(const FString& Opera
 		UE_LOG(LogSmartFoundations, Warning, TEXT("⚠️ BeginValidationProfile called while already profiling!"));
 		return;
 	}
-	
+
 	bIsProfiling = true;
 	CurrentProfile.OperationName = OperationName;
 	CurrentProfile.TimeStart = FPlatformTime::Seconds();
-	
+
 	UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("📊 VALIDATION PROFILE START: %s"), *OperationName);
 }
 
@@ -186,17 +186,17 @@ void FSFHologramPerformanceProfiler::EndValidationProfile(EHologramMaterialState
 		UE_LOG(LogSmartFoundations, Warning, TEXT("⚠️ EndValidationProfile called without BeginValidationProfile!"));
 		return;
 	}
-	
+
 	const double TimeElapsed = FPlatformTime::Seconds() - CurrentProfile.TimeStart;
-	
+
 	const TCHAR* StateStr = (MaterialState == EHologramMaterialState::HMS_OK) ? TEXT("HMS_OK") :
 	                        (MaterialState == EHologramMaterialState::HMS_WARNING) ? TEXT("HMS_WARNING") :
 	                        TEXT("HMS_ERROR");
-	
+
 	UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("📊 VALIDATION PROFILE END: %s"), *CurrentProfile.OperationName);
 	UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("   Time Elapsed: %.3f ms"), TimeElapsed * 1000.0);
 	UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("   Material State: %s"), StateStr);
-	
+
 	bIsProfiling = false;
 }
 
@@ -204,13 +204,13 @@ void FSFHologramPerformanceProfiler::LogUObjectStats(const FString& Context)
 {
 	const int32 TotalObjects = GUObjectArray.GetObjectArrayNum();
 	const int32 MaxObjects = GUObjectArray.GetObjectArrayNumMinusPermanent();
-	
+
 	UE_LOG(LogSmartFoundations, Warning, TEXT("📊 UOBJECT STATS [%s]"), *Context);
 	UE_LOG(LogSmartFoundations, Warning, TEXT("   Total UObjects: %d / %d"), TotalObjects, MaxObjects);
 	UE_LOG(LogSmartFoundations, Warning, TEXT("   Utilization: %.2f%%"), MaxObjects > 0 ? (static_cast<float>(TotalObjects) / MaxObjects * 100.0f) : 0.0f);
-	
+
 	FPlatformMemoryStats MemStats = FPlatformMemory::GetStats();
-	UE_LOG(LogSmartFoundations, Warning, TEXT("   Physical Memory: %.2f MB used / %.2f MB total"), 
+	UE_LOG(LogSmartFoundations, Warning, TEXT("   Physical Memory: %.2f MB used / %.2f MB total"),
 		MemStats.UsedPhysical / (1024.0 * 1024.0),
 		MemStats.TotalPhysical / (1024.0 * 1024.0));
 }
@@ -222,14 +222,14 @@ void FSFHologramPerformanceProfiler::LogHologramComponents(const AFGHologram* Ho
 		UE_LOG(LogSmartFoundations, Verbose, TEXT("⚠️ LogHologramComponents: Invalid hologram"));
 		return;
 	}
-	
+
 	TArray<UActorComponent*> Components;
 	Hologram->GetComponents(Components);
-	
+
 	// Component details at Verbose - testers don't need this level of detail
 	UE_LOG(LogSmartFoundations, Verbose, TEXT("📊 HOLOGRAM COMPONENTS: %s"), *Hologram->GetName());
 	UE_LOG(LogSmartFoundations, Verbose, TEXT("   Total Components: %d"), Components.Num());
-	
+
 	// Count by type
 	TMap<FString, int32> ComponentCounts;
 	for (UActorComponent* Component : Components)
@@ -240,7 +240,7 @@ void FSFHologramPerformanceProfiler::LogHologramComponents(const AFGHologram* Ho
 			ComponentCounts.FindOrAdd(TypeName)++;
 		}
 	}
-	
+
 	// Log breakdown at Verbose
 	for (const TPair<FString, int32>& Pair : ComponentCounts)
 	{

--- a/Source/SmartFoundations/Private/Subsystem/SFInputHandler.cpp
+++ b/Source/SmartFoundations/Private/Subsystem/SFInputHandler.cpp
@@ -31,7 +31,7 @@ void FSFInputHandler::Shutdown()
 	OwnerSubsystem.Reset();
 	LastController.Reset();
 	bInputSetupCompleted = false;
-	
+
 	UE_LOG(LogSmartFoundations, Log, TEXT("InputHandler: Shutdown complete"));
 }
 
@@ -50,7 +50,7 @@ void FSFInputHandler::SetupPlayerInput(AFGPlayerController* PlayerController)
 		return;
 	}
 
-	UE_LOG(LogSmartFoundations, Log, TEXT("Setting up Smart! Enhanced Input system for player controller"));
+	UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("Setting up Smart! Enhanced Input system for player controller"));
 	UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("🔧 Player controller: %s"), *PlayerController->GetName());
 
 	// Ensure input is enabled on the controller (some contexts require this for non-actor receivers)
@@ -76,15 +76,15 @@ void FSFInputHandler::SetupPlayerInput(AFGPlayerController* PlayerController)
 		// BUG FIX (Issue #148): Cache is cleared during world cleanup, ensuring fresh load for new worlds
 		if (UFGInputMappingContext* SmartContext = USFInputRegistry::GetSmartInputMappingContext())
 		{
-			UE_LOG(LogSmartFoundations, Log, TEXT("✅ Smart! Mapping Context loaded: %s"), *SmartContext->GetName());
-			
+			UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("✅ Smart! Mapping Context loaded: %s"), *SmartContext->GetName());
+
 			// Get the Enhanced Input Subsystem to add our mapping context
 			if (UEnhancedInputLocalPlayerSubsystem* InputSubsystem = PlayerController->GetLocalPlayer()->GetSubsystem<UEnhancedInputLocalPlayerSubsystem>())
 			{
 				// Add with HIGH priority (100) to ensure we consume input before base game
 				// This is critical for input consumption to work (prevents wheel from rotating hologram)
 				InputSubsystem->AddMappingContext(SmartContext, 100);
-				UE_LOG(LogSmartFoundations, Log, TEXT("Smart! Input Mapping Context added to Enhanced Input Subsystem (Priority: 100)"));
+				UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("Smart! Input Mapping Context added to Enhanced Input Subsystem (Priority: 100)"));
 			}
 			else
 			{
@@ -101,7 +101,7 @@ void FSFInputHandler::SetupPlayerInput(AFGPlayerController* PlayerController)
 	{
 		UE_LOG(LogSmartFoundations, Error, TEXT("Player controller does not have UFGEnhancedInputComponent"));
 	}
-	
+
 	bInputSetupCompleted = true;
 }
 
@@ -126,7 +126,7 @@ void FSFInputHandler::CheckForPlayerController()
 		{
 			if (AFGPlayerController* FGController = Cast<AFGPlayerController>(PC))
 			{
-				UE_LOG(LogSmartFoundations, Log, TEXT("Player controller found! Setting up Smart! input system..."));
+				UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("Player controller found! Setting up Smart! input system..."));
 				SetupPlayerInput(FGController);
 			}
 		}
@@ -160,7 +160,7 @@ void FSFInputHandler::RebindAfterDelay()
 			EnhancedInputComp->BindAction(IA, ETriggerEvent::Started, Subsystem, &USFSubsystem::OnDebugPrimaryFire);
 			EnhancedInputComp->BindAction(IA, ETriggerEvent::Triggered, Subsystem, &USFSubsystem::OnDebugPrimaryFire);
 			EnhancedInputComp->BindAction(IA, ETriggerEvent::Completed, Subsystem, &USFSubsystem::OnDebugPrimaryFire);
-			UE_LOG(LogSmartFoundations, Log, TEXT("Deferred rebind: Bound base action PrimaryFire -> %s"), *IA->GetPathName());
+			UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("Deferred rebind: Bound base action PrimaryFire -> %s"), *IA->GetPathName());
 		}
 		else
 		{
@@ -252,7 +252,7 @@ void FSFInputHandler::DisableVanillaBuildGunContext()
 	// Try standard path
 	FSoftObjectPath VanillaBuildGunPath(TEXT("/Game/FactoryGame/Inputs/Equipment/Buildgun/Build/MC_BuildGunBuild.MC_BuildGunBuild"));
 	UFGInputMappingContext* VanillaContext = Cast<UFGInputMappingContext>(VanillaBuildGunPath.TryLoad());
-	
+
 	if (!VanillaContext)
 	{
 		// Try alternative path (just in case)
@@ -269,7 +269,7 @@ void FSFInputHandler::DisableVanillaBuildGunContext()
 			CachedVanillaContextPriority = FoundPriority;
 			bVanillaContextRemoved = true;
 			InputSubsystem->RemoveMappingContext(VanillaContext);
-			UE_LOG(LogSmartFoundations, Log, TEXT("🚫 Disabled vanilla Build Gun context (priority=%d, prevents rotation while Smart! active) - %s"), FoundPriority, *VanillaContext->GetName());
+			UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("🚫 Disabled vanilla Build Gun context (priority=%d, prevents rotation while Smart! active) - %s"), FoundPriority, *VanillaContext->GetName());
 		}
 		else
 		{
@@ -305,7 +305,7 @@ void FSFInputHandler::EnableVanillaBuildGunContext()
 	// Re-add vanilla Build Gun context at its normal priority
 	FSoftObjectPath VanillaBuildGunPath(TEXT("/Game/FactoryGame/Inputs/Equipment/Buildgun/Build/MC_BuildGunBuild.MC_BuildGunBuild"));
 	UFGInputMappingContext* VanillaContext = Cast<UFGInputMappingContext>(VanillaBuildGunPath.TryLoad());
-	
+
 	if (!VanillaContext)
 	{
 		VanillaBuildGunPath = FSoftObjectPath(TEXT("/Game/FactoryGame/Inputs/Equipment/Buildgun/MC_BuildGun.MC_BuildGun"));
@@ -322,7 +322,7 @@ void FSFInputHandler::EnableVanillaBuildGunContext()
 			const int32 RestorePriority = (bVanillaContextRemoved && CachedVanillaContextPriority >= 0) ? CachedVanillaContextPriority : 0;
 			InputSubsystem->AddMappingContext(VanillaContext, RestorePriority);
 			bVanillaContextRemoved = false;
-			UE_LOG(LogSmartFoundations, Log, TEXT("✅ Re-enabled vanilla Build Gun context (priority=%d, rotation restored) - %s"), RestorePriority, *VanillaContext->GetName());
+			UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("✅ Re-enabled vanilla Build Gun context (priority=%d, rotation restored) - %s"), RestorePriority, *VanillaContext->GetName());
 		}
 	}
 	else
@@ -400,8 +400,8 @@ void FSFInputHandler::OnSpacingModeChanged(const FInputActionValue& Value)
 {
 	bool bPressed = Value.Get<bool>();
 	bSpacingModeActive = bPressed;
-	
-	UE_LOG(LogSmartFoundations, Log, TEXT("InputHandler: Spacing mode %s"), 
+
+	UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("InputHandler: Spacing mode %s"),
 		bPressed ? TEXT("activated") : TEXT("deactivated"));
 	if (USFSubsystem* Subsystem = OwnerSubsystem.Get())
 	{
@@ -420,8 +420,8 @@ void FSFInputHandler::OnStepsModeChanged(const FInputActionValue& Value)
 {
 	bool bPressed = Value.Get<bool>();
 	bStepsModeActive = bPressed;
-	
-	UE_LOG(LogSmartFoundations, Log, TEXT("InputHandler: Steps mode %s"), 
+
+	UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("InputHandler: Steps mode %s"),
 		bPressed ? TEXT("activated") : TEXT("deactivated"));
 	if (USFSubsystem* Subsystem = OwnerSubsystem.Get())
 	{
@@ -440,8 +440,8 @@ void FSFInputHandler::OnStaggerModeChanged(const FInputActionValue& Value)
 {
 	bool bPressed = Value.Get<bool>();
 	bStaggerModeActive = bPressed;
-	
-	UE_LOG(LogSmartFoundations, Log, TEXT("InputHandler: Stagger mode %s"), 
+
+	UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("InputHandler: Stagger mode %s"),
 		bPressed ? TEXT("activated") : TEXT("deactivated"));
 	if (USFSubsystem* Subsystem = OwnerSubsystem.Get())
 	{
@@ -453,8 +453,8 @@ void FSFInputHandler::OnRotationModeChanged(const FInputActionValue& Value)
 {
 	bool bPressed = Value.Get<bool>();
 	bRotationModeActive = bPressed;
-	
-	UE_LOG(LogSmartFoundations, Log, TEXT("InputHandler: Rotation mode %s"), 
+
+	UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("InputHandler: Rotation mode %s"),
 		bPressed ? TEXT("activated") : TEXT("deactivated"));
 	if (USFSubsystem* Subsystem = OwnerSubsystem.Get())
 	{

--- a/Source/SmartFoundations/Private/Subsystem/SFSubsystem.cpp
+++ b/Source/SmartFoundations/Private/Subsystem/SFSubsystem.cpp
@@ -162,7 +162,7 @@ namespace
 		TWeakObjectPtr<UFGFactoryConnectionComponent> InputConnector;
 		int32 BeltTier = 0;
 	};
-	
+
 	TArray<FStackableBeltBuildData> GCachedStackableBeltData;
 	bool bGStackableBeltDataCached = false;
 }
@@ -172,20 +172,20 @@ USFSubsystem::USFSubsystem() : Super()
 	#if SMART_ARROWS_ENABLED
 	ArrowModule = MakeUnique<FSFArrowModule_StaticMesh>();
 	#endif
-	
+
 	// Phase 0: Create extracted service modules (Task #61.6)
 	InputHandler = MakeUnique<FSFInputHandler>();
 	InputHandler->Initialize(this);
-	
+
 	PositionCalculator = MakeUnique<FSFPositionCalculator>();
 	// Note: PositionCalculator is stateless, no Initialize() needed
-	
+
 	ValidationService = MakeUnique<FSFValidationService>();
 	// Note: ValidationService is stateless, no Initialize() needed
-	
+
 	HologramHelper = MakeUnique<FSFHologramHelperService>();
 	// Note: HologramHelper::Initialize() takes UWorld*, called during subsystem Init
-	
+
 	// Create recipe management service as default subobject
 	RecipeManagementService = CreateDefaultSubobject<USFRecipeManagementService>(TEXT("RecipeManagementService"));
 	if (RecipeManagementService)
@@ -206,7 +206,7 @@ USFSubsystem::USFSubsystem() : Super()
 	{
 		UpgradeExecutionService->Initialize(this);
 	}
-	
+
 	// Create HUD service as default subobject (Phase A extraction)
 	HudService = CreateDefaultSubobject<USFHudService>(TEXT("HudService"));
 	if (HudService)
@@ -245,7 +245,7 @@ USFSubsystem::USFSubsystem() : Super()
 	{
 		GridTransformService->Initialize(this);
 	}
-	
+
 	UE_LOG(LogSmartFoundations, Log, TEXT("SFSubsystem: Phase 0 modules and recipe service initialized"));
 }
 
@@ -334,7 +334,7 @@ void USFSubsystem::RunPostLoadChainRepair()
 void USFSubsystem::OnDebugPrimaryFire()
 {
 	// Debug: Analyze nearby pipe splines to determine vanilla tangent formulas
-	UE_LOG(LogSmartFoundations, Display, TEXT("🔧 Debug Primary Fire: Analyzing nearby pipe splines..."));
+	UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("🔧 Debug Primary Fire: Analyzing nearby pipe splines..."));
 	AnalyzeNearbyPipeSplines(5000.0f);  // 50m radius
 }
 
@@ -373,12 +373,12 @@ void USFSubsystem::CommitBuildingConnections()
 				DeferredPoleConnections.Add(Connection);
 			}
 		}
-		UE_LOG(LogSmartFoundations, Log, TEXT("⚡ CommitBuildingConnections: Added %d pole connections to deferred queue (total: %d)"),
+		UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("⚡ CommitBuildingConnections: Added %d pole connections to deferred queue (total: %d)"),
 			PlannedPoleConnections.Num(), DeferredPoleConnections.Num());
 	}
 	else
 	{
-		UE_LOG(LogSmartFoundations, Log, TEXT("⚡ CommitBuildingConnections: No new pole connections (deferred queue: %d)"),
+		UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("⚡ CommitBuildingConnections: No new pole connections (deferred queue: %d)"),
 			DeferredPoleConnections.Num());
 	}
 }
@@ -392,7 +392,7 @@ void USFSubsystem::RemoveDeferredPoleConnection(const FVector& PoleA, const FVec
 			(Conn.Key.Equals(PoleB, 50.0f) && Conn.Value.Equals(PoleA, 50.0f)))
 		{
 			DeferredPoleConnections.RemoveAt(i);
-			UE_LOG(LogSmartFoundations, Log, TEXT("⚡ RemoveDeferredPoleConnection: Removed used connection, %d remaining"),
+			UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("⚡ RemoveDeferredPoleConnection: Removed used connection, %d remaining"),
 				DeferredPoleConnections.Num());
 			return;
 		}
@@ -403,7 +403,7 @@ void USFSubsystem::ClearDeferredPoleConnections()
 {
 	if (DeferredPoleConnections.Num() > 0)
 	{
-		UE_LOG(LogSmartFoundations, Log, TEXT("⚡ ClearDeferredPoleConnections: Cleared %d deferred connections"),
+		UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("⚡ ClearDeferredPoleConnections: Cleared %d deferred connections"),
 			DeferredPoleConnections.Num());
 		DeferredPoleConnections.Empty();
 	}
@@ -491,15 +491,15 @@ void USFSubsystem::UpdateCounterState(const FSFCounterState& NewState)
 void USFSubsystem::Initialize(FSubsystemCollectionBase& Collection)
 {
 	Super::Initialize(Collection);
-	
+
 	UE_LOG(LogSmartFoundations, Log, TEXT("Smart! Subsystem: Initialize() called"));
-	
+
 	// Reset recipe sampling subscription flag for safety
 	bHasSubscribedToRecipeSampled = false;
-	
+
 	// NOTE: Config loading deferred until first hologram registration
 	// ConfigManager subsystem may not be available during Initialize()
-	
+
 	// Task #58: Start lightweight timers
 	// Heavy initialization (arrows, assets) happens in RegisterActiveHologram()
 	UWorld* World = GetWorld();
@@ -508,12 +508,12 @@ void USFSubsystem::Initialize(FSubsystemCollectionBase& Collection)
 		UE_LOG(LogSmartFoundations, Warning, TEXT("Smart! Subsystem: No world in Initialize() - cannot start timers"));
 		return;
 	}
-	
+
 	// Initialize deterministic hologram lifecycle management (Layer 2) - bind once to prevent accumulation
 	InitializeHologramCleanup();
-	
+
 	UE_LOG(LogSmartFoundations, Log, TEXT("Smart! Subsystem: World found, starting timers"));
-	
+
 	// Phase 0: Initialize extracted modules with world context (Task #61.6)
 	if (InputHandler)
 	{
@@ -523,7 +523,7 @@ void USFSubsystem::Initialize(FSubsystemCollectionBase& Collection)
 	{
 		HologramHelper->Initialize(World);
 	}
-	
+
 	// Initialize auto-connect service (Refactor: Auto-Connect Service)
 	AutoConnectService = NewObject<USFAutoConnectService>(this);
 	if (AutoConnectService)
@@ -561,7 +561,7 @@ void USFSubsystem::Initialize(FSubsystemCollectionBase& Collection)
 	{
 		PowerAutoConnectManager->Initialize(this, AutoConnectService);
 	}
-	
+
 	// Start player controller detection timer (CRITICAL for input binding!)
 	World->GetTimerManager().SetTimer(
 		PlayerControllerCheckTimer,
@@ -570,7 +570,7 @@ void USFSubsystem::Initialize(FSubsystemCollectionBase& Collection)
 		1.0f,  // Check every second
 		true   // Repeat
 	);
-	
+
 	// Start hologram polling timer (lightweight - just checks for holograms)
 	World->GetTimerManager().SetTimer(
 		HologramPollTimer,
@@ -579,10 +579,10 @@ void USFSubsystem::Initialize(FSubsystemCollectionBase& Collection)
 		0.1f,  // Poll every 100ms
 		true   // Repeat
 	);
-	
+
 	// Bind to actor spawn delegate for recipe inheritance
 	World->AddOnActorSpawnedHandler(FOnActorSpawned::FDelegate::CreateUObject(this, &USFSubsystem::OnActorSpawned));
-	
+
 	// Schedule one-shot post-load chain diagnostics. Deferred by 8 seconds to ensure all
 	// buildable actors (and their chain actors) are fully spawned and initialized.
 	// This is intentionally diagnostic-only: mutating chain actors during normal load can
@@ -612,33 +612,33 @@ void USFSubsystem::TickArrows()
 		{
 			return;
 		}
-		
+
 		FTransform CurrentTransform = CurrentAdapter->GetBaseTransform();
-	
+
 	// Check if transform, axis input, or grid structure changed
 	const bool bTransformChanged = !CurrentTransform.Equals(LastHologramTransform);
 	const bool bAxisInputChanged = (LastAxisInput != LastKnownAxisInput);
-	
+
 	int32 CurrentChildCount = 0;
 	if (AFGHologram* Hologram = GetActiveHologram())
 	{
 		CurrentChildCount = Hologram->GetHologramChildren().Num();
 	}
 	const bool bChildCountChanged = (CurrentChildCount != LastChildCount);
-	
+
 	// Only update full arrows if something changed (optimization)
 	if (bTransformChanged || bAxisInputChanged || bChildCountChanged)
 	{
 		ArrowModule->UpdateArrows(World, CurrentTransform, LastAxisInput, true);
-		
+
 		// Update cache
 		LastHologramTransform = CurrentTransform;
 		LastKnownAxisInput = LastAxisInput;
 		LastChildCount = CurrentChildCount;
-			
+
 			// Log updates (only when changes occur)
-		UE_LOG(LogSmartFoundations, Verbose, 
-			TEXT("Arrows updated: Transform=%d Axis=%d ChildCount=%d (%d children) at %s"), 
+		UE_LOG(LogSmartFoundations, Verbose,
+			TEXT("Arrows updated: Transform=%d Axis=%d ChildCount=%d (%d children) at %s"),
 			bTransformChanged, bAxisInputChanged, bChildCountChanged, CurrentChildCount,
 			*CurrentTransform.GetLocation().ToString());
 		}
@@ -649,9 +649,9 @@ void USFSubsystem::TickArrows()
 		static bool bLastLabels = true;
 		if (ArrowConfig.bShowArrowOrbit != bLastOrbit || ArrowConfig.bShowArrowLabels != bLastLabels)
 		{
-			UE_LOG(LogSmartFoundations, Display, TEXT("Arrow config changed: Orbit=%s Labels=%s"),
-				ArrowConfig.bShowArrowOrbit ? TEXT("ON") : TEXT("OFF"),
-				ArrowConfig.bShowArrowLabels ? TEXT("ON") : TEXT("OFF"));
+			UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("Arrow config changed: Orbit=%s Labels=%s"),
+			ArrowConfig.bShowArrowOrbit ? TEXT("ON") : TEXT("OFF"),
+			ArrowConfig.bShowArrowLabels ? TEXT("ON") : TEXT("OFF"));
 			bLastOrbit = ArrowConfig.bShowArrowOrbit;
 			bLastLabels = ArrowConfig.bShowArrowLabels;
 		}
@@ -678,7 +678,7 @@ void USFSubsystem::InitializeWidgets()
 	// BUG FIX (Issue #148): Clear static input caches during world cleanup
 	// Must be done FIRST before any other cleanup to prevent accessing stale cached objects
 	USFInputRegistry::ClearInputCache();
-	
+
 	// Rest of the InitializeWidgets function remains the same
 }
 
@@ -689,10 +689,10 @@ void USFSubsystem::Deinitialize()
 	// BUG FIX (Issue #148): Clear static input caches during world cleanup
 	// Must be done FIRST before any other cleanup to prevent accessing stale cached objects
 	USFInputRegistry::ClearInputCache();
-	
+
 	// Clean up recipe inheritance state for world transition
 	CleanupStateForWorldTransition();
-	
+
 	// Clean up widgets
 	CleanupWidgets();
 
@@ -710,25 +710,25 @@ void USFSubsystem::Deinitialize()
 		InputHandler->Shutdown();
 	}
 	InputHandler.Reset();
-	
+
 	if (HologramHelper)
 	{
 		HologramHelper->Shutdown();
 	}
 	HologramHelper.Reset();
-	
+
 	// Reset other TUniquePtr members
 	PositionCalculator.Reset();
 	ValidationService.Reset();
-	
+
 #if SMART_ARROWS_ENABLED
 	ArrowModule.Reset();
 #endif
-	
+
 	// Reset Pipe/Power Auto-Connect managers (TUniquePtr members)
 	PipeAutoConnectManager.Reset();
 	PowerAutoConnectManager.Reset();
-	
+
 	// Shutdown auto-connect service (Refactor: Auto-Connect Service)
 	if (AutoConnectService)
 	{
@@ -775,7 +775,7 @@ void USFSubsystem::Deinitialize()
 		}
 	}
 	AutoConnectOrchestrators.Empty();
-	UE_LOG(LogSmartFoundations, Log, TEXT("🎯 All Auto-Connect Orchestrators cleaned up"));
+	UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("🎯 All Auto-Connect Orchestrators cleaned up"));
 
 	// Clean up timers
 	StopPeriodicCleanup();
@@ -791,18 +791,18 @@ void USFSubsystem::Deinitialize()
 		World->GetTimerManager().ClearTimer(ArrowTickTimer);
 #endif
 	}
-	
+
 	// Clean up deferred power pole connections
 	PendingPowerPoleConnections.Empty();
-	
+
 	// Clean up any resources
 	ActiveHologram.Reset();
-	
+
 	// Reset lazy initialization flag (Task #58) for menu → game → menu → game cycles
 	bSubsystemInitialized = false;
-	
+
 	Super::Deinitialize();
-	
+
 }
 // Tick (Phase 4)
 // ========================================
@@ -838,11 +838,11 @@ void USFSubsystem::Tick(float DeltaTime)
 			const TArray<FTransform>& ZoopTransforms = FactoryBuildingHolo->GetZoopInstanceTransforms();
 			const bool bZoopNowActive = ZoopTransforms.Num() > 0;
 			const bool bWasZoopActive = HologramHelper->IsZoopActive();
-			
+
 			// Zoop just became active - force grid regeneration to clear Smart! children
 			if (bZoopNowActive && !bWasZoopActive)
 			{
-				UE_LOG(LogSmartFoundations, Log, TEXT("⚠️ Zoop activated mid-placement - triggering grid regeneration"));
+				UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("⚠️ Zoop activated mid-placement - triggering grid regeneration"));
 				if (USFGridSpawnerService* Spawner = GetGridSpawnerService())
 				{
 					Spawner->RegenerateChildHologramGrid();
@@ -851,7 +851,7 @@ void USFSubsystem::Tick(float DeltaTime)
 			// Zoop just became inactive - could restore scaling, but user would need to re-input
 			else if (!bZoopNowActive && bWasZoopActive)
 			{
-				UE_LOG(LogSmartFoundations, Log, TEXT("✅ Zoop deactivated - Smart! scaling available again"));
+				UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("✅ Zoop deactivated - Smart! scaling available again"));
 			}
 		}
 	}
@@ -870,7 +870,7 @@ void USFSubsystem::Tick(float DeltaTime)
 	{
 		// Get the building the player is looking at via line trace
 		AFGBuildable* LookedAtBuilding = nullptr;
-		
+
 		AFGPlayerController* PC = Cast<AFGPlayerController>(LastController.Get());
 		if (!PC)
 		{
@@ -880,25 +880,25 @@ void USFSubsystem::Tick(float DeltaTime)
 				PC = Cast<AFGPlayerController>(World->GetFirstPlayerController());
 			}
 		}
-		
+
 		if (PC)
 		{
 			if (APlayerCameraManager* CameraManager = PC->PlayerCameraManager)
 			{
 				FVector Start = CameraManager->GetCameraLocation();
 				FVector End = Start + CameraManager->GetActorForwardVector() * 5000.0f;  // 50m range
-				
+
 				FHitResult HitResult;
 				FCollisionQueryParams Params;
 				Params.AddIgnoredActor(PC->GetPawn());
 				Params.AddIgnoredActor(ActiveHologram.Get());
-				
+
 				// Use WorldStatic channel which hits buildings, not just visibility
 				if (GetWorld()->LineTraceSingleByChannel(HitResult, Start, End, ECC_WorldStatic, Params))
 				{
 					AActor* HitActor = HitResult.GetActor();
 					LookedAtBuilding = Cast<AFGBuildable>(HitActor);
-					
+
 					// Debug: Log what we're hitting (throttled to once per second)
 					static double LastLogTime = 0;
 					double CurrentTime = FPlatformTime::Seconds();
@@ -926,7 +926,7 @@ void USFSubsystem::Tick(float DeltaTime)
 				LastWarnTime = CurrentTime;
 			}
 		}
-		
+
 		// TryExtendFromBuilding handles the automatic activation/deactivation
 		ExtendService->TryExtendFromBuilding(LookedAtBuilding, ActiveHologram.Get());
 	}
@@ -957,7 +957,7 @@ void USFSubsystem::SetupPlayerInput(AFGPlayerController* PlayerController)
 	if (InputHandler)
 	{
 		InputHandler->SetupPlayerInput(PlayerController);
-		
+
 		// Start hologram polling (every 0.1 seconds for responsive detection)
 		// Note: Timer management stays in subsystem for UObject lifecycle
 		if (UWorld* WorldForDelay = GetWorld())
@@ -971,10 +971,10 @@ void USFSubsystem::SetupPlayerInput(AFGPlayerController* PlayerController)
 			);
 			UE_LOG(LogSmartFoundations, Log, TEXT("Started hologram auto-detection polling"));
 		}
-		
+
 		// Store controller reference for subsystem use
 		LastController = PlayerController;
-		
+
 		// Log active contexts after setup
 		LogActiveInputContexts(TEXT("AfterContextAdded"));
 	}
@@ -990,12 +990,12 @@ void USFSubsystem::CheckForPlayerController()
 	if (InputHandler)
 	{
 		InputHandler->CheckForPlayerController();
-		
+
 		// Sync input setup state from module
 		if (InputHandler->IsInputSetupCompleted())
 		{
 			bInputSetupCompleted = true;
-			
+
 			// Clear the timer since we're done
 			if (UWorld* World = GetWorld())
 			{
@@ -1007,18 +1007,18 @@ void USFSubsystem::CheckForPlayerController()
 
 void USFSubsystem::ApplyAxisScaling(ESFScaleAxis Axis, int32 StepDelta, const TCHAR* DebugLabel)
 {
-	UE_LOG(LogSmartFoundations, Display, TEXT("[INPUT] ApplyAxisScaling: Axis=%d Delta=%d Label=%s Extend=%d"),
+	UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("[INPUT] ApplyAxisScaling: Axis=%d Delta=%d Label=%s Extend=%d"),
 		static_cast<int32>(Axis), StepDelta, DebugLabel, IsExtendModeActive());
-	
+
 	// Refactored (Phase 1): Thin orchestrator delegating to services
 	// - Counter mutations → GridStateService
 	// - Hologram scaling → HologramHelper
 	// - Validation & logging → Subsystem (keeps all diagnostic output centralized)
-	
+
 	// ========================================
 	// 1. Validation
 	// ========================================
-	
+
 	if (!ActiveHologram.IsValid())
 	{
 		UE_LOG(LogSmartFoundations, Warning, TEXT("ApplyAxisScaling: No active hologram registered"));
@@ -1035,7 +1035,7 @@ void USFSubsystem::ApplyAxisScaling(ESFScaleAxis Axis, int32 StepDelta, const TC
 	// Check if hologram supports scaling features
 	if (CurrentAdapter && !CurrentAdapter->SupportsFeature(ESFFeature::ScaleX))
 	{
-		UE_LOG(LogSmartFoundations, Warning, 
+		UE_LOG(LogSmartFoundations, Warning,
 			TEXT("Scaling not supported for %s - ignoring input"),
 			*CurrentAdapter->GetAdapterTypeName());
 		return;
@@ -1044,7 +1044,7 @@ void USFSubsystem::ApplyAxisScaling(ESFScaleAxis Axis, int32 StepDelta, const TC
 	// ========================================
 	// 2. Update Counters via GridStateService
 	// ========================================
-	
+
 	int32 PreviousValue = 0;
 	if (GridStateService)
 	{
@@ -1055,7 +1055,7 @@ void USFSubsystem::ApplyAxisScaling(ESFScaleAxis Axis, int32 StepDelta, const TC
 	// ========================================
 	// 3. Diagnostic Logging (Subsystem keeps all logs)
 	// ========================================
-	
+
 	if (StepDelta < 0)
 	{
 		const UWorld* World = GetWorld();
@@ -1063,19 +1063,19 @@ void USFSubsystem::ApplyAxisScaling(ESFScaleAxis Axis, int32 StepDelta, const TC
 		const int32 NewValue = (Axis == ESFScaleAxis::X) ? CounterState.GridCounters.X :
 		                       (Axis == ESFScaleAxis::Y) ? CounterState.GridCounters.Y :
 		                       CounterState.GridCounters.Z;
-		UE_LOG(LogSmartFoundations, Log, TEXT("[Frame=%llu t=%.3f] Axis negative step: Axis=%d Prev=%d New=%d"),
+		UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("[Frame=%llu t=%.3f] Axis negative step: Axis=%d Prev=%d New=%d"),
 			(unsigned long long)GFrameCounter, TS, static_cast<int32>(Axis), PreviousValue, NewValue);
 	}
 
 	// ========================================
 	// 4. Apply Scaling to Hologram via HologramHelper
 	// ========================================
-	
+
 	// Scaled Extend (Issue #265): When extend is active, don't apply normal grid scaling.
 	// UpdateCounterState (below) will notify ExtendService->OnScaledExtendStateChanged().
 	if (IsExtendModeActive())
 	{
-		UE_LOG(LogSmartFoundations, Log, TEXT("⚡ SCALED EXTEND: %s axis changed, grid=[%d,%d,%d]"), DebugLabel,
+		UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("⚡ SCALED EXTEND: %s axis changed, grid=[%d,%d,%d]"), DebugLabel,
 			CounterState.GridCounters.X, CounterState.GridCounters.Y, CounterState.GridCounters.Z);
 	}
 	else if (HologramHelper)
@@ -1089,7 +1089,7 @@ void USFSubsystem::ApplyAxisScaling(ESFScaleAxis Axis, int32 StepDelta, const TC
 		case ESFScaleAxis::Y: Delta.Y = StepSize; break;
 		case ESFScaleAxis::Z: Delta.Z = StepSize; break;
 		}
-		
+
 		// Apply via service with regenerate callback
 		auto RegenerateCallback = [this]() { RegenerateChildHologramGrid(); };
 		HologramHelper->ApplyScalingDelta(Hologram, Delta, CurrentScalingOffset, RegenerateCallback);
@@ -1098,14 +1098,14 @@ void USFSubsystem::ApplyAxisScaling(ESFScaleAxis Axis, int32 StepDelta, const TC
 	// ========================================
 	// 5. Post-Scaling Logging
 	// ========================================
-	
+
 	if (ActiveHologram.IsValid())
 	{
 		const UWorld* World = GetWorld();
 		const double TS = World ? World->GetTimeSeconds() : 0.0;
 		const TArray<AFGHologram*> ParentChildren = ActiveHologram->GetHologramChildren();
 		const int32 HelperCount = HologramHelper ? HologramHelper->GetSpawnedChildren().Num() : 0;
-		UE_LOG(LogSmartFoundations, Log, TEXT("[Frame=%llu t=%.3f] Post-axis counts: helper=%d parent=%d"),
+		UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("[Frame=%llu t=%.3f] Post-axis counts: helper=%d parent=%d"),
 			(unsigned long long)GFrameCounter, TS, HelperCount, ParentChildren.Num());
 	}
 
@@ -1115,7 +1115,7 @@ void USFSubsystem::ApplyAxisScaling(ESFScaleAxis Axis, int32 StepDelta, const TC
 	// ========================================
 	// 6. Update UI and Trigger Child Repositioning
 	// ========================================
-	
+
 	UpdateCounterState(CounterState);
 
 	// ========================================
@@ -1140,7 +1140,7 @@ void USFSubsystem::ApplyAxisScaling(ESFScaleAxis Axis, int32 StepDelta, const TC
 				{
 					bLockedByModifier = true;
 					ActiveHologram->LockHologramPosition(true);
-					UE_LOG(LogSmartFoundations, Log, TEXT("🔒 AUTO-HOLD: Locked hologram after grid change [%d,%d,%d]"),
+					UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("🔒 AUTO-HOLD: Locked hologram after grid change [%d,%d,%d]"),
 						Grid.X, Grid.Y, Grid.Z);
 				}
 
@@ -1150,7 +1150,7 @@ void USFSubsystem::ApplyAxisScaling(ESFScaleAxis Axis, int32 StepDelta, const TC
 				if (!bAutoHoldActive)
 				{
 					bAutoHoldActive = true;
-					UE_LOG(LogSmartFoundations, Log, TEXT("🔒 AUTO-HOLD: Claimed ownership (grid expanded [%d,%d,%d], wasAlreadyLocked=%d)"),
+					UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("🔒 AUTO-HOLD: Claimed ownership (grid expanded [%d,%d,%d], wasAlreadyLocked=%d)"),
 						Grid.X, Grid.Y, Grid.Z, ActiveHologram->IsHologramLocked());
 				}
 			}
@@ -1163,7 +1163,7 @@ void USFSubsystem::ApplyAxisScaling(ESFScaleAxis Axis, int32 StepDelta, const TC
 					bLockedByModifier = false;
 					bAutoHoldUserOverrode = false;
 					ActiveHologram->LockHologramPosition(false);
-					UE_LOG(LogSmartFoundations, Log, TEXT("🔓 AUTO-HOLD: Released lock (grid returned to 1x1x1)"));
+					UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("🔓 AUTO-HOLD: Released lock (grid returned to 1x1x1)"));
 				}
 				if (!IsAnyModalFeatureActive())
 				{
@@ -1179,23 +1179,23 @@ void USFSubsystem::OnScaleXChanged(const FInputActionValue& Value)
 {
 	// Scaled Extend (Issue #265): Allow X scaling during extend mode.
 	// ApplyAxisScaling routes to ExtendService when extend is active.
-	
+
 	// Phase 0: Delegate input processing to InputHandler (Task #61.6)
 	if (InputHandler)
 	{
 		InputHandler->OnScaleXChanged(Value);
 	}
-	
+
 	const float AxisValue = Value.Get<float>();
-	
+
 	// DIAGNOSTIC: Log at Display level to debug scaling input regression
-	UE_LOG(LogSmartFoundations, Display, TEXT("[INPUT] OnScaleXChanged: Value=%.3f, ModX=%d, ModY=%d, HasHolo=%d, Spacing=%d, Steps=%d, Stagger=%d, Recipe=%d, Extend=%d"), 
+	UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("[INPUT] OnScaleXChanged: Value=%.3f, ModX=%d, ModY=%d, HasHolo=%d, Spacing=%d, Steps=%d, Stagger=%d, Recipe=%d, Extend=%d"),
 		AxisValue, bModifierScaleXActive, bModifierScaleYActive, ActiveHologram.IsValid(),
 		bSpacingModeActive, bStepsModeActive, bStaggerModeActive, bRecipeModeActive, IsExtendModeActive());
-	
+
 	if (!ActiveHologram.IsValid())
 	{
-		UE_LOG(LogSmartFoundations, Display, TEXT("[INPUT] OnScaleXChanged: BLOCKED - No active hologram"));
+		UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("[INPUT] OnScaleXChanged: BLOCKED - No active hologram"));
 		return;
 	}
 
@@ -1209,23 +1209,23 @@ void USFSubsystem::OnScaleXChanged(const FInputActionValue& Value)
 		}
 		return;
 	}
-	
+
 	// NumPad8/5 keys may also be bound to this axis callback. To avoid double-processing
 	// when a modal feature is active, let the dedicated handlers manage modal adjustments.
 	if (!bModifierScaleXActive && !bModifierScaleYActive &&
 		(bSpacingModeActive || bStepsModeActive || bStaggerModeActive || bRecipeModeActive))
 	{
-		UE_LOG(LogSmartFoundations, Display, TEXT("[INPUT] OnScaleXChanged: BLOCKED - Modal active (spacing=%d steps=%d stagger=%d recipe=%d)"),
+		UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("[INPUT] OnScaleXChanged: BLOCKED - Modal active (spacing=%d steps=%d stagger=%d recipe=%d)"),
 			bSpacingModeActive, bStepsModeActive, bStaggerModeActive, bRecipeModeActive);
 		return; // Modal handling is performed in OnValueIncreased/OnValueDecreased/OnMouseWheelChanged
 	}
 
 	// These become universal increment/decrement when modifiers are held
 	const int32 Direction = AxisValue > 0.0f ? +1 : -1;
-	
+
 	// Capture rotation BEFORE scaling to detect if vanilla wheel rotation interfered
 	const FRotator RotationBefore = ActiveHologram->GetActorRotation();
-	
+
 	// MODIFIER PRIORITY: Check modifiers first to determine which axis to scale
 	if (bModifierScaleXActive && bModifierScaleYActive)
 	{
@@ -1255,7 +1255,7 @@ void USFSubsystem::OnScaleXChanged(const FInputActionValue& Value)
 		UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("Scale X: %.2f (direction: %d)"), AxisValue, Direction);
 		ApplyAxisScaling(ESFScaleAxis::X, Direction, TEXT("Scale X"));
 	}
-	
+
 	// Fix rotation leak: undo any vanilla rotation that leaked through during scaling.
 	// This handles cases where external mods interfere with lock
 	// state, allowing vanilla scroll wheel rotation to apply during Smart!'s modifier use.
@@ -1264,7 +1264,7 @@ void USFSubsystem::OnScaleXChanged(const FInputActionValue& Value)
 	{
 		ActiveHologram->SetActorRotation(RotationBefore);
 		UE_LOG(LogSmartFoundations, Warning, TEXT("\U0001f504 Rotation leak corrected during scaling. Before: %s, After: %s, Delta: Yaw=%.2f"),
-			*RotationBefore.ToCompactString(), *RotationAfter.ToCompactString(), 
+			*RotationBefore.ToCompactString(), *RotationAfter.ToCompactString(),
 			RotationAfter.Yaw - RotationBefore.Yaw);
 	}
 }
@@ -1273,13 +1273,13 @@ void USFSubsystem::OnScaleYChanged(const FInputActionValue& Value)
 {
 	// Scaled Extend (Issue #265): Allow Y scaling during extend mode.
 	// ApplyAxisScaling routes to ExtendService when extend is active.
-	
+
 	// Phase 0: Delegate input processing to InputHandler (Task #61.6)
 	if (InputHandler)
 	{
 		InputHandler->OnScaleYChanged(Value);
 	}
-	
+
 	if (!ActiveHologram.IsValid())
 	{
 		UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("OnScaleYChanged: No active hologram"));
@@ -1303,7 +1303,7 @@ void USFSubsystem::OnScaleYChanged(const FInputActionValue& Value)
 	// No modifiers → Default Y-axis behavior
 	const int32 Direction = AxisValue > 0.0f ? +1 : -1;
 	LastAxisInput = ELastAxisInput::Y;
-	
+
 	UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("Scale Y: %.2f (direction: %d)"), AxisValue, Direction);
 	ApplyAxisScaling(ESFScaleAxis::Y, Direction, TEXT("Scale Y"));
 }
@@ -1315,13 +1315,13 @@ void USFSubsystem::OnScaleZChanged(const FInputActionValue& Value)
     {
         return;
     }
-    
+
     // Phase 0: Delegate input processing to InputHandler (Task #61.6)
     if (InputHandler)
     {
         InputHandler->OnScaleZChanged(Value);
     }
-    
+
     if (!ActiveHologram.IsValid())
     {
         UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("OnScaleZChanged: No active hologram"));
@@ -1352,7 +1352,7 @@ void USFSubsystem::OnValueIncreased(const FInputActionValue& Value)
 {
     // Scaled Extend (Issue #265): Allow value increase during extend mode
     // for spacing, steps, and rotation adjustments.
-    
+
     // Phase 0: Delegate input processing to InputHandler (Task #61.6)
     if (InputHandler)
     {
@@ -1360,9 +1360,9 @@ void USFSubsystem::OnValueIncreased(const FInputActionValue& Value)
     }
 
     const float AxisValue = Value.Get<float>();
-    UE_LOG(LogSmartFoundations, Display, TEXT("[INPUT] OnValueIncreased: Value=%.3f, HasHolo=%d, Spacing=%d, Steps=%d, Stagger=%d, Recipe=%d, Rotation=%d, Extend=%d"),
+    UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("[INPUT] OnValueIncreased: Value=%.3f, HasHolo=%d, Spacing=%d, Steps=%d, Stagger=%d, Recipe=%d, Rotation=%d, Extend=%d"),
         AxisValue, ActiveHologram.IsValid(), bSpacingModeActive, bStepsModeActive, bStaggerModeActive, bRecipeModeActive, bRotationModeActive, IsExtendModeActive());
-    
+
     if (FMath::Abs(AxisValue) < 0.01f)
     {
         return;
@@ -1437,7 +1437,7 @@ void USFSubsystem::OnMouseWheelChanged(const FInputActionValue& Value)
         // Check if any modal feature or modifier is active
         bool bAnyModalActive = bSpacingModeActive || bStepsModeActive || bRotationModeActive ||
                                bModifierScaleXActive || bModifierScaleYActive;
-        
+
         if (!bAnyModalActive)
         {
             // No modifiers/modes - cycle extend direction
@@ -1488,7 +1488,7 @@ void USFSubsystem::OnValueDecreased(const FInputActionValue& Value)
 {
     // Scaled Extend (Issue #265): Allow value decrease during extend mode
     // for spacing, steps, and rotation adjustments.
-    
+
     // Phase 0: Delegate input processing to InputHandler (Task #61.6)
     if (InputHandler)
     {
@@ -1547,15 +1547,15 @@ void USFSubsystem::OnValueDecreased(const FInputActionValue& Value)
 void USFSubsystem::OnModifierScaleXPressed(const FInputActionValue& Value)
 {
     // Scaled Extend (Issue #265): Allow X modifier during extend mode for Scaled Extend.
-    
+
     // Phase 0: Forward to InputHandler module (Task #61.6)
     if (InputHandler)
     {
         InputHandler->OnModifierScaleXPressed(Value);
-        
+
         // Sync state from module (temporary during migration)
         bModifierScaleXActive = InputHandler->IsModifierScaleXActive();
-        
+
         // Update arrow highlighting immediately based on modifier combination
         if (InputHandler->IsModifierScaleXActive() && InputHandler->IsModifierScaleYActive())
         {
@@ -1565,7 +1565,7 @@ void USFSubsystem::OnModifierScaleXPressed(const FInputActionValue& Value)
         {
             LastAxisInput = ELastAxisInput::X;  // X modifier only = X axis
         }
-        
+
         // Try to acquire lock (Task 52 - centralized)
         TryAcquireHologramLock();
     }
@@ -1577,11 +1577,11 @@ void USFSubsystem::OnModifierScaleXReleased(const FInputActionValue& Value)
     if (InputHandler)
     {
         InputHandler->OnModifierScaleXReleased(Value);
-        
+
         // Sync state from module (temporary during migration)
         bModifierScaleXActive = InputHandler->IsModifierScaleXActive();
     }
-    
+
     // Update arrow highlighting based on remaining modifiers
     if (InputHandler && InputHandler->IsModifierScaleYActive())
     {
@@ -1591,7 +1591,7 @@ void USFSubsystem::OnModifierScaleXReleased(const FInputActionValue& Value)
     {
         LastAxisInput = ELastAxisInput::None;  // No modifiers = show all arrows
     }
-    
+
     // Try to release lock (Task 52 - centralized)
     TryReleaseHologramLock();
 }
@@ -1599,16 +1599,16 @@ void USFSubsystem::OnModifierScaleXReleased(const FInputActionValue& Value)
 void USFSubsystem::OnModifierScaleYPressed(const FInputActionValue& Value)
 {
     // Scaled Extend (Issue #265): Allow Y modifier during extend mode for Scaled Extend.
-    
+
     // Phase 0: Forward to InputHandler module (Task #61.6)
     if (InputHandler)
     {
         InputHandler->OnModifierScaleYPressed(Value);
-        
+
         // Sync state from module (temporary during migration)
         bModifierScaleYActive = InputHandler->IsModifierScaleYActive();
     }
-    
+
     // Update arrow highlighting immediately based on modifier combination
     if (InputHandler && InputHandler->IsModifierScaleXActive() && InputHandler->IsModifierScaleYActive())
     {
@@ -1618,7 +1618,7 @@ void USFSubsystem::OnModifierScaleYPressed(const FInputActionValue& Value)
     {
         LastAxisInput = ELastAxisInput::Y;  // Y modifier only = Y axis
     }
-    
+
     // Try to acquire lock (Task 52 - centralized)
     TryAcquireHologramLock();
 }
@@ -1629,11 +1629,11 @@ void USFSubsystem::OnModifierScaleYReleased(const FInputActionValue& Value)
     if (InputHandler)
     {
         InputHandler->OnModifierScaleYReleased(Value);
-        
+
         // Sync state from module (temporary during migration)
         bModifierScaleYActive = InputHandler->IsModifierScaleYActive();
     }
-    
+
     // Update arrow highlighting based on remaining modifiers
     if (InputHandler && InputHandler->IsModifierScaleXActive())
     {
@@ -1643,7 +1643,7 @@ void USFSubsystem::OnModifierScaleYReleased(const FInputActionValue& Value)
     {
         LastAxisInput = ELastAxisInput::None;  // No modifiers = show all arrows
     }
-    
+
     // Try to release lock (Task 52 - centralized)
     TryReleaseHologramLock();
 }
@@ -1658,7 +1658,7 @@ bool USFSubsystem::TryAcquireHologramLock()
     {
         return false;
     }
-    
+
     // Only lock if not already locked by vanilla hold system
     if (!ActiveHologram->IsHologramLocked())
     {
@@ -1695,9 +1695,9 @@ bool USFSubsystem::IsAnyModalFeatureActive() const
         // Also check EXTEND mode which is managed by the ExtendService
         return InputHandler->IsAnyModalFeatureActive() || IsExtendModeActive();
     }
-    
+
     // Fallback if module not initialized
-    return bModifierScaleXActive || bModifierScaleYActive || 
+    return bModifierScaleXActive || bModifierScaleYActive ||
            bSpacingModeActive || bStepsModeActive || bStaggerModeActive ||
            bRecipeModeActive || bAutoConnectSettingsModeActive || bRotationModeActive ||
            IsExtendModeActive();
@@ -1710,21 +1710,21 @@ FVector USFSubsystem::GetFurthestTopHologramPosition() const
     {
         return FVector::ZeroVector;
     }
-    
+
     // Get current grid counters
     const FIntVector& GridCounters = GetGridCounters();
-    
+
     // If grid is 1x1x1 (no extension), return parent position
     if (GridCounters.X == 1 && GridCounters.Y == 1 && GridCounters.Z == 1)
     {
         return ActiveHologram->GetActorLocation();
     }
-    
+
     // Calculate furthest grid position based on direction
-    // The "furthest top" is at the corner furthest from the parent (X,Y) 
+    // The "furthest top" is at the corner furthest from the parent (X,Y)
     // and at the TOP Z level (highest)
     int32 FurthestX, FurthestY, TopZ;
-    
+
     // Issue #275: Scaled Extend axis mapping
     // Extend clones are placed along the building's Y axis (via RightVector).
     // GridCounters.X = clone count (always positive, from FMath::Abs).
@@ -1732,22 +1732,22 @@ FVector USFSubsystem::GetFurthestTopHologramPosition() const
     // CalculateChildPosition maps X param → building X, Y param → building Y.
     // So for Scaled Extend we must swap: clone count → FurthestY, row count → FurthestX.
     const bool bScaledExtend = ExtendService && ExtendService->IsScaledExtendActive();
-    
+
     if (bScaledExtend)
     {
         ESFExtendDirection ExtendDir = ExtendService->GetExtendDirection();
         int32 CloneCount = FMath::Abs(GridCounters.X);
-        
+
         // Clones extend along building's Y axis (RightVector)
         FurthestY = CloneCount - 1;
         if (ExtendDir == ESFExtendDirection::Left)
         {
             FurthestY = -FurthestY;  // Left = negative Y
         }
-        
+
         // Rows extend along building's X axis (perpendicular to extend)
         FurthestX = GridCounters.Y > 0 ? GridCounters.Y - 1 : 0;
-        
+
         // Scaled Extend doesn't use Z scaling
         TopZ = 0;
     }
@@ -1767,7 +1767,7 @@ FVector USFSubsystem::GetFurthestTopHologramPosition() const
         {
             FurthestX = 0;
         }
-        
+
         // Y direction
         if (GridCounters.Y > 0)
         {
@@ -1781,7 +1781,7 @@ FVector USFSubsystem::GetFurthestTopHologramPosition() const
         {
             FurthestY = 0;
         }
-        
+
         // Z direction
         if (GridCounters.Z > 0)
         {
@@ -1796,12 +1796,12 @@ FVector USFSubsystem::GetFurthestTopHologramPosition() const
             TopZ = 0;
         }
     }
-    
+
     // Get parent transform and item size
     FVector ParentLocation = ActiveHologram->GetActorLocation();
     FRotator ParentRotation = ActiveHologram->GetActorRotation();
     FVector ItemSize = GetCachedBuildingSize();
-    
+
     // Calculate world position using PositionCalculator
     if (FSFPositionCalculator* PosCalc = GetPositionCalculator())
     {
@@ -1817,7 +1817,7 @@ FVector USFSubsystem::GetFurthestTopHologramPosition() const
             FVector::ZeroVector // No anchor offset for position query
         );
     }
-    
+
     // Fallback: return parent position if PositionCalculator is unavailable
     return ActiveHologram->GetActorLocation();
 }
@@ -1842,16 +1842,16 @@ void USFSubsystem::OnSpacingModeChanged(const FInputActionValue& Value)
     {
         UE_LOG(LogSmartFoundations, Warning, TEXT("\U0001F527 Spacing Mode: ACTIVE (Semicolon held) - Current axis: %s"),
             *UEnum::GetValueAsString(CounterState.SpacingAxis));
-        UE_LOG(LogSmartFoundations, Log, TEXT("   Counters: X=%d cm, Y=%d cm, Z=%d cm"),
+        UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("   Counters: X=%d cm, Y=%d cm, Z=%d cm"),
             CounterState.SpacingX, CounterState.SpacingY, CounterState.SpacingZ);
-        
+
         // Try to acquire lock (Task 52 - centralized)
         TryAcquireHologramLock();
     }
     else
     {
         UE_LOG(LogSmartFoundations, Warning, TEXT("\U0001F527 Spacing Mode: Inactive (Semicolon released)"));
-        
+
         // Try to release lock (Task 52 - centralized)
         TryReleaseHologramLock();
     }
@@ -1883,17 +1883,17 @@ void USFSubsystem::OnStepsModeChanged(const FInputActionValue& Value)
         // Y-axis: Rows (constant Y) step up based on Y position
         const TCHAR* AxisName = (CounterState.StepsAxis == ESFScaleAxis::X) ? TEXT("X (columns)") : TEXT("Y (rows)");
         const int32 CurrentCounter = (CounterState.StepsAxis == ESFScaleAxis::X) ? CounterState.StepsX : CounterState.StepsY;
-        
+
         UE_LOG(LogSmartFoundations, Warning, TEXT("🔧 Steps Mode: ACTIVE (I held) - Axis: %s"), AxisName);
-        UE_LOG(LogSmartFoundations, Log, TEXT("   Current counter: %d units (Num0 to toggle X/Y)"), CurrentCounter);
-        
+        UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("   Current counter: %d units (Num0 to toggle X/Y)"), CurrentCounter);
+
         // Try to acquire lock (Task 52 - centralized)
         TryAcquireHologramLock();
     }
     else
     {
         UE_LOG(LogSmartFoundations, Warning, TEXT("🔧 Steps Mode: Inactive (I released)"));
-        
+
         // Try to release lock (Task 52 - centralized)
         TryReleaseHologramLock();
     }
@@ -1906,10 +1906,10 @@ void USFSubsystem::OnCycleAxis()
     {
         InputHandler->OnCycleAxis();
     }
-    
+
     // Context-aware mode swapper - dispatches based on active mode
     // Allows Num0 to work intelligently across all modal features
-    
+
     if (bAutoConnectSettingsModeActive)
     {
         // Auto-Connect Settings mode: Cycle to next setting
@@ -1922,7 +1922,7 @@ void USFSubsystem::OnCycleAxis()
         {
             GridStateService->CycleSpacingAxis(CounterState);
         }
-        
+
         const TCHAR* AxisName = TEXT("");
         switch (CounterState.SpacingAxis)
         {
@@ -1931,7 +1931,7 @@ void USFSubsystem::OnCycleAxis()
         case ESFScaleAxis::Z: AxisName = TEXT("Z"); break;
         default: break;
         }
-        UE_LOG(LogSmartFoundations, Display, TEXT(" Spacing Axis Cycled: Now adjusting %s-axis"), AxisName);
+        UE_LOG(LogSmartFoundations, VeryVerbose, TEXT(" Spacing Axis Cycled: Now adjusting %s-axis"), AxisName);
         UpdateCounterState(CounterState);
     }
     else if (bStepsModeActive)
@@ -1943,7 +1943,7 @@ void USFSubsystem::OnCycleAxis()
         }
 
         const TCHAR* AxisName = (CounterState.StepsAxis == ESFScaleAxis::X) ? TEXT("X") : TEXT("Y");
-        UE_LOG(LogSmartFoundations, Display, TEXT(" Steps Axis Toggled: Now adjusting %s-axis (columns/rows)"), AxisName);
+        UE_LOG(LogSmartFoundations, VeryVerbose, TEXT(" Steps Axis Toggled: Now adjusting %s-axis (columns/rows)"), AxisName);
         UpdateCounterState(CounterState);
     }
     else if (bStaggerModeActive)
@@ -1979,7 +1979,7 @@ void USFSubsystem::OnCycleAxis()
 			break;
 		}
 
-		UE_LOG(LogSmartFoundations, Display, TEXT(" Stagger Axis Toggled: Now adjusting %s-axis (%s)"), AxisName, AxisDescription);
+		UE_LOG(LogSmartFoundations, VeryVerbose, TEXT(" Stagger Axis Toggled: Now adjusting %s-axis (%s)"), AxisName, AxisDescription);
 		UpdateCounterState(CounterState);
 	}
 	else if (bRecipeModeActive)
@@ -1991,10 +1991,10 @@ void USFSubsystem::OnCycleAxis()
 			ActiveRecipeSource = ERecipeSource::None;
 			ActiveRecipe = nullptr;
 			CurrentRecipeIndex = 0;
-			
+
 			// Apply recipe clear to parent hologram
 			ApplyRecipeToParentHologram();
-			
+
 			// Trigger debounced regeneration to propagate clear to children
 			if (ActiveHologram.IsValid() && ActiveHologram->GetHologramChildren().Num() > 0)
 			{
@@ -2008,17 +2008,17 @@ void USFSubsystem::OnCycleAxis()
 						0.2f,  // 200ms debounce
 						false
 					);
-					UE_LOG(LogSmartFoundations, Log, TEXT("🍽️ Recipe cleared - scheduled child regeneration in 200ms"));
+					UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("🍽️ Recipe cleared - scheduled child regeneration in 200ms"));
 				}
 			}
-			
-			UE_LOG(LogSmartFoundations, Log, TEXT("🍽️ Recipe selection cleared - no recipe will be applied to parent or children"));
+
+			UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("🍽️ Recipe selection cleared - no recipe will be applied to parent or children"));
 		}
 		else
 		{
 			// No manual selection to clear, just clear everything
 			ClearAllRecipes();
-			
+
 			// Apply clear to hologram registry and trigger regeneration
 			ApplyRecipeToParentHologram();
 			if (ActiveHologram.IsValid() && ActiveHologram->GetHologramChildren().Num() > 0)
@@ -2033,13 +2033,13 @@ void USFSubsystem::OnCycleAxis()
 						0.2f,  // 200ms debounce
 						false
 					);
-					UE_LOG(LogSmartFoundations, Log, TEXT("🍽️ All recipes cleared - scheduled child regeneration in 200ms"));
+					UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("🍽️ All recipes cleared - scheduled child regeneration in 200ms"));
 				}
 			}
 		}
-		
+
 		UpdateCounterDisplay();
-		UE_LOG(LogSmartFoundations, Log, TEXT("🍽️ Recipe selection cleared via Num0"));
+		UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("🍽️ Recipe selection cleared via Num0"));
 	}
 	else
 	{
@@ -2049,17 +2049,17 @@ void USFSubsystem::OnCycleAxis()
 		{
 			const double CurrentTime = FPlatformTime::Seconds();
 			const double TimeSinceLastTap = CurrentTime - LastCycleAxisTapTime;
-			
+
 			if (TimeSinceLastTap < DoubleTapWindow && LastCycleAxisTapTime > 0.0)
 			{
 				// Double-tap detected - toggle the disable flags
 				bDisableSmartForNextAction = !bDisableSmartForNextAction;
 				bExtendDisabledForSession = !bExtendDisabledForSession;  // Issue #257: toggle Extend too
-				
+
 				if (bDisableSmartForNextAction)
 				{
 					UE_LOG(LogSmartFoundations, Warning, TEXT("⏸️ Smart! DISABLED for session (Auto-Connect + Extend) (double-tap detected)"));
-					
+
 					// Issue #198: Immediately clear all auto-connect previews when disabling
 					if (ActiveHologram.IsValid() && AutoConnectService)
 					{
@@ -2069,7 +2069,7 @@ void USFSubsystem::OnCycleAxis()
 							Orchestrator->ForceRefresh();
 						}
 					}
-					
+
 					// Issue #257: Clear active Extend state when disabling
 					if (ExtendService)
 					{
@@ -2078,8 +2078,8 @@ void USFSubsystem::OnCycleAxis()
 				}
 				else
 				{
-					UE_LOG(LogSmartFoundations, Log, TEXT("▶️ Smart! RE-ENABLED (Auto-Connect + Extend) (double-tap detected)"));
-					
+					UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("▶️ Smart! RE-ENABLED (Auto-Connect + Extend) (double-tap detected)"));
+
 					// Re-enable: trigger refresh to recreate previews
 					if (ActiveHologram.IsValid() && AutoConnectService)
 					{
@@ -2090,10 +2090,10 @@ void USFSubsystem::OnCycleAxis()
 						}
 					}
 				}
-				
+
 				// Reset timing to prevent triple-tap from toggling again
 				LastCycleAxisTapTime = 0.0;
-				
+
 				// Update HUD to show the change
 				UpdateCounterDisplay();
 			}
@@ -2118,7 +2118,7 @@ void USFSubsystem::OnStaggerModeChanged(const FInputActionValue& Value)
 	{
 		return;
 	}
-	
+
 	// Phase 0: Delegate input processing to InputHandler (Task #61.6)
 	if (InputHandler)
 	{
@@ -2135,10 +2135,10 @@ void USFSubsystem::OnStaggerModeChanged(const FInputActionValue& Value)
 		// Stagger only uses X and Y axes (lateral grid offset)
 		const TCHAR* AxisName = (CounterState.StaggerAxis == ESFScaleAxis::X) ? TEXT("X (sideways curve)") : TEXT("Y (forward curve)");
 		const int32 CurrentCounter = (CounterState.StaggerAxis == ESFScaleAxis::X) ? CounterState.StaggerX : CounterState.StaggerY;
-		
+
 		UE_LOG(LogSmartFoundations, Warning, TEXT(" Stagger Mode: ACTIVE (Y held) - Axis: %s"), AxisName);
-		UE_LOG(LogSmartFoundations, Log, TEXT("   Current counter: %d units (Num0 to toggle X/Y)"), CurrentCounter);
-		
+		UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("   Current counter: %d units (Num0 to toggle X/Y)"), CurrentCounter);
+
 		// Try to acquire lock (Task 52 - centralized)
 		TryAcquireHologramLock();
 	}
@@ -2152,7 +2152,7 @@ void USFSubsystem::OnStaggerModeChanged(const FInputActionValue& Value)
 void USFSubsystem::OnRotationModeChanged(const FInputActionValue& Value)
 {
 	// Scaled Extend (Issue #265): Allow rotation mode during extend.
-	
+
 	// Phase 0: Delegate input processing to InputHandler (Task #61.6)
 	if (InputHandler)
 	{
@@ -2169,8 +2169,8 @@ void USFSubsystem::OnRotationModeChanged(const FInputActionValue& Value)
 		// Rotation currently only uses Z axis (horizontal arc)
 		// Phase 2 will add X and Y axes for vertical arches
 		UE_LOG(LogSmartFoundations, Warning, TEXT(" Rotation Mode: ACTIVE (Comma held) - Axis: Z (horizontal arc)"));
-		UE_LOG(LogSmartFoundations, Log, TEXT("   Current rotation: %.1f° (Num0 to cycle axis when Phase 2 adds X/Y)"), CounterState.RotationZ);
-		
+		UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("   Current rotation: %.1f° (Num0 to cycle axis when Phase 2 adds X/Y)"), CounterState.RotationZ);
+
 		// Try to acquire lock (Task 52 - centralized)
 		TryAcquireHologramLock();
 	}
@@ -2188,15 +2188,15 @@ void USFSubsystem::OnToggleArrows()
 	{
 		InputHandler->OnToggleArrows();
 	}
-	
+
 #if SMART_ARROWS_ENABLED
 	// Toggle runtime visibility flag (doesn't change config)
 	bArrowsRuntimeVisible = !bArrowsRuntimeVisible;
 	bArrowsVisible = bArrowsRuntimeVisible; // Sync deprecated flag
-	UE_LOG(LogSmartFoundations, Log, TEXT("INPUT EVENT: Arrows TOGGLE - Visible: %s (Config default: %s)"), 
+	UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("INPUT EVENT: Arrows TOGGLE - Visible: %s (Config default: %s)"),
 		bArrowsRuntimeVisible ? TEXT("ON") : TEXT("OFF"),
 		CachedConfig.bShowArrows ? TEXT("true") : TEXT("false"));
-	
+
 	// Force immediate arrow update to handle visibility change
 	// This ensures arrows appear/disappear instantly without waiting for hologram movement
 	if (ActiveHologram.IsValid() && CurrentAdapter && CurrentAdapter->IsValid() && ArrowModule)
@@ -2205,7 +2205,7 @@ void USFSubsystem::OnToggleArrows()
 		if (World)
 		{
 			FTransform CurrentTransform = CurrentAdapter->GetBaseTransform();
-			
+
 			if (bArrowsRuntimeVisible)
 			{
 				// Force redraw when enabling - show arrows immediately
@@ -2218,7 +2218,7 @@ void USFSubsystem::OnToggleArrows()
 				ArrowModule->UpdateArrows(World, CurrentTransform, LastAxisInput, false);
 				UE_LOG(LogSmartFoundations, Verbose, TEXT("Arrows: Forced clear on visibility disable"));
 			}
-			
+
 			// Update cache to prevent immediate redraw in next Tick
 			LastHologramTransform = CurrentTransform;
 			LastKnownAxisInput = LastAxisInput;
@@ -2234,15 +2234,15 @@ void USFSubsystem::OnToggleArrows()
 	if (RadarPulseService)
 	{
 		const float ScanRadius = 5000.0f;   // 50m = 5000cm
-		UE_LOG(LogSmartFoundations, Display, TEXT("📡 [Arrow Toggle Debug] Comprehensive scan within 50m..."));
-		
+		UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("📡 [Arrow Toggle Debug] Comprehensive scan within 50m..."));
+
 		// 1. HOLOGRAM SCAN - Inspect all holograms in range (captures mesh paths!)
-		UE_LOG(LogSmartFoundations, Display, TEXT("📡 Scanning for holograms..."));
+		UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("📡 Scanning for holograms..."));
 		RadarPulseService->InspectAllHologramsInRadius(ScanRadius);
-		
+
 		// 2. Chain actor scan (chain boundaries, members, connections)
 		RadarPulseService->ScanChainActors(ScanRadius);
-		
+
 		// 3. Full radar pulse snapshot (all buildables with properties)
 		// Filter to logistics and factory categories for manifold research
 		TArray<FString> ManifoldCategories;
@@ -2254,13 +2254,13 @@ void USFSubsystem::OnToggleArrows()
 		ManifoldCategories.Add(TEXT("Junction"));
 		ManifoldCategories.Add(TEXT("StackablePipePole"));
 		ManifoldCategories.Add(TEXT("StackableBeltPole"));
-		
+
 		FSFRadarPulseSnapshot Snapshot = RadarPulseService->CaptureSnapshotFiltered(
-			ScanRadius, 
-			TEXT("MANIFOLD_RESEARCH"), 
+			ScanRadius,
+			TEXT("MANIFOLD_RESEARCH"),
 			ManifoldCategories
 		);
-		
+
 		// Log with verbose details and enumerate all categories
 		RadarPulseService->LogSnapshotFiltered(Snapshot, true, ManifoldCategories);
 	}
@@ -2269,16 +2269,16 @@ void USFSubsystem::OnToggleArrows()
 void USFSubsystem::OnToggleSettingsForm()
 {
 	UE_LOG(LogSmartFoundations, Warning, TEXT("!!! K KEY PRESSED !!! (OnToggleSettingsForm)"));
-	UE_LOG(LogSmartFoundations, Log, TEXT("INPUT EVENT: Settings Form Toggle (Phase 0 validation)"));
-	
+	UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("INPUT EVENT: Settings Form Toggle (Phase 0 validation)"));
+
 	// Route to Upgrade Panel if holding an upgrade-capable hologram (belt/lift/pipe/pump/power pole/wall outlet)
 	if (IsUpgradeCapableContext())
 	{
-		UE_LOG(LogSmartFoundations, Log, TEXT("Settings Form: Routing to Upgrade Panel (upgrade-capable context)"));
+		UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("Settings Form: Routing to Upgrade Panel (upgrade-capable context)"));
 		OnToggleUpgradePanel();
 		return;
 	}
-	
+
 	// Get player controller
 	AFGPlayerController* PC = GetLastController();
 	if (!PC)
@@ -2289,62 +2289,62 @@ void USFSubsystem::OnToggleSettingsForm()
 			PC = World->GetFirstPlayerController<AFGPlayerController>();
 		}
 	}
-	
+
 	if (!PC)
 	{
 		UE_LOG(LogSmartFoundations, Error, TEXT("Settings Form: No valid PlayerController available"));
 		return;
 	}
-	
+
 	// Toggle behavior: if widget is open, close it (with cancel/revert)
 	if (SettingsFormWidget.IsValid() && SettingsFormWidget->IsInViewport())
 	{
-		UE_LOG(LogSmartFoundations, Log, TEXT("Settings Form: Closing via toggle key (canceling unapplied changes)"));
-		
+		UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("Settings Form: Closing via toggle key (canceling unapplied changes)"));
+
 		// Use CancelAndClose to revert unapplied changes before closing
 		SettingsFormWidget->CancelAndClose();
 		SettingsFormWidget.Reset();
 		return;
 	}
-	
+
 	// Load the Blueprint Widget class
 	FString WidgetPath = TEXT("/SmartFoundations/SmartFoundations/UI/Smart_SettingsForm_Widget.Smart_SettingsForm_Widget_C");
 	FSoftClassPath WidgetClassPath(WidgetPath);
 	UClass* WidgetClass = WidgetClassPath.TryLoadClass<UUserWidget>();
-	
+
 	if (!WidgetClass)
 	{
 		UE_LOG(LogSmartFoundations, Error, TEXT("Settings Form: Failed to load Blueprint widget class at path: %s"), *WidgetPath);
 		return;
 	}
-	
-	UE_LOG(LogSmartFoundations, Log, TEXT("Settings Form: Loaded widget class: %s"), *WidgetClass->GetName());
-	
+
+	UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("Settings Form: Loaded widget class: %s"), *WidgetClass->GetName());
+
 	// Create widget instance and add to viewport
 	USmartSettingsFormWidget* WidgetInstance = CreateWidget<USmartSettingsFormWidget>(PC, WidgetClass);
-	
+
 	if (!WidgetInstance)
 	{
 		UE_LOG(LogSmartFoundations, Error, TEXT("Settings Form: Failed to create widget instance"));
 		return;
 	}
-	
+
 	// Store reference for toggle behavior
 	SettingsFormWidget = WidgetInstance;
-	
+
 	// Suppress HUD while settings form is open
 	if (HudService)
 	{
 		HudService->SetHUDSuppressed(true);
 	}
-	
+
 	// Populate form with current counter state values
 	WidgetInstance->PopulateFromCounterState(this);
-	
+
 	// Set visibility and add to viewport
 	WidgetInstance->SetVisibility(ESlateVisibility::Visible);
 	WidgetInstance->AddToViewport(100);
-	
+
 	// Enable mouse cursor and UI-only input mode (blocks game input to prevent click-through)
 	PC->bShowMouseCursor = true;
 	FInputModeUIOnly InputMode;
@@ -2383,45 +2383,45 @@ bool USFSubsystem::IsUpgradeCapableContext() const
     {
         return false;
     }
-    
+
     FString ClassName = Hologram->GetClass()->GetName();
     UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("IsUpgradeCapableContext: Checking hologram class: %s"), *ClassName);
-    
+
     // Belt holograms (conveyor belts) - e.g. Holo_ConveyorBelt_C
     if (ClassName.Contains(TEXT("ConveyorBelt")) && !ClassName.Contains(TEXT("Lift")))
     {
         return true;
     }
-    
+
     // Lift holograms (conveyor lifts) - e.g. Holo_ConveyorLift_C
     if (ClassName.Contains(TEXT("ConveyorLift")) || ClassName.Contains(TEXT("Lift")))
     {
         return true;
     }
-    
+
     // Pipeline holograms (pipes)
     if (ClassName.Contains(TEXT("Pipeline")) && !ClassName.Contains(TEXT("Junction")) && !ClassName.Contains(TEXT("Pump")) && !ClassName.Contains(TEXT("Support")))
     {
         return true;
     }
-    
+
     // Power line/wire holograms - use for power network upgrades instead of power poles
     // This avoids conflict with power pole (and wall outlet) scaling feature
     if (ClassName.Contains(TEXT("Wire")) || ClassName.Contains(TEXT("PowerLine")))
     {
         return true;
     }
-    
+
     // Note: Pipeline Pumps, Power Poles, and Wall Outlets intentionally return false here
     // so that the Smart! Panel opens instead, allowing players to use grid scaling.
-    
+
     return false;
 }
 
 void USFSubsystem::OnToggleUpgradePanel()
 {
-	UE_LOG(LogSmartFoundations, Log, TEXT("INPUT EVENT: Upgrade Panel Toggle"));
-	
+	UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("INPUT EVENT: Upgrade Panel Toggle"));
+
 	// Get player controller
 	AFGPlayerController* PC = GetLastController();
 	if (!PC)
@@ -2432,25 +2432,25 @@ void USFSubsystem::OnToggleUpgradePanel()
 			PC = World->GetFirstPlayerController<AFGPlayerController>();
 		}
 	}
-	
+
 	if (!PC)
 	{
 		UE_LOG(LogSmartFoundations, Error, TEXT("Upgrade Panel: No valid PlayerController available"));
 		return;
 	}
-	
+
 	// Toggle behavior: if widget is open, close it
 	if (UpgradePanelWidget.IsValid() && UpgradePanelWidget->IsInViewport())
 	{
-		UE_LOG(LogSmartFoundations, Log, TEXT("Upgrade Panel: Closing via toggle key"));
+		UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("Upgrade Panel: Closing via toggle key"));
 		UpgradePanelWidget->RemoveFromParent();
 		UpgradePanelWidget.Reset();
-		
+
 		// Restore game input mode
 		PC->bShowMouseCursor = false;
 		FInputModeGameOnly InputMode;
 		PC->SetInputMode(InputMode);
-		
+
 		// Re-enable HUD
 		if (HudService)
 		{
@@ -2458,89 +2458,89 @@ void USFSubsystem::OnToggleUpgradePanel()
 		}
 		return;
 	}
-	
+
 	// Load the Upgrade Panel Blueprint Widget class
 	FString WidgetPath = TEXT("/SmartFoundations/SmartFoundations/UI/Smart_UpgradePanel_Widget.Smart_UpgradePanel_Widget_C");
 	FSoftClassPath WidgetClassPath(WidgetPath);
 	UClass* WidgetClass = WidgetClassPath.TryLoadClass<UUserWidget>();
-	
+
 	if (!WidgetClass)
 	{
 		UE_LOG(LogSmartFoundations, Error, TEXT("Upgrade Panel: Failed to load Blueprint widget class at path: %s"), *WidgetPath);
 		return;
 	}
-	
-	UE_LOG(LogSmartFoundations, Log, TEXT("Upgrade Panel: Loaded widget class: %s"), *WidgetClass->GetName());
-	
+
+	UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("Upgrade Panel: Loaded widget class: %s"), *WidgetClass->GetName());
+
 	// Create widget instance - try our C++ class first, fall back to UUserWidget if Blueprint not reparented
 	USmartUpgradePanel* SmartPanelInstance = CreateWidget<USmartUpgradePanel>(PC, WidgetClass);
 	UUserWidget* WidgetInstance = SmartPanelInstance;
-	
+
 	if (!WidgetInstance)
 	{
 		UE_LOG(LogSmartFoundations, Warning, TEXT("Upgrade Panel: CreateWidget<USmartUpgradePanel> failed, trying UUserWidget fallback"));
 		// Blueprint may not be reparented yet - fall back to base UUserWidget
 		WidgetInstance = CreateWidget<UUserWidget>(PC, WidgetClass);
 	}
-	
+
 	if (!WidgetInstance)
 	{
 		UE_LOG(LogSmartFoundations, Error, TEXT("Upgrade Panel: Failed to create widget instance - Blueprint may need to be reparented to UserWidget in Unreal Editor"));
 		UE_LOG(LogSmartFoundations, Error, TEXT("Upgrade Panel: Open Smart_UpgradePanel_Widget in UE Editor, go to Class Settings, and set Parent Class to UserWidget or SmartUpgradePanel"));
 		return;
 	}
-	
+
 	// Store reference for toggle behavior
 	UpgradePanelWidget = WidgetInstance;
-	
+
 	// If using fallback UUserWidget, manually bind the close button
 	if (!SmartPanelInstance)
 	{
-		UE_LOG(LogSmartFoundations, Log, TEXT("Upgrade Panel: Using fallback mode - manually binding close button"));
+		UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("Upgrade Panel: Using fallback mode - manually binding close button"));
 		if (UButton* CloseButton = Cast<UButton>(WidgetInstance->GetWidgetFromName(TEXT("CloseButton"))))
 		{
 			CloseButton->OnClicked.AddDynamic(this, &USFSubsystem::OnUpgradePanelCloseClicked);
-			UE_LOG(LogSmartFoundations, Log, TEXT("Upgrade Panel: CloseButton bound successfully"));
+			UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("Upgrade Panel: CloseButton bound successfully"));
 		}
 		else
 		{
 			UE_LOG(LogSmartFoundations, Warning, TEXT("Upgrade Panel: CloseButton not found in widget"));
 		}
 	}
-	
+
 	// Suppress HUD while upgrade panel is open
 	if (HudService)
 	{
 		HudService->SetHUDSuppressed(true);
 	}
-	
+
 	// Set visibility and add to viewport
 	WidgetInstance->SetVisibility(ESlateVisibility::Visible);
 	WidgetInstance->AddToViewport(100);
-	
+
 	// Enable mouse cursor and UI-only input mode (blocks game input to prevent click-through)
 	PC->bShowMouseCursor = true;
 	FInputModeUIOnly InputMode;
 	InputMode.SetWidgetToFocus(WidgetInstance->TakeWidget());
 	InputMode.SetLockMouseToViewportBehavior(EMouseLockMode::DoNotLock);
 	PC->SetInputMode(InputMode);
-	
+
 	// Set widget to be focusable so it can receive keyboard input
 	WidgetInstance->SetIsFocusable(true);
 	WidgetInstance->SetKeyboardFocus();
-	
-	UE_LOG(LogSmartFoundations, Log, TEXT("Upgrade Panel: Opened (ESC or Close button to close)"));
+
+	UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("Upgrade Panel: Opened (ESC or Close button to close)"));
 }
 
 void USFSubsystem::OnUpgradePanelCloseClicked()
 {
-	UE_LOG(LogSmartFoundations, Log, TEXT("Upgrade Panel: Close button clicked (fallback handler)"));
-	
+	UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("Upgrade Panel: Close button clicked (fallback handler)"));
+
 	if (!UpgradePanelWidget.IsValid())
 	{
 		return;
 	}
-	
+
 	// Get player controller
 	AFGPlayerController* PC = GetLastController();
 	if (!PC)
@@ -2551,11 +2551,11 @@ void USFSubsystem::OnUpgradePanelCloseClicked()
 			PC = World->GetFirstPlayerController<AFGPlayerController>();
 		}
 	}
-	
+
 	// Remove widget from viewport
 	UpgradePanelWidget->RemoveFromParent();
 	UpgradePanelWidget.Reset();
-	
+
 	// Restore game input mode
 	if (PC)
 	{
@@ -2563,14 +2563,14 @@ void USFSubsystem::OnUpgradePanelCloseClicked()
 		FInputModeGameOnly InputMode;
 		PC->SetInputMode(InputMode);
 	}
-	
+
 	// Re-enable HUD
 	if (HudService)
 	{
 		HudService->SetHUDSuppressed(false);
 	}
-	
-	UE_LOG(LogSmartFoundations, Log, TEXT("Upgrade Panel: Closed via close button"));
+
+	UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("Upgrade Panel: Closed via close button"));
 }
 
 // Hologram management with enhanced logging
@@ -2581,7 +2581,7 @@ void USFSubsystem::RegisterActiveHologram(AFGHologram* Hologram)
 		UE_LOG(LogSmartFoundations, Warning, TEXT("HOLOGRAM REGISTRATION FAILED: Null hologram pointer"));
 		return;
 	}
-	
+
 	// Lazy initialization on first hologram registration (Task #58)
 	if (!bSubsystemInitialized)
 	{
@@ -2589,25 +2589,25 @@ void USFSubsystem::RegisterActiveHologram(AFGHologram* Hologram)
 		if (World)
 		{
 			UE_LOG(LogSmartFoundations, Log, TEXT("Smart! Subsystem: Lazy initialization on first hologram registration"));
-			
+
 			// Load configuration (deferred from Initialize() to ensure ConfigManager is available)
 			if (!bConfigLoaded)
 			{
 				LoadConfiguration();
 			}
-			
+
 			// Initialize HUD widgets
 			InitializeWidgets();
-			
+
 #if SMART_ARROWS_ENABLED
 			// Initialize StaticMeshComponent-based arrow visualization (Task 17)
 			// Always initialize so Num1 toggle works, but respect config for initial visibility
 			if (ArrowModule && ArrowModule->Initialize(World, this, this))
 			{
-				UE_LOG(LogSmartFoundations, Log, TEXT("✅ Arrow visualization initialized (StaticMeshComponent) - Config: bShowArrows=%s, Runtime: %s"), 
+				UE_LOG(LogSmartFoundations, Log, TEXT("✅ Arrow visualization initialized (StaticMeshComponent) - Config: bShowArrows=%s, Runtime: %s"),
 					CachedConfig.bShowArrows ? TEXT("true") : TEXT("false"),
 					bArrowsRuntimeVisible ? TEXT("true") : TEXT("false"));
-				
+
 				// Start arrow drawing timer (every frame = ~16ms at 60fps)
 				World->GetTimerManager().SetTimer(
 					ArrowTickTimer,
@@ -2625,17 +2625,17 @@ void USFSubsystem::RegisterActiveHologram(AFGHologram* Hologram)
 #else
 			UE_LOG(LogSmartFoundations, Verbose, TEXT("Arrow visualization disabled (SMART_ARROWS_ENABLED=0)"));
 #endif
-			
+
 			bSubsystemInitialized = true;
 		}
 	}
-	
+
 	// Reset auto-connect runtime settings when hologram changes
 	ResetAutoConnectRuntimeSettings();
-	
+
 	// Issue #198: Reset one-shot Smart disable flag when hologram changes
 	ResetSmartDisableFlag();
-	
+
 	// Reset current auto-connect setting based on hologram type
 	// This ensures the HUD shows appropriate defaults for the new hologram type
 	// NOTE: We determine the setting AFTER ActiveHologram is assigned so detection works
@@ -2664,67 +2664,67 @@ void USFSubsystem::RegisterActiveHologram(AFGHologram* Hologram)
 	{
 		CurrentAutoConnectSetting = EAutoConnectSetting::Enabled;
 	}
-	
+
 	// NOTE: Hologram swapping is DISABLED to fix the infinite re-registration loop
 	// The build gun holds the original hologram reference, and swapping creates a mismatch:
 	// - BuildState->GetHologram() returns vanilla hologram
 	// - ActiveHologram is our swapped custom hologram
 	// - PollForActiveHologram sees mismatch → unregister/re-register → infinite loop
-	// 
+	//
 	// EXTEND and Scaling work with vanilla holograms - no swap needed.
 	// If custom hologram behavior is needed in the future, use Blueprint class remapping at module load.
 	ActiveHologram = Hologram;
-	UE_LOG(LogSmartFoundations, Log, TEXT("RegisterActiveHologram: %s"), *Hologram->GetName());
-	
+	UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("RegisterActiveHologram: %s"), *Hologram->GetName());
+
 	// Issue #281: Notify hint bar service
 	if (HintBarService)
 	{
 		HintBarService->OnHologramRegistered();
 	}
-	
+
 	// NOTE: Pipe previews are now handled by the Auto-Connect Orchestrator (created below)
 	// Don't call PipeAutoConnectManager directly here to avoid duplicate managers
-	
+
 	CurrentScalingOffset = FVector::ZeroVector;
-	
+
 	// Clear recipe cache when switching to new hologram type
 	if (SortedFilteredRecipes.Num() > 0)
 	{
-		UE_LOG(LogSmartFoundations, Log, TEXT("🍽️ Clearing recipe cache for new hologram type (had %d recipes)"), 
+		UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("🍽️ Clearing recipe cache for new hologram type (had %d recipes)"),
 			SortedFilteredRecipes.Num());
 		SortedFilteredRecipes.Empty();
 		CurrentRecipeIndex = 0;
 	}
-	
+
 	// Clear active recipe when switching to new hologram type to prevent stale display
 	if (ActiveRecipe != nullptr)
 	{
-		UE_LOG(LogSmartFoundations, Log, TEXT("🍽️ Clearing active recipe for new hologram type"));
+		UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("🍽️ Clearing active recipe for new hologram type"));
 		ActiveRecipe = nullptr;
 		ActiveRecipeSource = ERecipeSource::None;
 	}
-	
+
 	// Clear any pending recipe regeneration timer when switching building types
 	if (UWorld* World = GetWorld())
 	{
 		World->GetTimerManager().ClearTimer(RecipeRegenerationTimer);
 	}
-	
+
 	// Reset all counters for new hologram (centralized - Task 51)
 	ResetCounters();
-	
+
 	// Reset HUD state to prevent stale display from previous hologram
 	if (HudService)
 	{
 		HudService->ResetState();
 	}
-	
+
 	// Reset Zoop flag in HologramHelper (Issue #160)
 	if (HologramHelper)
 	{
 		HologramHelper->ClearZoopState();
 	}
-	
+
 	// Log counter state after reset to verify proper initialization
 	UE_LOG(LogSmartFoundations, VeryVerbose, TEXT(" COUNTER STATE AFTER RESET:"));
 	UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("   Grid: [%d, %d, %d] = %d items | ValidChildren=%d"),
@@ -2737,7 +2737,7 @@ void USFSubsystem::RegisterActiveHologram(AFGHologram* Hologram)
 	UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("   Steps: Axis=%d | X=%d Y=%d (cm)"),
 		(int32)CounterState.StepsAxis, CounterState.StepsX, CounterState.StepsY);
 	UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("   Stagger: Axis=%d | X=%d Y=%d ZX=%d ZY=%d (cm)"),
-		(int32)CounterState.StaggerAxis, CounterState.StaggerX, CounterState.StaggerY, 
+		(int32)CounterState.StaggerAxis, CounterState.StaggerX, CounterState.StaggerY,
 		CounterState.StaggerZX, CounterState.StaggerZY);
 	UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("   Summary: GridCounters=[%d,%d,%d] SpacingMode=%d SpacingX=%d StepsX=%d StaggerX=%d"),
         CounterState.GridCounters.X, CounterState.GridCounters.Y, CounterState.GridCounters.Z,
@@ -2758,10 +2758,10 @@ void USFSubsystem::RegisterActiveHologram(AFGHologram* Hologram)
 	// Identify what we're trying to build (recipe/build class) for troubleshooting
 	UClass* RecipeUClass = Hologram->GetRecipe();
 	UClass* BuildUClass = Hologram->GetBuildClass();
-	UE_LOG(LogSmartFoundations, Log, TEXT("BUILD SELECTION: Recipe=%s BuildClass=%s Hologram=%s"),
+	UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("BUILD SELECTION: Recipe=%s BuildClass=%s Hologram=%s"),
 		*GetNameSafe(RecipeUClass), *GetNameSafe(BuildUClass), *Hologram->GetName());
 
-	UE_LOG(LogSmartFoundations, Log, TEXT("My log is running."));
+	UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("My log is running."));
 
 	// Apply default ramp stepping if this is a ramp hologram (Task 76.3)
 	// This sets a sensible default X-axis step based on the ramp's slope
@@ -2772,7 +2772,7 @@ void USFSubsystem::RegisterActiveHologram(AFGHologram* Hologram)
 	{
 		FSFBuildableSizeProfile Profile = USFBuildableSizeRegistry::GetProfile(BuildUClass);
 		float RampUnitHeight = USFBuildableSizeRegistry::GetRampUnitHeight(Profile);
-		
+
 		// Only apply default if this is a ramp (RampUnitHeight != 0) and StepsX is still unset (0)
 		// Note: RampUnitHeight can be negative for descending structures (walkway ramps, catwalk stairs)
 		if (RampUnitHeight != 0.0f && CounterState.StepsX == 0)
@@ -2780,17 +2780,17 @@ void USFSubsystem::RegisterActiveHologram(AFGHologram* Hologram)
 			// Convert unit height to integer cm (rounding to nearest 100cm for clean values)
 			int32 DefaultStepX = FMath::RoundToInt(RampUnitHeight / 100.0f) * 100;
 			CounterState.StepsX = DefaultStepX;
-			
+
 			// Sync the updated state back to GridStateService if it exists
 			if (GridStateService)
 			{
 				GridStateService->UpdateCounterState(CounterState);
 			}
-			
-			UE_LOG(LogSmartFoundations, Log, 
+
+			UE_LOG(LogSmartFoundations, VeryVerbose,
 				TEXT("🔧 RAMP DEFAULT STEPPING: Applied default StepsX=%dcm for %s (UnitHeight=%.1fcm)"),
 				DefaultStepX, *Profile.BuildableClassName, RampUnitHeight);
-			
+
 			// Trigger HUD refresh to show the new stepping value
 			UpdateCounterDisplay();
 		}
@@ -2803,18 +2803,18 @@ void USFSubsystem::RegisterActiveHologram(AFGHologram* Hologram)
 	{
 		const bool bWallPole = USFAutoConnectService::IsWallConveyorPoleHologram(Hologram);
 		int32& SpacingAxis = bWallPole ? CounterState.SpacingY : CounterState.SpacingX;
-		
+
 		if (SpacingAxis == 0)
 		{
 			SpacingAxis = 5400; // 54m (belts vanish at 55m due to belt length limit)
-			
+
 			// Sync the updated state back to GridStateService if it exists
 			if (GridStateService)
 			{
 				GridStateService->UpdateCounterState(CounterState);
 			}
-			
-			UE_LOG(LogSmartFoundations, Log, TEXT("🔧 SUPPORT POLE: Applied default Spacing%s=5400cm for bus layout"),
+
+			UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("🔧 SUPPORT POLE: Applied default Spacing%s=5400cm for bus layout"),
 				bWallPole ? TEXT("Y") : TEXT("X"));
 			UpdateCounterDisplay();
 		}
@@ -2823,10 +2823,10 @@ void USFSubsystem::RegisterActiveHologram(AFGHologram* Hologram)
 	// Smart Auto-Connect: Check if this is a distributor hologram for auto-connect
 	UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("🔧 DEBUG: Checking hologram type for auto-connect"));
 	UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("🔧 DEBUG: AutoConnectService available: %s"), AutoConnectService ? TEXT("YES") : TEXT("NO"));
-	
+
 	if (AutoConnectService && AutoConnectService->IsDistributorHologram(Hologram))
 	{
-		UE_LOG(LogSmartFoundations, Log, TEXT("🎯 Distributor hologram detected - enabling auto-connect"));
+		UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("🎯 Distributor hologram detected - enabling auto-connect"));
 		OnDistributorHologramUpdated(Hologram);
 	}
 	else
@@ -2840,26 +2840,26 @@ void USFSubsystem::RegisterActiveHologram(AFGHologram* Hologram)
 		const bool bIsLocked = Hologram->IsHologramLocked();
 		const bool bCanLock = Hologram->CanLockHologram();
 		const bool bCanNudge = Hologram->CanNudgeHologram();
-		UE_LOG(LogSmartFoundations, Display, TEXT("HOLOGRAM REGISTERED: %s (%s adapter) - Ready for scaling | LOCK STATE: Locked=%s, CanLock=%s, CanNudge=%s"),
+		UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("HOLOGRAM REGISTERED: %s (%s adapter) - Ready for scaling | LOCK STATE: Locked=%s, CanLock=%s, CanNudge=%s"),
 			*Hologram->GetName(), *CurrentAdapter->GetAdapterTypeName(),
 			bIsLocked ? TEXT("YES") : TEXT("NO"),
 			bCanLock ? TEXT("YES") : TEXT("NO"),
 			bCanNudge ? TEXT("YES") : TEXT("NO"));
 
 		// Debug: Check recipe cache initialization conditions
-		UE_LOG(LogSmartFoundations, Log, TEXT("🍽️ DEBUG: Cache init check - bHasStored=%d, Recipe=%s, CacheSize=%d"), 
+		UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("🍽️ DEBUG: Cache init check - bHasStored=%d, Recipe=%s, CacheSize=%d"),
 			bHasStoredProductionRecipe, StoredProductionRecipe ? TEXT("Valid") : TEXT("Null"), SortedFilteredRecipes.Num());
 
 		// Initialize recipe cache now that hologram is registered
 		// Cache should initialize for ANY factory building, not just when we have a stored recipe
 		if (SortedFilteredRecipes.Num() == 0)
 		{
-			UE_LOG(LogSmartFoundations, Log, TEXT("🍽️ Initializing recipe cache after hologram registration"));
+			UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("🍽️ Initializing recipe cache after hologram registration"));
 			SortedFilteredRecipes = GetFilteredRecipesForCurrentHologram();
 			if (SortedFilteredRecipes.Num() > 0)
 			{
-				UE_LOG(LogSmartFoundations, Log, TEXT("🍽️ Recipe cache populated: %d recipes available"), SortedFilteredRecipes.Num());
-				
+				UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("🍽️ Recipe cache populated: %d recipes available"), SortedFilteredRecipes.Num());
+
 				// Restore active recipe from stored recipe if available and no manual selection is active
 				if (bHasStoredProductionRecipe && StoredProductionRecipe && ActiveRecipeSource != ERecipeSource::ManuallySelected)
 				{
@@ -2872,40 +2872,40 @@ void USFSubsystem::RegisterActiveHologram(AFGHologram* Hologram)
 							CurrentRecipeIndex = i;
 							ActiveRecipeSource = ERecipeSource::Copied;
 							StoredRecipeDisplayName = GetRecipeDisplayName(ActiveRecipe);
-							
-							UE_LOG(LogSmartFoundations, Log, TEXT("🍽️ Restored active recipe from stored: %s [%d/%d]"), 
+
+							UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("🍽️ Restored active recipe from stored: %s [%d/%d]"),
 								*StoredRecipeDisplayName, i + 1, SortedFilteredRecipes.Num());
 							break;
 						}
 					}
 				}
-				
+
 				UpdateCounterDisplay(); // Refresh display with populated cache
 			}
 		}
 		else
 		{
-			UE_LOG(LogSmartFoundations, Log, TEXT("🍽️ DEBUG: Cache already exists with %d recipes"), SortedFilteredRecipes.Num());
+			UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("🍽️ DEBUG: Cache already exists with %d recipes"), SortedFilteredRecipes.Num());
 		}
 
 		// ========================================
 		// Recipe Copying System - Use existing stored recipe
 		// ========================================
-		
+
 		// Recipe storage should only come from existing buildings via StoreProductionRecipeFromBuilding
 		// Holograms only have build recipes, not production recipes
 		// We preserve any existing stored production recipe for inheritance
-		
+
 		if (!Hologram->GetParentHologram()) // Only log for parent holograms
 		{
 			if (bHasStoredProductionRecipe)
 			{
-				UE_LOG(LogSmartFoundations, Log, TEXT("RECIPE COPYING: Using stored production recipe %s for child inheritance"), 
+				UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("RECIPE COPYING: Using stored production recipe %s for child inheritance"),
 					*StoredProductionRecipe->GetName());
 			}
 			else
 			{
-				UE_LOG(LogSmartFoundations, Log, TEXT("RECIPE COPYING: No stored production recipe - middle-click an existing building to copy its recipe"));
+				UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("RECIPE COPYING: No stored production recipe - middle-click an existing building to copy its recipe"));
 			}
 		}
 
@@ -2913,7 +2913,7 @@ void USFSubsystem::RegisterActiveHologram(AFGHologram* Hologram)
 		// This size is reused for all child positioning to avoid repeated adapter queries
 		// Priority: Use validated registry dimensions if available, otherwise fall back to adapter bounds
 		bool bBuildingSupportsScaling = true;  // Default to true for unknown buildings (safe fallback)
-		
+
 		if (USFBuildableSizeRegistry::HasProfile(BuildUClass))
 		{
 			// Use validated dimensions from registry
@@ -2924,16 +2924,16 @@ void USFSubsystem::RegisterActiveHologram(AFGHologram* Hologram)
 				CachedBuildingSize = USFBuildableSizeRegistry::GetSizeForHologram(BuildableHologram);
 				CachedAnchorOffset = Profile.AnchorOffset;
 				bBuildingSupportsScaling = Profile.bSupportsScaling;  // Issue #164: Check if building is scalable
-				
+
 				if (!CachedAnchorOffset.IsZero())
 				{
-					UE_LOG(LogSmartFoundations, Display, TEXT("✅ CACHED BUILDING SIZE: %s | ANCHOR OFFSET: %s | Source: %s | Scalable: %s"), 
+					UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("✅ CACHED BUILDING SIZE: %s | ANCHOR OFFSET: %s | Source: %s | Scalable: %s"),
 						*CachedBuildingSize.ToString(), *CachedAnchorOffset.ToString(), *Profile.SourceFile,
 						bBuildingSupportsScaling ? TEXT("YES") : TEXT("NO"));
 				}
 				else
 				{
-					UE_LOG(LogSmartFoundations, Display, TEXT("✅ CACHED BUILDING SIZE: %s | Source: %s | Scalable: %s"), 
+					UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("✅ CACHED BUILDING SIZE: %s | Source: %s | Scalable: %s"),
 						*CachedBuildingSize.ToString(), *Profile.SourceFile,
 						bBuildingSupportsScaling ? TEXT("YES") : TEXT("NO"));
 				}
@@ -2953,7 +2953,7 @@ void USFSubsystem::RegisterActiveHologram(AFGHologram* Hologram)
 			const FBoxSphereBounds AdapterBounds = CurrentAdapter->GetBuildingBounds();
 			CachedBuildingSize = AdapterBounds.BoxExtent * 2.0f;
 			CachedAnchorOffset = FVector::ZeroVector;
-			
+
 			// Validate and clamp to reasonable range
 			const float MaxReasonableSize = 2000.0f; // 20 meters
 			if (CachedBuildingSize.X > 1.f && CachedBuildingSize.Y > 1.f && CachedBuildingSize.Z > 1.f)
@@ -2967,8 +2967,8 @@ void USFSubsystem::RegisterActiveHologram(AFGHologram* Hologram)
 				// Invalid size, use default
 				CachedBuildingSize = FVector(800.0f, 800.0f, 100.0f);
 			}
-			
-			UE_LOG(LogSmartFoundations, Warning, TEXT("⚠️ CACHED BUILDING SIZE: %s via %s fallback (unknown buildable - consider adding to registry)"), 
+
+			UE_LOG(LogSmartFoundations, Warning, TEXT("⚠️ CACHED BUILDING SIZE: %s via %s fallback (unknown buildable - consider adding to registry)"),
 				*CachedBuildingSize.ToString(), *CurrentAdapter->GetAdapterTypeName());
 		}
 
@@ -2976,12 +2976,12 @@ void USFSubsystem::RegisterActiveHologram(AFGHologram* Hologram)
 		// When building while holding modifiers, vanilla releases the lock on hologram transition.
 		// We need to reset our ownership flag and re-acquire if modifiers are still held.
 		bLockedByModifier = false;
-		
+
 		// If any modal features are still active (modifiers held during build), re-acquire lock
 		if (IsAnyModalFeatureActive())
 		{
 			TryAcquireHologramLock();
-			UE_LOG(LogSmartFoundations, Display, TEXT("🔒 Lock re-acquired for new hologram (modifiers still held)"));
+			UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("🔒 Lock re-acquired for new hologram (modifiers still held)"));
 		}
 
 #if SMART_ARROWS_ENABLED
@@ -2993,20 +2993,20 @@ void USFSubsystem::RegisterActiveHologram(AFGHologram* Hologram)
 			if (ArrowModule && ArrowModule->IsInitialized())
 			{
 				USceneComponent* RootComponent = Hologram->GetRootComponent();
-				
+
 				if (RootComponent && ArrowModule->AttachToHologram(RootComponent))
 				{
 					// Reset arrow state for new hologram - should show all 3 arrows initially
 					LastAxisInput = ELastAxisInput::None;
 					ArrowModule->SetHighlightedAxis(ELastAxisInput::None);
-					
-					UE_LOG(LogSmartFoundations, Log, TEXT("✅ ARROWS ATTACHED TO HOLOGRAM - State reset to show all 3 arrows"));
+
+					UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("✅ ARROWS ATTACHED TO HOLOGRAM - State reset to show all 3 arrows"));
 				}
 				else
 				{
 					// AttachToHologram returns false when assets are still loading (async)
 					// The deferred attachment system will complete the attachment when assets are ready
-					UE_LOG(LogSmartFoundations, Log, TEXT("⏳ DEFERRED ARROW ATTACHMENT - Waiting for assets to load (arrows will appear shortly)"));
+					UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("⏳ DEFERRED ARROW ATTACHMENT - Waiting for assets to load (arrows will appear shortly)"));
 				}
 			}
 			else
@@ -3017,7 +3017,7 @@ void USFSubsystem::RegisterActiveHologram(AFGHologram* Hologram)
 		else
 		{
 			// Building does not support scaling - skip arrow attachment
-			UE_LOG(LogSmartFoundations, Log, TEXT("⏭️ ARROWS SKIPPED - Building does not support scaling (Issue #164)"));
+			UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("⏭️ ARROWS SKIPPED - Building does not support scaling (Issue #164)"));
 		}
 #endif
 	}
@@ -3025,11 +3025,11 @@ void USFSubsystem::RegisterActiveHologram(AFGHologram* Hologram)
 	{
 		UE_LOG(LogSmartFoundations, Warning, TEXT("HOLOGRAM REGISTERED: %s - Adapter creation failed"), *Hologram->GetName());
 	}
-	
+
 	// Initial auto-connect check for distributor holograms (fixes missing previews on first selection)
 	if (Hologram && AutoConnectService && AutoConnectService->IsDistributorHologram(Hologram))
 	{
-		UE_LOG(LogSmartFoundations, Log, TEXT("🎯 AUTO-CONNECT: Initial check for newly selected distributor hologram: %s"), *Hologram->GetName());
+		UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("🎯 AUTO-CONNECT: Initial check for newly selected distributor hologram: %s"), *Hologram->GetName());
 		OnDistributorHologramUpdated(Hologram);
 
 		// Issue #269: Post-registration refresh with FORCE RECREATE on next tick
@@ -3045,7 +3045,7 @@ void USFSubsystem::RegisterActiveHologram(AFGHologram* Hologram)
 				if (USFAutoConnectOrchestrator* Orchestrator = GetOrCreateOrchestrator(WeakHolo.Get()))
 				{
 					Orchestrator->OnGridChanged();
-					UE_LOG(LogSmartFoundations, Log, TEXT("🎯 Orchestrator: Post-registration forced refresh (next tick) for %s"), *WeakHolo->GetName());
+					UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("🎯 Orchestrator: Post-registration forced refresh (next tick) for %s"), *WeakHolo->GetName());
 				}
 			});
 			World->GetTimerManager().SetTimerForNextTick(D);
@@ -3063,7 +3063,7 @@ void USFSubsystem::RegisterActiveHologram(AFGHologram* Hologram)
 	// Notify external systems (like SmartCamera)
 	if (OnHologramCreated.IsBound())
 	{
-		UE_LOG(LogSmartFoundations, Display, TEXT("🎥 Broadcasting OnHologramCreated to external systems"));
+		UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("🎥 Broadcasting OnHologramCreated to external systems"));
 		OnHologramCreated.Broadcast(Hologram);
 	}
 }
@@ -3078,18 +3078,18 @@ void USFSubsystem::UnregisterActiveHologram(AFGHologram* Hologram)
 			OnHologramDestroyed.Broadcast(Hologram);
 		}
 
-		UE_LOG(LogSmartFoundations, Log, TEXT("Unregistering active hologram: %s"), *Hologram->GetName());
-		
+		UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("Unregistering active hologram: %s"), *Hologram->GetName());
+
 		// Issue #281: Remove Smart! hints from hint bar
 		if (HintBarService)
 		{
 			HintBarService->OnHologramUnregistered();
 		}
-		
+
 		// CRITICAL: Suppress child updates during mass destruction to prevent UObject exhaustion
 		// When destroying 700+ children, each OnChildHologramDestroyed would trigger expensive updates
 		bSuppressChildUpdates = true;
-		
+
 		// Clean up spawned children from HologramHelper (Phase 3 fix)
 		if (HologramHelper)
 		{
@@ -3102,22 +3102,22 @@ void USFSubsystem::UnregisterActiveHologram(AFGHologram* Hologram)
 				}
 			}
 		}
-		
+
 		// Re-enable updates and clear mass destruction flag after manual cleanup complete
 		bSuppressChildUpdates = false;
 		bInMassDestruction = false;
-		
+
 		ActiveHologram.Reset();
 		CurrentScalingOffset = FVector::ZeroVector;
 
 		// Clear Smart Dismantle blueprint proxy for this build session (Issue #166)
 		if (CurrentBuildProxy.IsValid())
 		{
-			UE_LOG(LogSmartFoundations, Log, TEXT("🏗️ SMART DISMANTLE: Build session ended - clearing proxy %s"), *CurrentBuildProxy->GetName());
+			UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("🏗️ SMART DISMANTLE: Build session ended - clearing proxy %s"), *CurrentBuildProxy->GetName());
 			CurrentBuildProxy.Reset();
 			CurrentProxyOwner.Reset();
 		}
-		
+
 		// Clear transform cache via transform service (Phase 3 extraction)
 		if (GridTransformService)
 		{
@@ -3131,7 +3131,7 @@ void USFSubsystem::UnregisterActiveHologram(AFGHologram* Hologram)
 		// Reset auto-hold state (Issue #273)
 		bAutoHoldActive = false;
 		bAutoHoldUserOverrode = false;
-		
+
 		// Clear adapter
 		CurrentAdapter.Reset();
 
@@ -3164,11 +3164,11 @@ void USFSubsystem::UnregisterActiveHologram(AFGHologram* Hologram)
 
 		// Reset all counters (fixes persistence bug - Task 51)
 		ResetCounters();
-		
+
 		// CRITICAL FIX: Reset auto-connect runtime settings so next build session loads from global config
 		// Without this, runtime settings persist between build sessions, ignoring global config changes
 		AutoConnectRuntimeSettings.bInitialized = false;
-		UE_LOG(LogSmartFoundations, Log, TEXT("   Reset auto-connect runtime settings (will reload from config on next hologram)"));
+		UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("   Reset auto-connect runtime settings (will reload from config on next hologram)"));
 	}
 	else
 	{
@@ -3197,10 +3197,10 @@ void USFSubsystem::PollForActiveHologram()
 			if (PC)
 			{
 				LastController = PC;
-				UE_LOG(LogSmartFoundations, Log, TEXT("PollForActiveHologram: Found player controller"));
+				UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("PollForActiveHologram: Found player controller"));
 			}
 		}
-		
+
 		if (!PC)
 		{
 			return; // Still no controller - early return
@@ -3247,7 +3247,7 @@ void USFSubsystem::PollForActiveHologram()
 			UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("Clearing hologram: Build gun not in build state"));
 			UnregisterActiveHologram(ActiveHologram.Get());
 		}
-		
+
 		// CRITICAL: Final cleanup for EXTEND when build gun leaves build mode
 		// This catches any orphaned preview holograms that weren't cleaned up normally
 		if (ExtendService)
@@ -3276,14 +3276,14 @@ void USFSubsystem::PollForActiveHologram()
 			const FText FriendlyName = UFGItemDescriptor::GetItemName(CurrentRecipe);
 			const FBox HoloBox = H ? H->GetComponentsBoundingBox(/*bNonColliding=*/true) : FBox(ForceInit);
 			const FString HoloSizeStr = (H && HoloBox.IsValid) ? HoloBox.GetSize().ToString() : FString(TEXT("<n/a>"));
-			UE_LOG(LogSmartFoundations, Log, TEXT("BUILD RECIPE CHANGED: Recipe=%s Name=\"%s\" BuildClass=%s Hologram=%s HoloSize=%s"),
+			UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("BUILD RECIPE CHANGED: Recipe=%s Name=\"%s\" BuildClass=%s Hologram=%s HoloSize=%s"),
 				*GetNameSafe(CurrentRecipe), *FriendlyName.ToString(), *GetNameSafe(InnerBuildClass), H ? *H->GetName() : TEXT("<none>"), *HoloSizeStr);
 		}
 	}
 
 	// Get the hologram from the build state
 	AFGHologram* CurrentHologram = BuildState->GetHologram();
-	
+
 	// Update registration if hologram changed
 	if (CurrentHologram != ActiveHologram.Get())
 	{
@@ -3310,7 +3310,7 @@ void USFSubsystem::PollForActiveHologram()
 			bAutoHoldActive = false;
 			bLockedByModifier = false;
 			bAutoHoldUserOverrode = true;
-			UE_LOG(LogSmartFoundations, Log, TEXT("🔓 AUTO-HOLD: User released lock manually — suppressing re-lock until next grid change"));
+			UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("🔓 AUTO-HOLD: User released lock manually — suppressing re-lock until next grid change"));
 		}
 	}
 
@@ -3335,9 +3335,9 @@ void USFSubsystem::PollForActiveHologram()
 					LiftHeight = TopTransformPtr->GetTranslation().Z;
 				}
 			}
-			
+
 			float WorldHeight = LiftHologram->GetActorLocation().Z + LiftHeight;
-			
+
 			// Update HUD (HudService handles change detection internally)
 			HudService->UpdateLiftHeight(LiftHeight, WorldHeight);
 		}
@@ -3403,7 +3403,7 @@ void USFSubsystem::SyncMultiStepHologramProperties()
 			}
 			if (SyncedCount > 0)
 			{
-				UE_LOG(LogSmartFoundations, Log, TEXT("Synced floodlight properties to %d children: Angle=%d, BuildStep=%d"),
+				UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("Synced floodlight properties to %d children: Angle=%d, BuildStep=%d"),
 					SyncedCount, ParentAngle, ParentBuildStep);
 			}
 		}
@@ -3440,7 +3440,7 @@ void USFSubsystem::SyncMultiStepHologramProperties()
 			}
 			if (SyncedCount > 0)
 			{
-				UE_LOG(LogSmartFoundations, Log, TEXT("Synced sign build step to %d children: BuildStep=%d"),
+				UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("Synced sign build step to %d children: BuildStep=%d"),
 					SyncedCount, ParentBuildStep);
 			}
 		}
@@ -3458,7 +3458,7 @@ void USFSubsystem::ApplyScalingToHologram(const FVector& ScalingDelta)
 	}
 
 	AFGHologram* Hologram = ActiveHologram.Get();
-	
+
 	// Store old transform for logging
 	const FTransform OldTransform = Hologram->GetTransform();
 	const FVector OldLocation = OldTransform.GetLocation();
@@ -3468,9 +3468,9 @@ void USFSubsystem::ApplyScalingToHologram(const FVector& ScalingDelta)
 
 	// Let the Build Gun own the parent transform; only regenerate Smart! children
 	const FVector NewLocation = OldLocation; // unchanged parent location for logging
-	UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("SCALING APPLIED: Delta=%s | Old=%s | New=%s | TotalOffset=%s"), 
+	UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("SCALING APPLIED: Delta=%s | Old=%s | New=%s | TotalOffset=%s"),
 		*ScalingDelta.ToString(), *OldLocation.ToString(), *NewLocation.ToString(), *CurrentScalingOffset.ToString());
-	
+
 	// POC: Regenerate child hologram grid based on counters
 	RegenerateChildHologramGrid();
 }
@@ -3545,7 +3545,7 @@ void USFSubsystem::OnChildHologramDestroyed(AActor* DestroyedActor)
 		{
 			this->UpdateChildrenForCurrentTransform();
 		};
-		
+
 		HologramHelper->OnChildHologramDestroyed(DestroyedActor, UpdateCallback);
 	}
 }
@@ -3557,7 +3557,7 @@ void USFSubsystem::OnParentHologramDestroyed(AActor* DestroyedActor)
 	{
 		HologramHelper->OnParentHologramDestroyed(DestroyedActor);
 	}
-	
+
 	// Check if this was our active hologram for local state cleanup
 	AFGHologram* DestroyedHologram = Cast<AFGHologram>(DestroyedActor);
 	if (DestroyedHologram && ActiveHologram.Get() == DestroyedHologram)
@@ -3571,19 +3571,19 @@ void USFSubsystem::OnParentHologramDestroyed(AActor* DestroyedActor)
 		// Positions are cached in ProcessStackablePipelineSupports where children are still valid
 		if (AutoConnectService && AutoConnectService->IsStackablePipelineSupportHologram(DestroyedHologram))
 		{
-			UE_LOG(LogSmartFoundations, Log, TEXT("🔧 STACKABLE PIPE SUPPORT: OnParentHologramDestroyed - cache already set (Expected=%d, Pending=%d)"), 
+			UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("🔧 STACKABLE PIPE SUPPORT: OnParentHologramDestroyed - cache already set (Expected=%d, Pending=%d)"),
 				StackablePipeSupportExpectedCount, bStackablePipeBuildPending);
 		}
-		
+
 		// Clean up local SFSubsystem state
 		CurrentScalingOffset = FVector::ZeroVector;
-		
+
 		// Clear transform cache via transform service (Phase 3 extraction)
 		if (GridTransformService)
 		{
 			GridTransformService->ClearCache();
 		}
-		
+
 		CurrentAdapter.Reset();
 
 		// Reset all counters (fixes persistence bug - Task 51)
@@ -3598,56 +3598,56 @@ void USFSubsystem::OnBuildGunEquipped()
 		UE_LOG(LogSmartFoundations, Warning, TEXT("Cannot log contexts: No player controller"));
 		return;
 	}
-	
+
 	AFGPlayerController* PC = LastController.Get();
 	UEnhancedInputLocalPlayerSubsystem* InputSubsystem = PC->GetLocalPlayer()->GetSubsystem<UEnhancedInputLocalPlayerSubsystem>();
-	
+
 	if (!InputSubsystem)
 	{
 		UE_LOG(LogSmartFoundations, Error, TEXT("Cannot log contexts: No Enhanced Input subsystem"));
 		return;
 	}
-	
-	UE_LOG(LogSmartFoundations, Log, TEXT("═══════════════════════════════════════════════════════════"));
-	UE_LOG(LogSmartFoundations, Log, TEXT("📋 ACTIVE INPUT CONTEXTS [BuildGunEquipped]"));
-	UE_LOG(LogSmartFoundations, Log, TEXT("═══════════════════════════════════════════════════════════"));
-	
+
+	UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("═══════════════════════════════════════════════════════════"));
+	UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("📋 ACTIVE INPUT CONTEXTS [BuildGunEquipped]"));
+	UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("═══════════════════════════════════════════════════════════"));
+
 	// Get all active mapping contexts using the correct API
 	const TArray<FEnhancedActionKeyMapping>& CurrentMappings = InputSubsystem->GetAllPlayerMappableActionKeyMappings();
-	
-	UE_LOG(LogSmartFoundations, Log, TEXT("Total player mappable key mappings: %d"), CurrentMappings.Num());
-	
+
+	UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("Total player mappable key mappings: %d"), CurrentMappings.Num());
+
 	// Log Smart! specific context status
 	UFGInputMappingContext* SmartContext = USFInputRegistry::GetSmartInputMappingContext();
 	if (SmartContext)
 	{
-		UE_LOG(LogSmartFoundations, Log, TEXT("✅ Smart! Context exists: %s"), *SmartContext->GetName());
-		UE_LOG(LogSmartFoundations, Log, TEXT("   Parent: %s"), SmartContext->mParentContext.IsValid() ? *SmartContext->mParentContext->GetName() : TEXT("None"));
-		UE_LOG(LogSmartFoundations, Log, TEXT("   Display Name: %s"), *SmartContext->mDisplayName.ToString());
-		UE_LOG(LogSmartFoundations, Log, TEXT("   Priority: %.1f"), SmartContext->mMenuPriority);
+		UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("✅ Smart! Context exists: %s"), *SmartContext->GetName());
+		UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("   Parent: %s"), SmartContext->mParentContext.IsValid() ? *SmartContext->mParentContext->GetName() : TEXT("None"));
+		UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("   Display Name: %s"), *SmartContext->mDisplayName.ToString());
+		UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("   Priority: %.1f"), SmartContext->mMenuPriority);
 	}
 	else
 	{
 		UE_LOG(LogSmartFoundations, Error, TEXT("❌ Smart! Context NOT LOADED"));
 	}
-	
-	UE_LOG(LogSmartFoundations, Log, TEXT("═══════════════════════════════════════════════════════════"));
-	
-	UE_LOG(LogSmartFoundations, Log, TEXT("🔫 BUILD GUN EQUIPPED - Smart! input context should now be active"));
-	UE_LOG(LogSmartFoundations, Log, TEXT("   Numpad keys should trigger Smart! actions when hologram is present"));
-	
+
+	UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("═══════════════════════════════════════════════════════════"));
+
+	UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("🔫 BUILD GUN EQUIPPED - Smart! input context should now be active"));
+	UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("   Numpad keys should trigger Smart! actions when hologram is present"));
+
 	// Clean up any stale recipe inheritance state for safety
 	// This ensures fresh state when equipping build gun after save loads
 	CleanupStateForWorldTransition();
-	
+
 	// Start periodic cleanup of dead hologram entries
 	StartPeriodicCleanup();
-	
+
 	// Note: Recipe delegate subscription now happens in MonitorActiveHologram() on first access
-	
+
 	// Log active contexts immediately after equip
 	LogActiveInputContexts(TEXT("BuildGunEquipped"));
-	
+
 	// Start periodic monitoring during build mode
 	if (UWorld* World = GetWorld())
 	{
@@ -3665,20 +3665,20 @@ void USFSubsystem::OnBuildGunEquipped()
 
 void USFSubsystem::OnBuildGunUnequipped()
 {
-	UE_LOG(LogSmartFoundations, Log, TEXT(" BUILD GUN UNEQUIPPED - Smart! build context deactivated"));
-	
+	UE_LOG(LogSmartFoundations, VeryVerbose, TEXT(" BUILD GUN UNEQUIPPED - Smart! build context deactivated"));
+
 	// Reset recipe sampling subscription flag
 	bHasSubscribedToRecipeSampled = false;
-	
+
 	// Log contexts at unequip
 	LogActiveInputContexts(TEXT("BuildGunUnequipped"));
-	
+
 	// Stop periodic monitoring
 	if (UWorld* World = GetWorld())
 	{
 		World->GetTimerManager().ClearTimer(ContextMonitorTimer);
 	}
-	
+
 	// Stop periodic cleanup of dead hologram entries
 	StopPeriodicCleanup();
 
@@ -3687,7 +3687,7 @@ void USFSubsystem::OnBuildGunUnequipped()
 	{
 		UnregisterActiveHologram(ActiveHologram.Get());
 	}
-	
+
 	// Force counter display to clear (in case hologram was already unregistered)
 	ResetCounters();
 
@@ -3698,7 +3698,7 @@ void USFSubsystem::OnBuildGunUnequipped()
 	// should NOT persist across build gun sessions to avoid accidentally applying them
 	// to unrelated builds later. We clear them on unequip.
 	ClearStoredProductionRecipe();
-	UE_LOG(LogSmartFoundations, Log, TEXT("RECIPE COPYING: Cleared stored recipe and items on build gun unequip"));
+	UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("RECIPE COPYING: Cleared stored recipe and items on build gun unequip"));
 
 	// Now it is safe to destroy any pending children we deferred while building
 	ForceDestroyPendingChildren();
@@ -3706,9 +3706,9 @@ void USFSubsystem::OnBuildGunUnequipped()
 
 void USFSubsystem::OnBuildGunStateChanged(const FString& NewStateName, const FString& OldStateName)
 {
-	UE_LOG(LogSmartFoundations, Log, TEXT("🔄 BUILD GUN STATE CHANGE: %s -> %s"), *OldStateName, *NewStateName);
+	UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("🔄 BUILD GUN STATE CHANGE: %s -> %s"), *OldStateName, *NewStateName);
 	LastBuildGunState = NewStateName;
-	
+
 	// Log contexts at every state change
 	LogActiveInputContexts(FString::Printf(TEXT("StateChange_%s"), *NewStateName));
 }
@@ -3720,40 +3720,40 @@ void USFSubsystem::LogActiveInputContexts(const FString& CallerContext)
 		UE_LOG(LogSmartFoundations, Warning, TEXT("[%s] Cannot log contexts: No player controller"), *CallerContext);
 		return;
 	}
-	
+
 	AFGPlayerController* PC = LastController.Get();
 	UEnhancedInputLocalPlayerSubsystem* InputSubsystem = PC->GetLocalPlayer()->GetSubsystem<UEnhancedInputLocalPlayerSubsystem>();
-	
+
 	if (!InputSubsystem)
 	{
 		UE_LOG(LogSmartFoundations, Error, TEXT("[%s] Cannot log contexts: No Enhanced Input subsystem"), *CallerContext);
 		return;
 	}
-	
-	UE_LOG(LogSmartFoundations, Log, TEXT("═══════════════════════════════════════════════════════════"));
-	UE_LOG(LogSmartFoundations, Log, TEXT("📋 ACTIVE INPUT CONTEXTS [%s]"), *CallerContext);
-	UE_LOG(LogSmartFoundations, Log, TEXT("═══════════════════════════════════════════════════════════"));
-	
+
+	UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("═══════════════════════════════════════════════════════════"));
+	UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("📋 ACTIVE INPUT CONTEXTS [%s]"), *CallerContext);
+	UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("═══════════════════════════════════════════════════════════"));
+
 	// Get all active mapping contexts using the correct API
 	const TArray<FEnhancedActionKeyMapping>& CurrentMappings = InputSubsystem->GetAllPlayerMappableActionKeyMappings();
-	
-	UE_LOG(LogSmartFoundations, Log, TEXT("Total player mappable key mappings: %d"), CurrentMappings.Num());
-	
+
+	UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("Total player mappable key mappings: %d"), CurrentMappings.Num());
+
 	// Log Smart! specific context status
 	UFGInputMappingContext* SmartContext = USFInputRegistry::GetSmartInputMappingContext();
 	if (SmartContext)
 	{
-		UE_LOG(LogSmartFoundations, Log, TEXT("✅ Smart! Context exists: %s"), *SmartContext->GetName());
-		UE_LOG(LogSmartFoundations, Log, TEXT("   Parent: %s"), SmartContext->mParentContext.IsValid() ? *SmartContext->mParentContext->GetName() : TEXT("None"));
-		UE_LOG(LogSmartFoundations, Log, TEXT("   Display Name: %s"), *SmartContext->mDisplayName.ToString());
-		UE_LOG(LogSmartFoundations, Log, TEXT("   Priority: %.1f"), SmartContext->mMenuPriority);
+		UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("✅ Smart! Context exists: %s"), *SmartContext->GetName());
+		UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("   Parent: %s"), SmartContext->mParentContext.IsValid() ? *SmartContext->mParentContext->GetName() : TEXT("None"));
+		UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("   Display Name: %s"), *SmartContext->mDisplayName.ToString());
+		UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("   Priority: %.1f"), SmartContext->mMenuPriority);
 	}
 	else
 	{
 		UE_LOG(LogSmartFoundations, Error, TEXT("❌ Smart! Context NOT LOADED"));
 	}
-	
-	UE_LOG(LogSmartFoundations, Log, TEXT("═══════════════════════════════════════════════════════════"));
+
+	UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("═══════════════════════════════════════════════════════════"));
 }
 
 TSharedPtr<ISFHologramAdapter> USFSubsystem::CreateHologramAdapter(AFGHologram* Hologram)
@@ -3773,14 +3773,14 @@ TSharedPtr<ISFHologramAdapter> USFSubsystem::CreateHologramAdapter(AFGHologram* 
 	{
 		InheritanceChain.Add(CurrentClass->GetName());
 		CurrentClass = CurrentClass->GetSuperClass();
-		
+
 		if (CurrentClass && CurrentClass->GetName() == TEXT("Object"))
 		{
 			InheritanceChain.Add(TEXT("UObject"));
 			break;
 		}
 	}
-	
+
 	FString InheritanceStr;
 	for (int32 i = 0; i < InheritanceChain.Num(); i++)
 	{
@@ -3790,13 +3790,13 @@ TSharedPtr<ISFHologramAdapter> USFSubsystem::CreateHologramAdapter(AFGHologram* 
 			InheritanceStr += TEXT(" -> ");
 		}
 	}
-	
+
 	// Also log the BuildClass to help identify resource extractors
 	UClass* BuildClass = Hologram->GetBuildClass();
 	FString BuildClassName = BuildClass ? BuildClass->GetName() : TEXT("NONE");
-	
-	UE_LOG(LogSmartFoundations, Display, TEXT("🔍 Hologram inheritance: %s"), *InheritanceStr);
-	UE_LOG(LogSmartFoundations, Display, TEXT("🔍 BuildClass: %s"), *BuildClassName);
+
+	UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("🔍 Hologram inheritance: %s"), *InheritanceStr);
+	UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("🔍 BuildClass: %s"), *BuildClassName);
 
 	// ========================================
 	// PHASE 4: RUNTIME HOLOGRAM SWAPPING (Smart Custom Holograms)
@@ -3804,51 +3804,51 @@ TSharedPtr<ISFHologramAdapter> USFSubsystem::CreateHologramAdapter(AFGHologram* 
 	// NOTE: Parent hologram swapping removed - only swap child holograms
 	// Parent holograms are already valid and don't need recipe copying
 	// Child holograms are swapped in SpawnChildHologram function
-	
+
 	// ========================================
 	// CRITICAL: Detect vanilla blueprint holograms FIRST (Issue #166)
 	// Blueprint placement must not be scaled - it would break the blueprint system
 	// ========================================
 	if (Cast<AFGBlueprintHologram>(Hologram))
 	{
-		UE_LOG(LogSmartFoundations, Warning, 
+		UE_LOG(LogSmartFoundations, Warning,
 			TEXT("Detected Blueprint hologram (%s) - Smart! features disabled (blueprint placement)"),
 			*Hologram->GetName());
 		return MakeShared<FSFUnsupportedAdapter>(Hologram, TEXT("Blueprint"));
 	}
-	
+
 	// Check for custom logistics holograms first (most specific)
 	if (ASFLogisticsHologram* LogisticsHolo = Cast<ASFLogisticsHologram>(Hologram))
 	{
-		UE_LOG(LogSmartFoundations, Log, TEXT("✅ Creating Smart Logistics adapter for %s"), *Hologram->GetName());
+		UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("✅ Creating Smart Logistics adapter for %s"), *Hologram->GetName());
 		return MakeShared<FSFSmartLogisticsAdapter>(LogisticsHolo);
 	}
-	
+
 	// Check for custom factory holograms
 	if (ASFFactoryHologram* FactoryHolo = Cast<ASFFactoryHologram>(Hologram))
 	{
-		UE_LOG(LogSmartFoundations, Log, TEXT("✅ Creating Factory adapter for custom factory hologram %s"), *Hologram->GetName());
+		UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("✅ Creating Factory adapter for custom factory hologram %s"), *Hologram->GetName());
 		return MakeShared<FSFFactoryAdapter>(FactoryHolo);
 	}
-	
+
 	// Check for custom foundation holograms
 	if (ASFFoundationHologram* FoundationHolo = Cast<ASFFoundationHologram>(Hologram))
 	{
-		UE_LOG(LogSmartFoundations, Log, TEXT("✅ Creating Foundation adapter for custom foundation hologram %s"), *Hologram->GetName());
+		UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("✅ Creating Foundation adapter for custom foundation hologram %s"), *Hologram->GetName());
 		return MakeShared<FSFGenericAdapter>(Hologram, TEXT("Foundation"));
 	}
-	
+
 	// Check for custom buildable base class (catch-all for other custom holograms)
 	if (ASFBuildableHologram* BuildableHolo = Cast<ASFBuildableHologram>(Hologram))
 	{
-		UE_LOG(LogSmartFoundations, Log, TEXT("✅ Creating Smart Buildable adapter for %s"), *Hologram->GetName());
+		UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("✅ Creating Smart Buildable adapter for %s"), *Hologram->GetName());
 		return MakeShared<FSFSmartBuildableAdapter>(BuildableHolo);
 	}
 
 	// ========================================
 	// VANILLA HOLOGRAMS (Fallback for mod compatibility)
 	// ========================================
-	
+
 	// CRITICAL: Check resource extractors BEFORE foundations!
 	// Some miners use Holo_Snappable_C which inherits from AFGFoundationHologram for grid snapping
 	// but are actually resource extractors that must be on resource nodes
@@ -3858,7 +3858,7 @@ TSharedPtr<ISFHologramAdapter> USFSubsystem::CreateHologramAdapter(AFGHologram* 
 		// Children validate independently via CheckMinimumDepth()
 		UClass* InnerBuildClass = Hologram->GetBuildClass();
 		FString InnerBuildClassName = InnerBuildClass ? InnerBuildClass->GetName() : TEXT("NONE");
-		UE_LOG(LogSmartFoundations, Display, TEXT("Creating WaterExtractor adapter for %s (scaling enabled - validates per-child) BuildClass=%s"), 
+		UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("Creating WaterExtractor adapter for %s (scaling enabled - validates per-child) BuildClass=%s"),
 			*Hologram->GetName(), *InnerBuildClassName);
 		return MakeShared<FSFWaterExtractorAdapter>(Hologram);
 	}
@@ -3871,12 +3871,12 @@ TSharedPtr<ISFHologramAdapter> USFSubsystem::CreateHologramAdapter(AFGHologram* 
 	}
 	else if (Cast<AFGFoundationHologram>(Hologram))
 	{
-		UE_LOG(LogSmartFoundations, Log, TEXT("Creating Foundation adapter for %s"), *Hologram->GetName());
+		UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("Creating Foundation adapter for %s"), *Hologram->GetName());
 		return MakeShared<FSFGenericAdapter>(Hologram, TEXT("Foundation"));
 	}
 	else if (Cast<AFGStackableStorageHologram>(Hologram))
 	{
-		UE_LOG(LogSmartFoundations, Log, TEXT("Creating Storage adapter for %s"), *Hologram->GetName());
+		UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("Creating Storage adapter for %s"), *Hologram->GetName());
 		return MakeShared<FSFGenericAdapter>(Hologram, TEXT("Storage"));
 	}
 	else if (Cast<AFGPipelineJunctionHologram>(Hologram))
@@ -3884,7 +3884,7 @@ TSharedPtr<ISFHologramAdapter> USFSubsystem::CreateHologramAdapter(AFGHologram* 
 		// CRITICAL: Check PipelineJunction BEFORE ConveyorAttachment and Factory!
 		// AFGPipelineJunctionHologram inherits from AFGFactoryHologram
 		// Uses registry AnchorOffset for elevated pivot compensation
-		UE_LOG(LogSmartFoundations, Log, TEXT("Creating PipelineJunction adapter for %s"), *Hologram->GetName());
+		UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("Creating PipelineJunction adapter for %s"), *Hologram->GetName());
 		return MakeShared<FSFGenericAdapter>(Hologram, TEXT("PipelineJunction"));
 	}
 	else if (Cast<AFGConveyorAttachmentHologram>(Hologram))
@@ -3892,7 +3892,7 @@ TSharedPtr<ISFHologramAdapter> USFSubsystem::CreateHologramAdapter(AFGHologram* 
 		// CRITICAL: Check ConveyorAttachment BEFORE Factory!
 		// AFGConveyorAttachmentHologram inherits from AFGFactoryHologram
 		// Uses registry AnchorOffset for center-pivot compensation + unique floor validation
-		UE_LOG(LogSmartFoundations, Log, TEXT("Creating ConveyorAttachment adapter for %s"), *Hologram->GetName());
+		UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("Creating ConveyorAttachment adapter for %s"), *Hologram->GetName());
 		return MakeShared<FSFGenericAdapter>(Hologram, TEXT("ConveyorAttachment"));
 	}
 	else if (Cast<AFGPipeHyperAttachmentHologram>(Hologram))
@@ -3900,7 +3900,7 @@ TSharedPtr<ISFHologramAdapter> USFSubsystem::CreateHologramAdapter(AFGHologram* 
 		// CRITICAL: Check PipeHyperAttachment BEFORE Factory!
 		// AFGPipeHyperAttachmentHologram inherits from AFGPipeAttachmentHologram -> AFGFactoryHologram
 		// Uses registry AnchorOffset for elevated pivot compensation (7/8 height ratio)
-		UE_LOG(LogSmartFoundations, Log, TEXT("Creating HypertubeAttachment adapter for %s"), *Hologram->GetName());
+		UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("Creating HypertubeAttachment adapter for %s"), *Hologram->GetName());
 		return MakeShared<FSFGenericAdapter>(Hologram, TEXT("HypertubeAttachment"));
 	}
 	else if (Cast<AFGPassthroughHologram>(Hologram))
@@ -3908,7 +3908,7 @@ TSharedPtr<ISFHologramAdapter> USFSubsystem::CreateHologramAdapter(AFGHologram* 
 		// Issue #187: Check Passthrough BEFORE Factory!
 		// AFGPassthroughHologram inherits from AFGFactoryHologram
 		// Floor holes for conveyors and pipes - children snap to foundations independently
-		UE_LOG(LogSmartFoundations, Log, TEXT("Creating Passthrough adapter for %s"), *Hologram->GetName());
+		UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("Creating Passthrough adapter for %s"), *Hologram->GetName());
 		return MakeShared<FSFPassthroughAdapter>(Hologram);
 	}
 	else if (Cast<AFGFactoryHologram>(Hologram))
@@ -3928,54 +3928,54 @@ TSharedPtr<ISFHologramAdapter> USFSubsystem::CreateHologramAdapter(AFGHologram* 
 			}
 		}
 		// Registry allows scaling or no profile - use Factory adapter
-		UE_LOG(LogSmartFoundations, Log, TEXT("Creating Factory adapter for %s"), *Hologram->GetName());
+		UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("Creating Factory adapter for %s"), *Hologram->GetName());
 		return MakeShared<FSFFactoryAdapter>(Hologram);
 	}
 
 	// ========================================
 	// PARTIAL SUPPORT (Stub Adapters - Features Disabled)
 	// ========================================
-	
+
 	else if (Cast<AFGWallHologram>(Hologram))
 	{
-		UE_LOG(LogSmartFoundations, Log, TEXT("Creating Wall adapter for %s (features currently disabled)"), *Hologram->GetName());
+		UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("Creating Wall adapter for %s (features currently disabled)"), *Hologram->GetName());
 		return MakeShared<FSFWallAdapter>(Hologram);
 	}
 	else if (Cast<AFGPillarHologram>(Hologram))
 	{
-		UE_LOG(LogSmartFoundations, Log, TEXT("Creating Pillar adapter for %s (features currently disabled)"), *Hologram->GetName());
+		UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("Creating Pillar adapter for %s (features currently disabled)"), *Hologram->GetName());
 		return MakeShared<FSFPillarAdapter>(Hologram);
 	}
 	else if (Cast<AFGElevatorHologram>(Hologram))
 	{
-		UE_LOG(LogSmartFoundations, Log, TEXT("Creating Elevator adapter for %s (features currently disabled)"), *Hologram->GetName());
+		UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("Creating Elevator adapter for %s (features currently disabled)"), *Hologram->GetName());
 		return MakeShared<FSFElevatorAdapter>(Hologram);
 	}
 	else if (Cast<AFGStairHologram>(Hologram))
 	{
-		UE_LOG(LogSmartFoundations, Log, TEXT("Creating Ramp adapter for %s (features currently disabled)"), *Hologram->GetName());
+		UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("Creating Ramp adapter for %s (features currently disabled)"), *Hologram->GetName());
 		return MakeShared<FSFRampAdapter>(Hologram);
 	}
 	else if (Cast<AFGJumpPadHologram>(Hologram))
 	{
-		UE_LOG(LogSmartFoundations, Log, TEXT("Creating JumpPad adapter for %s (features currently disabled)"), *Hologram->GetName());
+		UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("Creating JumpPad adapter for %s (features currently disabled)"), *Hologram->GetName());
 		return MakeShared<FSFJumpPadAdapter>(Hologram);
 	}
 
 	// ========================================
 	// EXPLICITLY UNSUPPORTED TYPES
 	// ========================================
-	
+
 	else if (Cast<AFGWheeledVehicleHologram>(Hologram))
 	{
-		UE_LOG(LogSmartFoundations, Warning, 
+		UE_LOG(LogSmartFoundations, Warning,
 			TEXT("Detected vehicle hologram (%s) - Smart! features disabled (vehicles not supported)"),
 			*HologramTypeName);
 		return MakeShared<FSFUnsupportedAdapter>(Hologram, TEXT("Vehicle"));
 	}
 	else if (Cast<AFGSpaceElevatorHologram>(Hologram))
 	{
-		UE_LOG(LogSmartFoundations, Warning, 
+		UE_LOG(LogSmartFoundations, Warning,
 			TEXT("Detected Space Elevator hologram (%s) - Smart! features disabled (unique building)"),
 			*HologramTypeName);
 		return MakeShared<FSFUnsupportedAdapter>(Hologram, TEXT("SpaceElevator"));
@@ -3984,7 +3984,7 @@ TSharedPtr<ISFHologramAdapter> USFSubsystem::CreateHologramAdapter(AFGHologram* 
 	// ========================================
 	// REGISTRY-BASED ADAPTER SELECTION
 	// ========================================
-	
+
 	// Check if this buildable has a registry profile with scaling enabled
 	// This allows the registry to drive adapter selection for special buildables
 	else if (Cast<AFGBuildableHologram>(Hologram))
@@ -3996,7 +3996,7 @@ TSharedPtr<ISFHologramAdapter> USFSubsystem::CreateHologramAdapter(AFGHologram* 
 			if (Profile.bSupportsScaling)
 			{
 				// Registry says this buildable supports scaling - use Factory adapter
-				UE_LOG(LogSmartFoundations, Log, TEXT("Creating Factory adapter for %s (registry-enabled: %s)"),
+				UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("Creating Factory adapter for %s (registry-enabled: %s)"),
 					*Hologram->GetName(), *InnerBuildClass->GetName());
 				return MakeShared<FSFFactoryAdapter>(Hologram);
 			}
@@ -4015,7 +4015,7 @@ TSharedPtr<ISFHologramAdapter> USFSubsystem::CreateHologramAdapter(AFGHologram* 
 	// ========================================
 	// UNKNOWN TYPES (Default to Unsupported)
 	// ========================================
-	
+
 	// No registry profile and no specific adapter - unsupported
 	{
 		// Log full inheritance chain to help identify modded buildables
@@ -4025,7 +4025,7 @@ TSharedPtr<ISFHologramAdapter> USFSubsystem::CreateHologramAdapter(AFGHologram* 
 		{
 			InnerInheritanceChain.Add(CurrentClassForChain->GetName());
 			CurrentClassForChain = CurrentClassForChain->GetSuperClass();
-			
+
 			// Stop at UObject to avoid cluttering the log
 			if (CurrentClassForChain && CurrentClassForChain->GetName() == TEXT("Object"))
 			{
@@ -4033,7 +4033,7 @@ TSharedPtr<ISFHologramAdapter> USFSubsystem::CreateHologramAdapter(AFGHologram* 
 				break;
 			}
 		}
-		
+
 		// Build inheritance string (e.g., "Holo_X -> AFGBuildableHologram -> AActor -> UObject")
 		FString InnerInheritanceStr;
 		for (int32 i = 0; i < InnerInheritanceChain.Num(); i++)
@@ -4044,7 +4044,7 @@ TSharedPtr<ISFHologramAdapter> USFSubsystem::CreateHologramAdapter(AFGHologram* 
 				InnerInheritanceStr += TEXT(" -> ");
 			}
 		}
-		
+
 		UE_LOG(LogSmartFoundations, Warning,
 			TEXT("Detected unknown hologram type (%s) - Smart! features disabled. Inheritance: %s"),
 			*HologramTypeName, *InnerInheritanceStr);
@@ -4059,14 +4059,14 @@ TSharedPtr<ISFHologramAdapter> USFSubsystem::CreateHologramAdapter(AFGHologram* 
 
 void USFSubsystem::ApplyScalingFromRPC(AFGHologram* HologramActor, uint8 Axis, int32 Delta, int32 NewCounter)
 {
-	UE_LOG(LogSmartFoundations, Log, 
+	UE_LOG(LogSmartFoundations, VeryVerbose,
 		TEXT("[RPC] ApplyScalingFromRPC: Axis=%d, Delta=%d, Counter=%d, Hologram=%s"),
 		Axis, Delta, NewCounter, *GetNameSafe(HologramActor));
 
 	// Validate hologram matches our active hologram
 	if (!HologramActor || HologramActor != ActiveHologram.Get())
 	{
-		UE_LOG(LogSmartFoundations, Warning, 
+		UE_LOG(LogSmartFoundations, Warning,
 			TEXT("[RPC] ApplyScalingFromRPC: Hologram mismatch or invalid"));
 		return;
 	}
@@ -4074,7 +4074,7 @@ void USFSubsystem::ApplyScalingFromRPC(AFGHologram* HologramActor, uint8 Axis, i
 	// Validate axis
 	if (Axis > 2)
 	{
-		UE_LOG(LogSmartFoundations, Error, 
+		UE_LOG(LogSmartFoundations, Error,
 			TEXT("[RPC] ApplyScalingFromRPC: Invalid axis %d"), Axis);
 		return;
 	}
@@ -4083,7 +4083,7 @@ void USFSubsystem::ApplyScalingFromRPC(AFGHologram* HologramActor, uint8 Axis, i
 	// Counter represents cumulative steps; Delta is the increment direction
 	const float StepSize = ScaleStepSize * Delta;
 	FVector ScalingDelta = FVector::ZeroVector;
-	
+
 	switch (Axis)
 	{
 		case 0: // X axis
@@ -4100,7 +4100,7 @@ void USFSubsystem::ApplyScalingFromRPC(AFGHologram* HologramActor, uint8 Axis, i
 	// Apply the scaling
 	ApplyScalingToHologram(ScalingDelta);
 
-	UE_LOG(LogSmartFoundations, Display, 
+	UE_LOG(LogSmartFoundations, VeryVerbose,
 		TEXT("[RPC] ApplyScalingFromRPC: Applied delta %s, TotalOffset now %s"),
 		*ScalingDelta.ToString(), *CurrentScalingOffset.ToString());
 
@@ -4109,13 +4109,13 @@ void USFSubsystem::ApplyScalingFromRPC(AFGHologram* HologramActor, uint8 Axis, i
 
 void USFSubsystem::ResetScalingFromRPC(AFGHologram* HologramActor)
 {
-	UE_LOG(LogSmartFoundations, Log, 
+	UE_LOG(LogSmartFoundations, VeryVerbose,
 		TEXT("[RPC] ResetScalingFromRPC: Hologram=%s"), *GetNameSafe(HologramActor));
 
 	// Validate hologram matches our active hologram
 	if (!HologramActor || HologramActor != ActiveHologram.Get())
 	{
-		UE_LOG(LogSmartFoundations, Warning, 
+		UE_LOG(LogSmartFoundations, Warning,
 			TEXT("[RPC] ResetScalingFromRPC: Hologram mismatch or invalid"));
 		return;
 	}
@@ -4123,7 +4123,7 @@ void USFSubsystem::ResetScalingFromRPC(AFGHologram* HologramActor)
 	// Reset scaling offset
 	CurrentScalingOffset = FVector::ZeroVector;
 
-	UE_LOG(LogSmartFoundations, Display, 
+	UE_LOG(LogSmartFoundations, VeryVerbose,
 		TEXT("[RPC] ResetScalingFromRPC: Scaling offset cleared"));
 
 	// TODO Task #21: Replicate to other clients
@@ -4131,14 +4131,14 @@ void USFSubsystem::ResetScalingFromRPC(AFGHologram* HologramActor)
 
 void USFSubsystem::SetSpacingModeFromRPC(ESFSpacingMode NewMode)
 {
-	UE_LOG(LogSmartFoundations, Log, 
+	UE_LOG(LogSmartFoundations, VeryVerbose,
 		TEXT("[RPC] SetSpacingModeFromRPC: NewMode=%d"), static_cast<uint8>(NewMode));
 
 	// Update spacing mode in CounterState
 	CounterState.SpacingMode = NewMode;
 
 	FString ModeName = FSFSpacingModule::GetSpacingModeName(CounterState.SpacingMode);
-	UE_LOG(LogSmartFoundations, Display, 
+	UE_LOG(LogSmartFoundations, VeryVerbose,
 		TEXT("[RPC] SetSpacingModeFromRPC: Mode set to %s"), *ModeName);
 
 	// Sync via centralized update
@@ -4150,15 +4150,15 @@ void USFSubsystem::SetSpacingModeFromRPC(ESFSpacingMode NewMode)
 void USFSubsystem::SetArrowVisibilityFromRPC(bool bVisible)
 {
 #if SMART_ARROWS_ENABLED
-    UE_LOG(LogSmartFoundations, Log, 
+    UE_LOG(LogSmartFoundations, VeryVerbose,
         TEXT("[RPC] SetArrowVisibilityFromRPC: Visible=%d"), bVisible);
 
     // Update arrow runtime visibility state - Tick() will handle drawing
     bArrowsRuntimeVisible = bVisible;
     bArrowsVisible = bVisible; // Sync deprecated flag
 
-    UE_LOG(LogSmartFoundations, Display, 
-        TEXT("[RPC] SetArrowVisibilityFromRPC: Arrows visibility set to %s"), 
+    UE_LOG(LogSmartFoundations, VeryVerbose,
+        TEXT("[RPC] SetArrowVisibilityFromRPC: Arrows visibility set to %s"),
         bVisible ? TEXT("VISIBLE") : TEXT("HIDDEN"));
 #else
     UE_LOG(LogSmartFoundations, Warning,
@@ -4238,7 +4238,7 @@ void USFSubsystem::UpdateCounterDisplay()
     // Log for debugging
     if (FirstLine.Len() > 0 || SecondLine.Len() > 0)
     {
-        UE_LOG(LogSmartFoundations, Display, TEXT("[Counter Display] Line1: '%s' Line2: '%s'"), 
+        UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("[Counter Display] Line1: '%s' Line2: '%s'"),
             *FirstLine, *SecondLine);
     }
 
@@ -4265,7 +4265,7 @@ void USFSubsystem::LoadConfiguration()
 		bArrowsRuntimeVisible = true;
 		return;
 	}
-	
+
 	UGameInstance* GameInstance = World->GetGameInstance();
 	if (!GameInstance)
 	{
@@ -4273,7 +4273,7 @@ void USFSubsystem::LoadConfiguration()
 		bArrowsRuntimeVisible = true;
 		return;
 	}
-	
+
 	UConfigManager* ConfigManager = GameInstance->GetSubsystem<UConfigManager>();
 	if (!ConfigManager)
 	{
@@ -4281,29 +4281,29 @@ void USFSubsystem::LoadConfiguration()
 		bArrowsRuntimeVisible = true;
 		return;
 	}
-	
+
 	// ConfigManager is available, load config
 	CachedConfig = FSmart_ConfigStruct::GetActiveConfig(this);
-	
+
 	// Initialize runtime arrow visibility from config (Issue #146)
 	// This can be toggled during runtime with Num1, but starts with config value
 	bArrowsRuntimeVisible = CachedConfig.bShowArrows;
-	
+
 	// Initialize arrow orbit and label toggles from config (Issue #179)
 	if (ArrowModule)
 	{
 		ArrowModule->SetOrbitEnabled(CachedConfig.bShowArrowOrbit);
 		ArrowModule->SetLabelsVisible(CachedConfig.bShowArrowLabels);
 	}
-	
+
 	// Issue #257: Initialize Extend enabled state from config
 	bExtendEnabledByConfig = CachedConfig.bExtendEnabled;
-	
+
 	bConfigLoaded = true;
-	
-	UE_LOG(LogSmartFoundations, Display, TEXT(" Smart! Configuration loaded:"));
-	UE_LOG(LogSmartFoundations, Display, TEXT("   bShowHUD: %s"), CachedConfig.bShowHUD ? TEXT("true") : TEXT("false"));
-	UE_LOG(LogSmartFoundations, Display, TEXT("   bShowArrows: %s (runtime: %s, orbit: %s, labels: %s)"), 
+
+	UE_LOG(LogSmartFoundations, VeryVerbose, TEXT(" Smart! Configuration loaded:"));
+	UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("   bShowHUD: %s"), CachedConfig.bShowHUD ? TEXT("true") : TEXT("false"));
+	UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("   bShowArrows: %s (runtime: %s, orbit: %s, labels: %s)"),
 		CachedConfig.bShowArrows ? TEXT("true") : TEXT("false"),
 		bArrowsRuntimeVisible ? TEXT("true") : TEXT("false"),
 		CachedConfig.bShowArrowOrbit ? TEXT("true") : TEXT("false"),
@@ -4312,20 +4312,20 @@ void USFSubsystem::LoadConfiguration()
 
 void USFSubsystem::CleanupStateForWorldTransition()
 {
-	UE_LOG(LogSmartFoundations, Log, TEXT("CleanupStateForWorldTransition: Resetting recipe inheritance state"));
-	
+	UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("CleanupStateForWorldTransition: Resetting recipe inheritance state"));
+
 	// Clear stored recipe and cache
 	StoredProductionRecipe = nullptr;
 	StoredRecipeDisplayName = TEXT("");
 	bHasStoredProductionRecipe = false;
-	
+
 	// Clear hologram registry to prevent stale entries
 	USFHologramDataRegistry::ClearRegistry();
-	
+
 	// Update HUD to reflect cleared state
 	UpdateCounterDisplay();
-	
-	UE_LOG(LogSmartFoundations, Log, TEXT("CleanupStateForWorldTransition: Recipe inheritance state reset complete"));
+
+	UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("CleanupStateForWorldTransition: Recipe inheritance state reset complete"));
 }
 
 void USFSubsystem::InitializeHologramCleanup()
@@ -4349,9 +4349,9 @@ void USFSubsystem::OnActorDestroyed(AActor* DestroyedActor)
 	if (AFGHologram* Hologram = Cast<AFGHologram>(DestroyedActor))
 	{
 		USFHologramDataRegistry::ClearData(Hologram);
-		UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("OnActorDestroyed: Auto-cleared hologram %s from registry"), 
+		UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("OnActorDestroyed: Auto-cleared hologram %s from registry"),
 			*GetNameSafe(Hologram));
-		
+
 		// Clean up auto-connect previews when hologram is destroyed (covers Escape, right-click, etc.)
 		if (ActiveHologram.IsValid() && ActiveHologram.Get() == Hologram)
 		{
@@ -4361,25 +4361,25 @@ void USFSubsystem::OnActorDestroyed(AActor* DestroyedActor)
 				if (AutoConnectService->IsDistributorHologram(Hologram))
 				{
 					AutoConnectService->ClearBeltPreviewHelpers();
-					UE_LOG(LogSmartFoundations, Log, TEXT(" AUTO-CONNECT CLEANUP: Cleared belt previews for distributor (OnActorDestroyed)"));
+					UE_LOG(LogSmartFoundations, VeryVerbose, TEXT(" AUTO-CONNECT CLEANUP: Cleared belt previews for distributor (OnActorDestroyed)"));
 				}
 				else if (AutoConnectService->IsPipelineJunctionHologram(Hologram))
 				{
 					// CRITICAL FIX: Only clear previews for THIS specific junction, not all junctions
 					// This prevents child hologram destruction from clearing parent previews (fixes flickering)
 					AutoConnectService->ClearPipePreviews(Hologram);
-					UE_LOG(LogSmartFoundations, Log, TEXT(" AUTO-CONNECT CLEANUP: Cleared pipe previews for junction %s (OnActorDestroyed)"),
+					UE_LOG(LogSmartFoundations, VeryVerbose, TEXT(" AUTO-CONNECT CLEANUP: Cleared pipe previews for junction %s (OnActorDestroyed)"),
 						*GetNameSafe(Hologram));
 				}
 				else if (AutoConnectService->IsPowerPoleHologram(Hologram))
 				{
 					// Clear power line previews when power pole hologram is destroyed
 					AutoConnectService->ClearAllPowerPreviews();
-					UE_LOG(LogSmartFoundations, Log, TEXT(" AUTO-CONNECT CLEANUP: Cleared power line previews for pole %s (OnActorDestroyed)"),
+					UE_LOG(LogSmartFoundations, VeryVerbose, TEXT(" AUTO-CONNECT CLEANUP: Cleared power line previews for pole %s (OnActorDestroyed)"),
 						*GetNameSafe(Hologram));
 				}
 			}
-			
+
 			// NOTE: Don't reset bProcessingGridPlacement here!
 			// The hologram is destroyed both on successful build AND on cancel.
 			// The belt building lambda will reset the flag after completion.
@@ -4400,8 +4400,8 @@ void USFSubsystem::StartPeriodicCleanup()
 			10.0f,  // Every 10 seconds
 			true    // Looping
 		);
-		
-		UE_LOG(LogSmartFoundations, Log, TEXT("StartPeriodicCleanup: Started periodic hologram registry cleanup"));
+
+		UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("StartPeriodicCleanup: Started periodic hologram registry cleanup"));
 	}
 }
 
@@ -4411,7 +4411,7 @@ void USFSubsystem::StopPeriodicCleanup()
 	if (UWorld* World = GetWorld())
 	{
 		World->GetTimerManager().ClearTimer(PeriodicCleanupTimer);
-		UE_LOG(LogSmartFoundations, Log, TEXT("StopPeriodicCleanup: Stopped periodic hologram registry cleanup"));
+		UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("StopPeriodicCleanup: Stopped periodic hologram registry cleanup"));
 	}
 }
 
@@ -4448,7 +4448,7 @@ void USFSubsystem::CleanupWidgets()
         HudService->CleanupWidgets();
     }
 
-    UE_LOG(LogSmartFoundations, Log, TEXT("Widgets cleaned up"));
+    UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("Widgets cleaned up"));
 }
 
 void USFSubsystem::DisableVanillaBuildGunContext()
@@ -4533,13 +4533,13 @@ void USFSubsystem::OnBuildGunRecipeSampled(TSubclassOf<UFGRecipe> SampledRecipe)
 void USFSubsystem::OnRecipeModeChanged(const FInputActionValue& Value)
 {
 	bool bPressed = Value.Get<bool>();
-	
+
 	// Context-aware mode switching: U button behaves differently based on hologram type
 	// - Distributors: Auto-Connect Settings Mode (navigate belt settings)
 	// - Pipe Junctions: Auto-Connect Settings Mode (navigate pipe settings)
 	// - Power Poles: Auto-Connect Settings Mode (navigate power settings)
 	// - Factories: Recipe Mode (select recipes)
-	
+
 	bool bIsAutoConnectHologram = false;
 	if (ActiveHologram.IsValid() && AutoConnectService)
 	{
@@ -4549,11 +4549,11 @@ void USFSubsystem::OnRecipeModeChanged(const FInputActionValue& Value)
 		bool bIsStackableBelt = USFAutoConnectService::IsBeltSupportHologram(ActiveHologram.Get());
 		bool bIsPowerPole = AutoConnectService->IsPowerPoleHologram(ActiveHologram.Get());
 		bool bIsPassthroughPipe = USFAutoConnectService::IsPassthroughPipeHologram(ActiveHologram.Get());
-		
+
 		bIsAutoConnectHologram = bIsDistributor || bIsPipeJunction || bIsStackablePipe || bIsStackableBelt || bIsPowerPole || bIsPassthroughPipe;
-		
+
 		FString BuildClassName = ActiveHologram->GetBuildClass() ? ActiveHologram->GetBuildClass()->GetName() : TEXT("NULL");
-		UE_LOG(LogSmartFoundations, Log, TEXT(" OnRecipeModeChanged: Hologram=%s, BuildClass=%s, Distributor=%d, PipeJunction=%d, StackablePipe=%d, BeltSupport=%d, PowerPole=%d, PassthroughPipe=%d, IsAutoConnect=%d"),
+		UE_LOG(LogSmartFoundations, VeryVerbose, TEXT(" OnRecipeModeChanged: Hologram=%s, BuildClass=%s, Distributor=%d, PipeJunction=%d, StackablePipe=%d, BeltSupport=%d, PowerPole=%d, PassthroughPipe=%d, IsAutoConnect=%d"),
 			*ActiveHologram->GetClass()->GetName(), *BuildClassName, bIsDistributor, bIsPipeJunction, bIsStackablePipe, bIsStackableBelt, bIsPowerPole, bIsPassthroughPipe, bIsAutoConnectHologram);
 	}
 	else
@@ -4561,13 +4561,13 @@ void USFSubsystem::OnRecipeModeChanged(const FInputActionValue& Value)
 		UE_LOG(LogSmartFoundations, Warning, TEXT(" OnRecipeModeChanged: ActiveHologram=%d, AutoConnectService=%d"),
 			ActiveHologram.IsValid(), AutoConnectService != nullptr);
 	}
-	
+
 	if (bIsAutoConnectHologram)
 	{
 		// Auto-Connect Settings Mode for distributors, pipe junctions, and power poles
 		bAutoConnectSettingsModeActive = bPressed;
 		bRecipeModeActive = false;  // Ensure recipe mode is off
-		
+
 		if (bAutoConnectSettingsModeActive)
 		{
 			// Initialize runtime settings from config only if not already initialized
@@ -4575,25 +4575,25 @@ void USFSubsystem::OnRecipeModeChanged(const FInputActionValue& Value)
 			if (bConfigLoaded && !AutoConnectRuntimeSettings.bInitialized)
 			{
 				AutoConnectRuntimeSettings.InitFromConfig(CachedConfig);
-				UE_LOG(LogSmartFoundations, Log, TEXT("⚙️ Auto-Connect runtime settings initialized from config"));
+				UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("⚙️ Auto-Connect runtime settings initialized from config"));
 			}
-			
-			UE_LOG(LogSmartFoundations, Log, TEXT("⚙️ Auto-Connect Settings Mode: Active (U held on auto-connect hologram)"));
-			UE_LOG(LogSmartFoundations, Log, TEXT("   Current Setting: %s"), *GetAutoConnectSettingDisplayString());
-			
+
+			UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("⚙️ Auto-Connect Settings Mode: Active (U held on auto-connect hologram)"));
+			UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("   Current Setting: %s"), *GetAutoConnectSettingDisplayString());
+
 			// Try to acquire lock
 			TryAcquireHologramLock();
-			
+
 			// Update HUD to show current active setting
 			UpdateCounterDisplay();
 		}
 		else
 		{
 			UE_LOG(LogSmartFoundations, Warning, TEXT("⚙️ Auto-Connect Settings Mode: Inactive (U released)"));
-			
+
 			// Try to release lock
 			TryReleaseHologramLock();
-			
+
 			// Update HUD to refresh display (remove active indicator)
 			UpdateCounterDisplay();
 		}
@@ -4603,22 +4603,22 @@ void USFSubsystem::OnRecipeModeChanged(const FInputActionValue& Value)
 		// Recipe Mode for factory buildings
 		bRecipeModeActive = bPressed;
 		bAutoConnectSettingsModeActive = false;  // Ensure auto-connect settings mode is off
-		
+
 		if (bRecipeModeActive)
 		{
-			UE_LOG(LogSmartFoundations, Log, TEXT("🍽️ Recipe Mode: Active (U held on factory)"));
-			
+			UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("🍽️ Recipe Mode: Active (U held on factory)"));
+
 			// Try to acquire lock
 			TryAcquireHologramLock();
 		}
 		else
 		{
 			UE_LOG(LogSmartFoundations, Warning, TEXT("🍽️ Recipe Mode: Inactive (U released)"));
-			
+
 			// Try to release lock
 			TryReleaseHologramLock();
 		}
-		
+
 		// Delegate to recipe management service (only for factories)
 		if (RecipeManagementService)
 		{
@@ -4704,7 +4704,7 @@ UClass* USFSubsystem::GetPipeClassForTier(int32 Tier, bool bWithIndicator, AFGPl
 		UE_LOG(LogSmartFoundations, Warning, TEXT("GetPipeClassForTier: Invalid tier %d (must be 1-2)"), Tier);
 		return nullptr;
 	}
-	
+
 	// Build pipe class path based on tier and style
 	FString PipePath;
 	if (Tier == 1)
@@ -4731,16 +4731,16 @@ UClass* USFSubsystem::GetPipeClassForTier(int32 Tier, bool bWithIndicator, AFGPl
 			PipePath = TEXT("/Game/FactoryGame/Buildable/Factory/PipelineMK2/Build_PipelineMK2_NoIndicator.Build_PipelineMK2_NoIndicator_C");
 		}
 	}
-	
+
 	UClass* PipeClass = LoadObject<UClass>(nullptr, *PipePath);
-	
+
 	if (!PipeClass)
 	{
-		UE_LOG(LogSmartFoundations, Warning, TEXT("GetPipeClassForTier: Failed to load pipe class for tier %d (indicator=%d)"), 
+		UE_LOG(LogSmartFoundations, Warning, TEXT("GetPipeClassForTier: Failed to load pipe class for tier %d (indicator=%d)"),
 			Tier, bWithIndicator);
 		return nullptr;
 	}
-	
+
 	// Check if player has unlocked this pipe tier
 	if (PlayerController)
 	{
@@ -4754,14 +4754,14 @@ UClass* USFSubsystem::GetPipeClassForTier(int32 Tier, bool bWithIndicator, AFGPl
 				TSubclassOf<AFGBuildable> PipeBuildableClass = PipeClass;
 				if (!RecipeManager->IsBuildingAvailable(PipeBuildableClass))
 				{
-					UE_LOG(LogSmartFoundations, Log, TEXT("GetPipeClassForTier: Pipe tier Mk%d (%s) not unlocked yet"), 
-						Tier, bWithIndicator ? TEXT("Normal") : TEXT("Clean"));
+					UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("GetPipeClassForTier: Pipe tier Mk%d (%s) not unlocked yet"),
+					Tier, bWithIndicator ? TEXT("Normal") : TEXT("Clean"));
 					return nullptr;  // Pipe tier not unlocked - prevents cheating
 				}
 			}
 		}
 	}
-	
+
 	return PipeClass;
 }
 
@@ -4773,7 +4773,7 @@ TSubclassOf<UFGRecipe> USFSubsystem::GetBeltRecipeForTier(int32 Tier)
 		UE_LOG(LogSmartFoundations, Warning, TEXT("GetBeltRecipeForTier: Invalid tier %d (must be 1-6)"), Tier);
 		return nullptr;
 	}
-	
+
 	// Build belt recipe path based on tier
 	FString RecipePath;
 	switch (Tier)
@@ -4786,15 +4786,15 @@ TSubclassOf<UFGRecipe> USFSubsystem::GetBeltRecipeForTier(int32 Tier)
 		case 6: RecipePath = TEXT("/Game/FactoryGame/Recipes/Buildings/Recipe_ConveyorBeltMk6.Recipe_ConveyorBeltMk6_C"); break;
 		default: return nullptr;
 	}
-	
+
 	UClass* RecipeClass = LoadObject<UClass>(nullptr, *RecipePath);
-	
+
 	if (!RecipeClass)
 	{
 		UE_LOG(LogSmartFoundations, Warning, TEXT("GetBeltRecipeForTier: Failed to load recipe for Mk%d belt"), Tier);
 		return nullptr;
 	}
-	
+
 	return TSubclassOf<UFGRecipe>(RecipeClass);
 }
 
@@ -4806,7 +4806,7 @@ TSubclassOf<UFGRecipe> USFSubsystem::GetPipeRecipeForTier(int32 Tier, bool bWith
 		UE_LOG(LogSmartFoundations, Warning, TEXT("GetPipeRecipeForTier: Invalid tier %d (must be 1-2)"), Tier);
 		return nullptr;
 	}
-	
+
 	// Build pipe recipe path based on tier and style
 	FString RecipePath;
 	if (Tier == 1)
@@ -4833,16 +4833,16 @@ TSubclassOf<UFGRecipe> USFSubsystem::GetPipeRecipeForTier(int32 Tier, bool bWith
 			RecipePath = TEXT("/Game/FactoryGame/Recipes/Buildings/Recipe_PipelineMK2_NoIndicator.Recipe_PipelineMK2_NoIndicator_C");
 		}
 	}
-	
+
 	UClass* RecipeClass = LoadObject<UClass>(nullptr, *RecipePath);
-	
+
 	if (!RecipeClass)
 	{
-		UE_LOG(LogSmartFoundations, Warning, TEXT("GetPipeRecipeForTier: Failed to load recipe for tier %d (indicator=%d)"), 
+		UE_LOG(LogSmartFoundations, Warning, TEXT("GetPipeRecipeForTier: Failed to load recipe for tier %d (indicator=%d)"),
 			Tier, bWithIndicator);
 		return nullptr;
 	}
-	
+
 	return TSubclassOf<UFGRecipe>(RecipeClass);
 }
 
@@ -4853,21 +4853,21 @@ int32 USFSubsystem::GetHighestUnlockedPipeTier(AFGPlayerController* PlayerContro
 		UE_LOG(LogSmartFoundations, Warning, TEXT("GetHighestUnlockedPipeTier: No player controller, defaulting to Mk1"));
 		return 1;  // Default to Mk1 if no player context
 	}
-	
+
 	UWorld* World = PlayerController->GetWorld();
 	if (!World)
 	{
 		UE_LOG(LogSmartFoundations, Warning, TEXT("GetHighestUnlockedPipeTier: No world context, defaulting to Mk1"));
 		return 1;
 	}
-	
+
 	AFGRecipeManager* RecipeManager = AFGRecipeManager::Get(World);
 	if (!RecipeManager)
 	{
 		UE_LOG(LogSmartFoundations, Warning, TEXT("GetHighestUnlockedPipeTier: No recipe manager, defaulting to Mk1"));
 		return 1;
 	}
-	
+
 	// Check pipe tiers from highest (Mk2) to lowest (Mk1) to find highest unlocked
 	// Check "Normal" variant (with indicators) as the canonical unlock check
 	for (int32 Tier = 2; Tier >= 1; Tier--)
@@ -4881,7 +4881,7 @@ int32 USFSubsystem::GetHighestUnlockedPipeTier(AFGPlayerController* PlayerContro
 		{
 			PipePath = TEXT("/Game/FactoryGame/Buildable/Factory/PipelineMk2/Build_PipelineMK2.Build_PipelineMK2_C");
 		}
-		
+
 		UClass* PipeClass = LoadObject<UClass>(nullptr, *PipePath);
 		if (PipeClass)
 		{
@@ -4893,7 +4893,7 @@ int32 USFSubsystem::GetHighestUnlockedPipeTier(AFGPlayerController* PlayerContro
 			}
 		}
 	}
-	
+
 	// Fallback: If nothing is unlocked (shouldn't happen), return Mk1
 	UE_LOG(LogSmartFoundations, Warning, TEXT("GetHighestUnlockedPipeTier: No pipes unlocked, defaulting to Mk1"));
 	return 1;
@@ -4905,23 +4905,23 @@ bool USFSubsystem::AreCleanPipesUnlocked(AFGPlayerController* PlayerController)
 	{
 		return false;
 	}
-	
+
 	UWorld* World = PlayerController->GetWorld();
 	if (!World)
 	{
 		return false;
 	}
-	
+
 	AFGRecipeManager* RecipeManager = AFGRecipeManager::Get(World);
 	if (!RecipeManager)
 	{
 		return false;
 	}
-	
+
 	// Check if Mk1 clean pipe is unlocked (NoIndicator variant)
 	FString CleanPipePath = TEXT("/Game/FactoryGame/Buildable/Factory/Pipeline/Build_Pipeline_NoIndicator.Build_Pipeline_NoIndicator_C");
 	UClass* CleanPipeClass = LoadObject<UClass>(nullptr, *CleanPipePath);
-	
+
 	if (CleanPipeClass)
 	{
 		TSubclassOf<AFGBuildable> CleanPipeBuildableClass = CleanPipeClass;
@@ -4930,14 +4930,14 @@ bool USFSubsystem::AreCleanPipesUnlocked(AFGPlayerController* PlayerController)
 			return true;
 		}
 	}
-	
+
 	return false;
 }
 
 UClass* USFSubsystem::GetPipeClassFromConfig(int32 ConfigTier, bool bWithIndicator, AFGPlayerController* PlayerController)
 {
 	int32 ActualTier = ConfigTier;
-	
+
 	// Handle "Auto" mode (0 = use highest unlocked)
 	if (ConfigTier == 0)
 	{
@@ -4948,16 +4948,16 @@ UClass* USFSubsystem::GetPipeClassFromConfig(int32 ConfigTier, bool bWithIndicat
 	{
 		UE_LOG(LogSmartFoundations, Verbose, TEXT("GetPipeClassFromConfig: Using configured tier Mk%d"), ActualTier);
 	}
-	
+
 	// Get pipe class for the determined tier and style
 	UClass* PipeClass = GetPipeClassForTier(ActualTier, bWithIndicator, PlayerController);
-	
+
 	if (!PipeClass)
 	{
-		UE_LOG(LogSmartFoundations, Warning, TEXT("GetPipeClassFromConfig: Pipe tier Mk%d (%s) unavailable or not unlocked - pipe category disabled"), 
+		UE_LOG(LogSmartFoundations, Warning, TEXT("GetPipeClassFromConfig: Pipe tier Mk%d (%s) unavailable or not unlocked - pipe category disabled"),
 			ActualTier, bWithIndicator ? TEXT("Normal") : TEXT("Clean"));
 	}
-	
+
 	return PipeClass;
 }
 
@@ -4975,7 +4975,7 @@ void USFSubsystem::CycleAutoConnectSetting()
         bIsStackableBelt = USFAutoConnectService::IsBeltSupportHologram(ActiveHologram.Get());
         bIsPowerPole = AutoConnectService->IsPowerPoleHologram(ActiveHologram.Get());
     }
-    
+
     if (bIsPowerPole)
     {
         // Power Pole cycle: Enabled -> Reserved -> Grid Axis -> Enabled
@@ -5119,8 +5119,8 @@ void USFSubsystem::CycleAutoConnectSetting()
             break;
         }
     }
-    
-    UE_LOG(LogSmartFoundations, Log, TEXT(" Auto-Connect Setting Cycled: %s"), *GetAutoConnectSettingDisplayString());
+
+    UE_LOG(LogSmartFoundations, VeryVerbose, TEXT(" Auto-Connect Setting Cycled: %s"), *GetAutoConnectSettingDisplayString());
     UpdateCounterDisplay();
 }
 
@@ -5128,7 +5128,7 @@ void USFSubsystem::AdjustAutoConnectSetting(int32 Delta)
 {
     // Mark settings as modified (initialized) when user makes changes
     AutoConnectRuntimeSettings.bInitialized = true;
-    
+
     switch (CurrentAutoConnectSetting)
     {
     case EAutoConnectSetting::Enabled:
@@ -5170,22 +5170,22 @@ void USFSubsystem::AdjustAutoConnectSetting(int32 Delta)
         AutoConnectRuntimeSettings.bChainDistributors = !AutoConnectRuntimeSettings.bChainDistributors;
         break;
 
-        
+
     case EAutoConnectSetting::PipeTierMain:
         // Cycle through 0 (Auto), 1 (Mk1), 2 (Mk2)
         AutoConnectRuntimeSettings.PipeTierMain = FMath::Clamp(AutoConnectRuntimeSettings.PipeTierMain + Delta, 0, 2);
         break;
-        
+
     case EAutoConnectSetting::PipeTierToBuilding:
         // Cycle through 0 (Auto), 1 (Mk1), 2 (Mk2)
         AutoConnectRuntimeSettings.PipeTierToBuilding = FMath::Clamp(AutoConnectRuntimeSettings.PipeTierToBuilding + Delta, 0, 2);
         break;
-        
+
     case EAutoConnectSetting::PipeIndicator:
         // Toggle between Normal (with indicators) and Clean (no indicators)
         AutoConnectRuntimeSettings.bPipeIndicator = !AutoConnectRuntimeSettings.bPipeIndicator;
         break;
-        
+
     case EAutoConnectSetting::PipeRoutingMode:
         // Cycle through 0=Auto, 1=Auto2D, 2=Straight, 3=Curve, 4=Noodle, 5=HorizontalToVertical
         AutoConnectRuntimeSettings.PipeRoutingMode = (AutoConnectRuntimeSettings.PipeRoutingMode + Delta) % 6;
@@ -5194,12 +5194,12 @@ void USFSubsystem::AdjustAutoConnectSetting(int32 Delta)
             AutoConnectRuntimeSettings.PipeRoutingMode += 6;
         }
         break;
-        
+
     case EAutoConnectSetting::StackableBeltEnabled:
         // Toggle stackable conveyor pole belt auto-connect
         AutoConnectRuntimeSettings.bStackableBeltEnabled = !AutoConnectRuntimeSettings.bStackableBeltEnabled;
         break;
-        
+
     case EAutoConnectSetting::StackableBeltTier:
         {
             // Cycle through 0 (Auto), 1 (Mk1), ... up to highest unlocked tier - reuses BeltTierMain
@@ -5207,25 +5207,25 @@ void USFSubsystem::AdjustAutoConnectSetting(int32 Delta)
             AutoConnectRuntimeSettings.BeltTierMain = FMath::Clamp(AutoConnectRuntimeSettings.BeltTierMain + Delta, 0, MaxTier);
         }
         break;
-        
+
     case EAutoConnectSetting::StackableBeltDirection:
         // Toggle between 0 (Forward) and 1 (Backward)
         AutoConnectRuntimeSettings.StackableBeltDirection = (AutoConnectRuntimeSettings.StackableBeltDirection == 0) ? 1 : 0;
         break;
-        
+
     case EAutoConnectSetting::PowerEnabled:
         AutoConnectRuntimeSettings.bConnectPower = !AutoConnectRuntimeSettings.bConnectPower;
         break;
-        
+
     case EAutoConnectSetting::PowerReserved:
         AutoConnectRuntimeSettings.PowerReserved = FMath::Clamp(AutoConnectRuntimeSettings.PowerReserved + Delta, 0, 5);
         break;
-        
+
     case EAutoConnectSetting::PowerGridAxis:
         // Cycle through 0 (Auto), 1 (X), 2 (Y), 3 (X+Y)
         AutoConnectRuntimeSettings.PowerGridAxis = FMath::Clamp(AutoConnectRuntimeSettings.PowerGridAxis + Delta, 0, 3);
         break;
-        
+
     case EAutoConnectSetting::BeltRoutingMode:
         // Cycle through 0=Default, 1=Curve, 2=Straight (matches vanilla belt build modes)
         AutoConnectRuntimeSettings.BeltRoutingMode = (AutoConnectRuntimeSettings.BeltRoutingMode + Delta) % 3;
@@ -5235,9 +5235,9 @@ void USFSubsystem::AdjustAutoConnectSetting(int32 Delta)
         }
         break;
     }
-    
-    UE_LOG(LogSmartFoundations, Log, TEXT(" Auto-Connect Setting Adjusted: %s"), *GetAutoConnectSettingDisplayString());
-    
+
+    UE_LOG(LogSmartFoundations, VeryVerbose, TEXT(" Auto-Connect Setting Adjusted: %s"), *GetAutoConnectSettingDisplayString());
+
     // Trigger immediate re-evaluation of previews with new settings
     if (ActiveHologram.IsValid() && AutoConnectService)
     {
@@ -5249,7 +5249,7 @@ void USFSubsystem::AdjustAutoConnectSetting(int32 Delta)
             {
                 // Force recreation of all belt previews with new settings
                 Orchestrator->EvaluateGrid(true);
-                UE_LOG(LogSmartFoundations, Log, TEXT(" Orchestrator: Force recreated belt previews after settings change"));
+                UE_LOG(LogSmartFoundations, VeryVerbose, TEXT(" Orchestrator: Force recreated belt previews after settings change"));
             }
         }
         else if (AutoConnectService->IsPipelineJunctionHologram(ActiveHologram.Get()))
@@ -5260,26 +5260,26 @@ void USFSubsystem::AdjustAutoConnectSetting(int32 Delta)
             {
                 // Force recreation of all pipe previews with new settings
                 Orchestrator->OnPipeGridChanged();
-                UE_LOG(LogSmartFoundations, Log, TEXT(" Orchestrator: Force recreated pipe previews after settings change"));
+                UE_LOG(LogSmartFoundations, VeryVerbose, TEXT(" Orchestrator: Force recreated pipe previews after settings change"));
             }
         }
         else if (AutoConnectService->IsStackablePipelineSupportHologram(ActiveHologram.Get()))
         {
             // Stackable pipe supports: trigger re-processing of pipe previews
             AutoConnectService->ProcessStackablePipelineSupports(ActiveHologram.Get());
-            UE_LOG(LogSmartFoundations, Log, TEXT(" Stackable Pipe: Force recreated pipe previews after settings change"));
+            UE_LOG(LogSmartFoundations, VeryVerbose, TEXT(" Stackable Pipe: Force recreated pipe previews after settings change"));
         }
         else if (USFAutoConnectService::IsPassthroughPipeHologram(ActiveHologram.Get()))
         {
             // Floor hole pipes: trigger re-processing of pipe previews
             AutoConnectService->ProcessFloorHolePipes(ActiveHologram.Get());
-            UE_LOG(LogSmartFoundations, Log, TEXT(" Floor Hole Pipe: Force recreated pipe previews after settings change"));
+            UE_LOG(LogSmartFoundations, VeryVerbose, TEXT(" Floor Hole Pipe: Force recreated pipe previews after settings change"));
         }
         else if (USFAutoConnectService::IsBeltSupportHologram(ActiveHologram.Get()))
         {
             // Belt support poles (stackable, ceiling, wall): trigger re-processing of belt previews
             AutoConnectService->ProcessStackableConveyorPoles(ActiveHologram.Get());
-            UE_LOG(LogSmartFoundations, Log, TEXT(" Belt Support: Force recreated belt previews after settings change"));
+            UE_LOG(LogSmartFoundations, VeryVerbose, TEXT(" Belt Support: Force recreated belt previews after settings change"));
         }
         else if (AutoConnectService->IsPowerPoleHologram(ActiveHologram.Get()))
         {
@@ -5289,11 +5289,11 @@ void USFSubsystem::AdjustAutoConnectSetting(int32 Delta)
             {
                 // Force recreation of all power previews with new settings
                 Orchestrator->OnPowerGridChanged();
-                UE_LOG(LogSmartFoundations, Log, TEXT(" Orchestrator: Force recreated power previews after settings change"));
+                UE_LOG(LogSmartFoundations, VeryVerbose, TEXT(" Orchestrator: Force recreated power previews after settings change"));
             }
         }
     }
-    
+
     UpdateCounterDisplay();
     AutoConnectRuntimeSettings.bInitialized = true;
 }
@@ -5302,12 +5302,12 @@ FString USFSubsystem::GetAutoConnectSettingDisplayString() const
 {
     FString SettingName;
     FString SettingValue;
-    
+
     switch (CurrentAutoConnectSetting)
     {
     case EAutoConnectSetting::Enabled:
         // Context-aware display: show belt or pipe auto-connect status
-        if (ActiveHologram.IsValid() && AutoConnectService && 
+        if (ActiveHologram.IsValid() && AutoConnectService &&
             (AutoConnectService->IsPipelineJunctionHologram(ActiveHologram.Get()) ||
              AutoConnectService->IsStackablePipelineSupportHologram(ActiveHologram.Get()) ||
              USFAutoConnectService::IsPassthroughPipeHologram(ActiveHologram.Get())))
@@ -5321,7 +5321,7 @@ FString USFSubsystem::GetAutoConnectSettingDisplayString() const
             SettingValue = AutoConnectRuntimeSettings.bEnabled ? TEXT("ON") : TEXT("OFF");
         }
         break;
-        
+
     case EAutoConnectSetting::BeltTierMain:
         SettingName = TEXT("Belt Tier (Main)");
         if (AutoConnectRuntimeSettings.BeltTierMain == 0)
@@ -5333,7 +5333,7 @@ FString USFSubsystem::GetAutoConnectSettingDisplayString() const
             SettingValue = FString::Printf(TEXT("Mk%d"), AutoConnectRuntimeSettings.BeltTierMain);
         }
         break;
-        
+
     case EAutoConnectSetting::BeltTierToBuilding:
         SettingName = TEXT("Belt Tier (To Building)");
         if (AutoConnectRuntimeSettings.BeltTierToBuilding == 0)
@@ -5345,12 +5345,12 @@ FString USFSubsystem::GetAutoConnectSettingDisplayString() const
             SettingValue = FString::Printf(TEXT("Mk%d"), AutoConnectRuntimeSettings.BeltTierToBuilding);
         }
         break;
-        
+
     case EAutoConnectSetting::ChainDistributors:
         SettingName = TEXT("Chain Distributors");
         SettingValue = AutoConnectRuntimeSettings.bChainDistributors ? TEXT("ON") : TEXT("OFF");
         break;
-        
+
     case EAutoConnectSetting::BeltRoutingMode:
         SettingName = TEXT("Belt Routing");
         switch (AutoConnectRuntimeSettings.BeltRoutingMode)
@@ -5369,7 +5369,7 @@ FString USFSubsystem::GetAutoConnectSettingDisplayString() const
             break;
         }
         break;
-        
+
     case EAutoConnectSetting::PipeTierMain:
         SettingName = TEXT("Pipe Tier (Main)");
         if (AutoConnectRuntimeSettings.PipeTierMain == 0)
@@ -5381,7 +5381,7 @@ FString USFSubsystem::GetAutoConnectSettingDisplayString() const
             SettingValue = FString::Printf(TEXT("Mk%d"), AutoConnectRuntimeSettings.PipeTierMain);
         }
         break;
-        
+
     case EAutoConnectSetting::PipeTierToBuilding:
         SettingName = TEXT("Pipe Tier (To Building)");
         if (AutoConnectRuntimeSettings.PipeTierToBuilding == 0)
@@ -5393,12 +5393,12 @@ FString USFSubsystem::GetAutoConnectSettingDisplayString() const
             SettingValue = FString::Printf(TEXT("Mk%d"), AutoConnectRuntimeSettings.PipeTierToBuilding);
         }
         break;
-        
+
     case EAutoConnectSetting::PipeIndicator:
         SettingName = TEXT("Pipe Style");
         SettingValue = AutoConnectRuntimeSettings.bPipeIndicator ? TEXT("Normal") : TEXT("Clean");
         break;
-        
+
     case EAutoConnectSetting::PipeRoutingMode:
         SettingName = TEXT("Pipe Routing");
         switch (AutoConnectRuntimeSettings.PipeRoutingMode)
@@ -5426,12 +5426,12 @@ FString USFSubsystem::GetAutoConnectSettingDisplayString() const
             break;
         }
         break;
-        
+
     case EAutoConnectSetting::StackableBeltEnabled:
         SettingName = TEXT("Stackable Belt Auto-Connect");
         SettingValue = AutoConnectRuntimeSettings.bStackableBeltEnabled ? TEXT("ON") : TEXT("OFF");
         break;
-        
+
     case EAutoConnectSetting::StackableBeltTier:
         SettingName = TEXT("Stackable Belt Tier");
         if (AutoConnectRuntimeSettings.BeltTierMain == 0)
@@ -5443,17 +5443,17 @@ FString USFSubsystem::GetAutoConnectSettingDisplayString() const
             SettingValue = FString::Printf(TEXT("Mk%d"), AutoConnectRuntimeSettings.BeltTierMain);
         }
         break;
-        
+
     case EAutoConnectSetting::StackableBeltDirection:
         SettingName = TEXT("Stackable Belt Direction");
         SettingValue = AutoConnectRuntimeSettings.StackableBeltDirection == 0 ? TEXT("Forward") : TEXT("Backward");
         break;
-        
+
     case EAutoConnectSetting::PowerEnabled:
         SettingName = TEXT("Power Auto-Connect");
         SettingValue = AutoConnectRuntimeSettings.bConnectPower ? TEXT("ON") : TEXT("OFF");
         break;
-        
+
     case EAutoConnectSetting::PowerGridAxis:
         SettingName = TEXT("Grid Axis");
         switch (AutoConnectRuntimeSettings.PowerGridAxis)
@@ -5475,13 +5475,13 @@ FString USFSubsystem::GetAutoConnectSettingDisplayString() const
             break;
         }
         break;
-        
+
     case EAutoConnectSetting::PowerReserved:
         SettingName = TEXT("Reserved Slots");
         SettingValue = FString::Printf(TEXT("%d"), AutoConnectRuntimeSettings.PowerReserved);
         break;
     }
-    
+
     return FString::Printf(TEXT("%s: %s"), *SettingName, *SettingValue);
 }
 
@@ -5491,7 +5491,7 @@ bool USFSubsystem::IsCurrentHologramAutoConnectCapable() const
 	{
 		return false;
 	}
-	
+
 	AFGHologram* Hologram = ActiveHologram.Get();
 	return AutoConnectService->IsDistributorHologram(Hologram) ||
 	       AutoConnectService->IsPipelineJunctionHologram(Hologram) ||
@@ -5503,12 +5503,12 @@ bool USFSubsystem::IsCurrentHologramAutoConnectCapable() const
 TArray<FString> USFSubsystem::GetDirtyAutoConnectSettings() const
 {
 	TArray<FString> DirtySettings;
-	
+
 	if (!bConfigLoaded)
 	{
 		return DirtySettings; // No config to compare against
 	}
-	
+
 	// Determine hologram type to filter relevant settings
 	bool bIsPipeJunction = false;
 	bool bIsDistributor = false;
@@ -5517,78 +5517,72 @@ TArray<FString> USFSubsystem::GetDirtyAutoConnectSettings() const
 	bool bIsPassthroughPipe = false;
 	if (ActiveHologram.IsValid() && AutoConnectService)
 	{
-		bIsPipeJunction = AutoConnectService->IsPipelineJunctionHologram(ActiveHologram.Get());
-		bIsDistributor = AutoConnectService->IsDistributorHologram(ActiveHologram.Get());
-		bIsPowerPole = AutoConnectService->IsPowerPoleHologram(ActiveHologram.Get());
-		bIsStackableSupport = USFAutoConnectService::IsStackableSupportHologram(ActiveHologram.Get());
-		bIsPassthroughPipe = USFAutoConnectService::IsPassthroughPipeHologram(ActiveHologram.Get());
-		
-		UE_LOG(LogSmartFoundations, Log, TEXT("GetDirtyAutoConnectSettings: Hologram=%s | PipeJunction=%d Distributor=%d PowerPole=%d StackableSupport=%d PassthroughPipe=%d"),
-			*ActiveHologram->GetName(), bIsPipeJunction, bIsDistributor, bIsPowerPole, bIsStackableSupport, bIsPassthroughPipe);
+		AFGHologram* Hologram = ActiveHologram.Get();
+		bIsPipeJunction = AutoConnectService->IsPipelineJunctionHologram(Hologram);
+		bIsDistributor = AutoConnectService->IsDistributorHologram(Hologram);
+		bIsPowerPole = AutoConnectService->IsPowerPoleHologram(Hologram);
+		bIsStackableSupport = USFAutoConnectService::IsBeltSupportHologram(Hologram);
+		bIsPassthroughPipe = USFAutoConnectService::IsPassthroughPipeHologram(Hologram);
 	}
-	else
-	{
-		UE_LOG(LogSmartFoundations, Warning, TEXT("GetDirtyAutoConnectSettings: No ActiveHologram or AutoConnectService"));
-	}
-	
+
 	// CRITICAL FIX: Only show settings relevant to current hologram type
 	// Pipe junctions should only show pipe settings, distributors should only show belt settings
-	
+
 	if (bIsPipeJunction || bIsPassthroughPipe)
 	{
 		// Pipe junction or floor hole passthrough: Show pipe-related settings
 		if (AutoConnectRuntimeSettings.bPipeAutoConnectEnabled != CachedConfig.bPipeAutoConnectEnabled)
 		{
-			DirtySettings.Add(FString::Printf(TEXT("Pipe Auto-Connect: %s"), 
+			DirtySettings.Add(FString::Printf(TEXT("Pipe Auto-Connect: %s"),
 				AutoConnectRuntimeSettings.bPipeAutoConnectEnabled ? TEXT("ON") : TEXT("OFF")));
 		}
-		
+
 		if (AutoConnectRuntimeSettings.PipeTierMain != CachedConfig.PipeLevelMain)
 		{
-			const FString TierText = (AutoConnectRuntimeSettings.PipeTierMain == 0) ? 
+			const FString TierText = (AutoConnectRuntimeSettings.PipeTierMain == 0) ?
 				TEXT("Auto") : FString::Printf(TEXT("Mk%d"), AutoConnectRuntimeSettings.PipeTierMain);
 			DirtySettings.Add(FString::Printf(TEXT("Pipe Tier (Main): %s"), *TierText));
 		}
-		
+
 		if (AutoConnectRuntimeSettings.PipeTierToBuilding != CachedConfig.PipeLevelToBuilding)
 		{
-			const FString TierText = (AutoConnectRuntimeSettings.PipeTierToBuilding == 0) ? 
+			const FString TierText = (AutoConnectRuntimeSettings.PipeTierToBuilding == 0) ?
 				TEXT("Auto") : FString::Printf(TEXT("Mk%d"), AutoConnectRuntimeSettings.PipeTierToBuilding);
 			DirtySettings.Add(FString::Printf(TEXT("Pipe Tier (To Building): %s"), *TierText));
 		}
-		
+
 		if (AutoConnectRuntimeSettings.bPipeIndicator != CachedConfig.PipeIndicator)
 		{
-			DirtySettings.Add(FString::Printf(TEXT("Pipe Style: %s"), 
+			DirtySettings.Add(FString::Printf(TEXT("Pipe Style: %s"),
 				AutoConnectRuntimeSettings.bPipeIndicator ? TEXT("Normal") : TEXT("Clean")));
 		}
 	}
-	else if (bIsDistributor)
+	else if (bIsDistributor || bIsStackableSupport)
 	{
 		// Distributor: Show only belt-related settings
 		if (AutoConnectRuntimeSettings.bEnabled != CachedConfig.bAutoConnectEnabled)
 		{
-			DirtySettings.Add(FString::Printf(TEXT("Belt Auto-Connect: %s"), 
+			DirtySettings.Add(FString::Printf(TEXT("Belt Auto-Connect: %s"),
 				AutoConnectRuntimeSettings.bEnabled ? TEXT("ON") : TEXT("OFF")));
 		}
-		
+
 		if (AutoConnectRuntimeSettings.BeltTierMain != CachedConfig.BeltLevelMain)
 		{
-			const FString TierText = (AutoConnectRuntimeSettings.BeltTierMain == 0) ? 
+			const FString TierText = (AutoConnectRuntimeSettings.BeltTierMain == 0) ?
 				TEXT("Auto") : FString::Printf(TEXT("Mk%d"), AutoConnectRuntimeSettings.BeltTierMain);
 			DirtySettings.Add(FString::Printf(TEXT("Belt Tier (Main): %s"), *TierText));
 		}
-		
+
 		if (AutoConnectRuntimeSettings.BeltTierToBuilding != CachedConfig.BeltLevelToBuilding)
 		{
-			const FString TierText = (AutoConnectRuntimeSettings.BeltTierToBuilding == 0) ? 
+			const FString TierText = (AutoConnectRuntimeSettings.BeltTierToBuilding == 0) ?
 				TEXT("Auto") : FString::Printf(TEXT("Mk%d"), AutoConnectRuntimeSettings.BeltTierToBuilding);
 			DirtySettings.Add(FString::Printf(TEXT("Belt Tier (To Building): %s"), *TierText));
 		}
-		
+
 		if (AutoConnectRuntimeSettings.bChainDistributors != CachedConfig.bAutoConnectDistributors)
 		{
-			DirtySettings.Add(FString::Printf(TEXT("Chain Distributors: %s"), 
+			DirtySettings.Add(FString::Printf(TEXT("Chain Distributors: %s"),
 				AutoConnectRuntimeSettings.bChainDistributors ? TEXT("ON") : TEXT("OFF")));
 		}
 	}
@@ -5597,15 +5591,15 @@ TArray<FString> USFSubsystem::GetDirtyAutoConnectSettings() const
 		// Power pole: Show only power-related settings
 		if (AutoConnectRuntimeSettings.bConnectPower != CachedConfig.bPowerAutoConnectEnabled)
 		{
-			DirtySettings.Add(FString::Printf(TEXT("Power Auto-Connect: %s"), 
+			DirtySettings.Add(FString::Printf(TEXT("Power Auto-Connect: %s"),
 				AutoConnectRuntimeSettings.bConnectPower ? TEXT("ON") : TEXT("OFF")));
 		}
-		
+
 		if (AutoConnectRuntimeSettings.PowerReserved != CachedConfig.PowerConnectReserved)
 		{
 			DirtySettings.Add(FString::Printf(TEXT("Reserved Slots: %d"), AutoConnectRuntimeSettings.PowerReserved));
 		}
-		
+
 		if (AutoConnectRuntimeSettings.PowerGridAxis != CachedConfig.PowerConnectMode)
 		{
 			FString AxisText;
@@ -5619,7 +5613,7 @@ TArray<FString> USFSubsystem::GetDirtyAutoConnectSettings() const
 			}
 			DirtySettings.Add(FString::Printf(TEXT("Grid Axis: %s"), *AxisText));
 		}
-		
+
 		// Building range is config-only, but we can show if runtime value differs
 		// Convert both to meters for comparison (runtime is in cm, config is in meters)
 		int32 RuntimeRangeMeters = FMath::RoundToInt(AutoConnectRuntimeSettings.PowerBuildingRange / 100.0f);
@@ -5628,7 +5622,7 @@ TArray<FString> USFSubsystem::GetDirtyAutoConnectSettings() const
 			DirtySettings.Add(FString::Printf(TEXT("Building Range: %dm"), RuntimeRangeMeters));
 		}
 	}
-	
+
 	return DirtySettings;
 }
 
@@ -5638,23 +5632,23 @@ void USFSubsystem::ResetAutoConnectRuntimeSettings()
 	// This ensures config changes made mid-session take effect when equipping a new hologram
 	FSmart_ConfigStruct FreshConfig = FSmart_ConfigStruct::GetActiveConfig(this);
 	AutoConnectRuntimeSettings.InitFromConfig(FreshConfig);
-	
+
 	// Issue #257: Refresh Extend enabled state from fresh config
 	bExtendEnabledByConfig = FreshConfig.bExtendEnabled;
-	
-	UE_LOG(LogSmartFoundations, Log, TEXT(" Auto-Connect runtime settings reset from config:"));
-	UE_LOG(LogSmartFoundations, Log, TEXT("   Belt Auto-Connect: %s"), AutoConnectRuntimeSettings.bEnabled ? TEXT("ON") : TEXT("OFF"));
-	UE_LOG(LogSmartFoundations, Log, TEXT("   Pipe Auto-Connect: %s"), AutoConnectRuntimeSettings.bPipeAutoConnectEnabled ? TEXT("ON") : TEXT("OFF"));
-	UE_LOG(LogSmartFoundations, Log, TEXT("   Power Auto-Connect: %s"), AutoConnectRuntimeSettings.bConnectPower ? TEXT("ON") : TEXT("OFF"));
-	UE_LOG(LogSmartFoundations, Log, TEXT("   Power Range: %.0fm"), AutoConnectRuntimeSettings.PowerBuildingRange / 100.0f);
-	UE_LOG(LogSmartFoundations, Log, TEXT("   Extend Enabled: %s"), bExtendEnabledByConfig ? TEXT("ON") : TEXT("OFF"));
+
+	UE_LOG(LogSmartFoundations, VeryVerbose, TEXT(" Auto-Connect runtime settings reset from config:"));
+	UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("   Belt Auto-Connect: %s"), AutoConnectRuntimeSettings.bEnabled ? TEXT("ON") : TEXT("OFF"));
+	UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("   Pipe Auto-Connect: %s"), AutoConnectRuntimeSettings.bPipeAutoConnectEnabled ? TEXT("ON") : TEXT("OFF"));
+	UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("   Power Auto-Connect: %s"), AutoConnectRuntimeSettings.bConnectPower ? TEXT("ON") : TEXT("OFF"));
+	UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("   Power Range: %.0fm"), AutoConnectRuntimeSettings.PowerBuildingRange / 100.0f);
+	UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("   Extend Enabled: %s"), bExtendEnabledByConfig ? TEXT("ON") : TEXT("OFF"));
 }
 
 void USFSubsystem::ResetSmartDisableFlag()
 {
 	if (bDisableSmartForNextAction || bExtendDisabledForSession)
 	{
-		UE_LOG(LogSmartFoundations, Log, TEXT("▶️ Smart! re-enabled (Auto-Connect + Extend flags reset)"));
+		UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("▶️ Smart! re-enabled (Auto-Connect + Extend flags reset)"));
 	}
 	bDisableSmartForNextAction = false;
 	bExtendDisabledForSession = false;  // Issue #257: reset Extend session flag too
@@ -5670,7 +5664,7 @@ void USFSubsystem::SetAutoConnectBeltEnabled(bool bEnabled)
 	AutoConnectRuntimeSettings.bEnabled = bEnabled;
 	AutoConnectRuntimeSettings.bInitialized = true;
 	UpdateCounterDisplay();
-	UE_LOG(LogSmartFoundations, Log, TEXT("Belt auto-connect enabled set to: %s"), bEnabled ? TEXT("ON") : TEXT("OFF"));
+	UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("Belt auto-connect enabled set to: %s"), bEnabled ? TEXT("ON") : TEXT("OFF"));
 }
 
 void USFSubsystem::SetAutoConnectBeltTierMain(int32 Tier)
@@ -5678,7 +5672,7 @@ void USFSubsystem::SetAutoConnectBeltTierMain(int32 Tier)
 	AutoConnectRuntimeSettings.BeltTierMain = FMath::Clamp(Tier, 0, 6);
 	AutoConnectRuntimeSettings.bInitialized = true;
 	UpdateCounterDisplay();
-	UE_LOG(LogSmartFoundations, Log, TEXT("Belt tier main set to: %d"), AutoConnectRuntimeSettings.BeltTierMain);
+	UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("Belt tier main set to: %d"), AutoConnectRuntimeSettings.BeltTierMain);
 }
 
 void USFSubsystem::SetAutoConnectBeltTierToBuilding(int32 Tier)
@@ -5686,7 +5680,7 @@ void USFSubsystem::SetAutoConnectBeltTierToBuilding(int32 Tier)
 	AutoConnectRuntimeSettings.BeltTierToBuilding = FMath::Clamp(Tier, 0, 6);
 	AutoConnectRuntimeSettings.bInitialized = true;
 	UpdateCounterDisplay();
-	UE_LOG(LogSmartFoundations, Log, TEXT("Belt tier to building set to: %d"), AutoConnectRuntimeSettings.BeltTierToBuilding);
+	UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("Belt tier to building set to: %d"), AutoConnectRuntimeSettings.BeltTierToBuilding);
 }
 
 void USFSubsystem::SetAutoConnectBeltChain(bool bEnabled)
@@ -5694,7 +5688,7 @@ void USFSubsystem::SetAutoConnectBeltChain(bool bEnabled)
 	AutoConnectRuntimeSettings.bChainDistributors = bEnabled;
 	AutoConnectRuntimeSettings.bInitialized = true;
 	UpdateCounterDisplay();
-	UE_LOG(LogSmartFoundations, Log, TEXT("Belt chain distributors set to: %s"), bEnabled ? TEXT("ON") : TEXT("OFF"));
+	UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("Belt chain distributors set to: %s"), bEnabled ? TEXT("ON") : TEXT("OFF"));
 }
 
 void USFSubsystem::SetAutoConnectStackableBeltDirection(int32 Direction)
@@ -5702,7 +5696,7 @@ void USFSubsystem::SetAutoConnectStackableBeltDirection(int32 Direction)
 	AutoConnectRuntimeSettings.StackableBeltDirection = FMath::Clamp(Direction, 0, 1);
 	AutoConnectRuntimeSettings.bInitialized = true;
 	UpdateCounterDisplay();
-	UE_LOG(LogSmartFoundations, Log, TEXT("Stackable belt direction set to: %d (%s)"), 
+	UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("Stackable belt direction set to: %d (%s)"),
 		AutoConnectRuntimeSettings.StackableBeltDirection,
 		AutoConnectRuntimeSettings.StackableBeltDirection == 0 ? TEXT("Forward") : TEXT("Backward"));
 }
@@ -5712,7 +5706,7 @@ void USFSubsystem::SetAutoConnectBeltRoutingMode(int32 Mode)
 	AutoConnectRuntimeSettings.BeltRoutingMode = FMath::Clamp(Mode, 0, 2);
 	AutoConnectRuntimeSettings.bInitialized = true;
 	UpdateCounterDisplay();
-	
+
 	FString ModeName;
 	switch (AutoConnectRuntimeSettings.BeltRoutingMode)
 	{
@@ -5721,7 +5715,7 @@ void USFSubsystem::SetAutoConnectBeltRoutingMode(int32 Mode)
 	case 2: ModeName = TEXT("Straight"); break;
 	default: ModeName = TEXT("Default"); break;
 	}
-	UE_LOG(LogSmartFoundations, Log, TEXT("Belt routing mode set to: %d (%s)"), AutoConnectRuntimeSettings.BeltRoutingMode, *ModeName);
+	UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("Belt routing mode set to: %d (%s)"), AutoConnectRuntimeSettings.BeltRoutingMode, *ModeName);
 }
 
 // ========================================
@@ -5733,7 +5727,7 @@ void USFSubsystem::SetAutoConnectPipeEnabled(bool bEnabled)
 	AutoConnectRuntimeSettings.bPipeAutoConnectEnabled = bEnabled;
 	AutoConnectRuntimeSettings.bInitialized = true;
 	UpdateCounterDisplay();
-	UE_LOG(LogSmartFoundations, Log, TEXT("Pipe auto-connect enabled set to: %s"), bEnabled ? TEXT("ON") : TEXT("OFF"));
+	UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("Pipe auto-connect enabled set to: %s"), bEnabled ? TEXT("ON") : TEXT("OFF"));
 }
 
 void USFSubsystem::SetAutoConnectPipeTierMain(int32 Tier)
@@ -5741,7 +5735,7 @@ void USFSubsystem::SetAutoConnectPipeTierMain(int32 Tier)
 	AutoConnectRuntimeSettings.PipeTierMain = FMath::Clamp(Tier, 0, 2);
 	AutoConnectRuntimeSettings.bInitialized = true;
 	UpdateCounterDisplay();
-	UE_LOG(LogSmartFoundations, Log, TEXT("Pipe tier main set to: %d"), AutoConnectRuntimeSettings.PipeTierMain);
+	UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("Pipe tier main set to: %d"), AutoConnectRuntimeSettings.PipeTierMain);
 }
 
 void USFSubsystem::SetAutoConnectPipeTierToBuilding(int32 Tier)
@@ -5749,7 +5743,7 @@ void USFSubsystem::SetAutoConnectPipeTierToBuilding(int32 Tier)
 	AutoConnectRuntimeSettings.PipeTierToBuilding = FMath::Clamp(Tier, 0, 2);
 	AutoConnectRuntimeSettings.bInitialized = true;
 	UpdateCounterDisplay();
-	UE_LOG(LogSmartFoundations, Log, TEXT("Pipe tier to building set to: %d"), AutoConnectRuntimeSettings.PipeTierToBuilding);
+	UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("Pipe tier to building set to: %d"), AutoConnectRuntimeSettings.PipeTierToBuilding);
 }
 
 void USFSubsystem::SetAutoConnectPipeIndicator(bool bIndicator)
@@ -5757,7 +5751,7 @@ void USFSubsystem::SetAutoConnectPipeIndicator(bool bIndicator)
 	AutoConnectRuntimeSettings.bPipeIndicator = bIndicator;
 	AutoConnectRuntimeSettings.bInitialized = true;
 	UpdateCounterDisplay();
-	UE_LOG(LogSmartFoundations, Log, TEXT("Pipe indicator style set to: %s"), bIndicator ? TEXT("Normal") : TEXT("Clean"));
+	UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("Pipe indicator style set to: %s"), bIndicator ? TEXT("Normal") : TEXT("Clean"));
 }
 
 void USFSubsystem::SetAutoConnectPipeRoutingMode(int32 Mode)
@@ -5765,7 +5759,7 @@ void USFSubsystem::SetAutoConnectPipeRoutingMode(int32 Mode)
 	AutoConnectRuntimeSettings.PipeRoutingMode = FMath::Clamp(Mode, 0, 5);
 	AutoConnectRuntimeSettings.bInitialized = true;
 	UpdateCounterDisplay();
-	
+
 	FString ModeName;
 	switch (AutoConnectRuntimeSettings.PipeRoutingMode)
 	{
@@ -5777,7 +5771,7 @@ void USFSubsystem::SetAutoConnectPipeRoutingMode(int32 Mode)
 	case 5: ModeName = TEXT("Horiz→Vert"); break;
 	default: ModeName = TEXT("Auto"); break;
 	}
-	UE_LOG(LogSmartFoundations, Log, TEXT("Pipe routing mode set to: %s (%d)"), *ModeName, AutoConnectRuntimeSettings.PipeRoutingMode);
+	UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("Pipe routing mode set to: %s (%d)"), *ModeName, AutoConnectRuntimeSettings.PipeRoutingMode);
 }
 
 // ========================================
@@ -5789,7 +5783,7 @@ void USFSubsystem::SetAutoConnectPowerEnabled(bool bEnabled)
 	AutoConnectRuntimeSettings.bConnectPower = bEnabled;
 	AutoConnectRuntimeSettings.bInitialized = true;
 	UpdateCounterDisplay();
-	UE_LOG(LogSmartFoundations, Log, TEXT("Power auto-connect enabled set to: %s"), bEnabled ? TEXT("ON") : TEXT("OFF"));
+	UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("Power auto-connect enabled set to: %s"), bEnabled ? TEXT("ON") : TEXT("OFF"));
 }
 
 void USFSubsystem::SetAutoConnectPowerGridAxis(int32 Axis)
@@ -5797,7 +5791,7 @@ void USFSubsystem::SetAutoConnectPowerGridAxis(int32 Axis)
 	AutoConnectRuntimeSettings.PowerGridAxis = FMath::Clamp(Axis, 0, 3);
 	AutoConnectRuntimeSettings.bInitialized = true;
 	UpdateCounterDisplay();
-	
+
 	FString AxisName;
 	switch (AutoConnectRuntimeSettings.PowerGridAxis)
 	{
@@ -5807,7 +5801,7 @@ void USFSubsystem::SetAutoConnectPowerGridAxis(int32 Axis)
 	case 3: AxisName = TEXT("X+Y"); break;
 	default: AxisName = TEXT("Auto"); break;
 	}
-	UE_LOG(LogSmartFoundations, Log, TEXT("Power grid axis set to: %d (%s)"), AutoConnectRuntimeSettings.PowerGridAxis, *AxisName);
+	UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("Power grid axis set to: %d (%s)"), AutoConnectRuntimeSettings.PowerGridAxis, *AxisName);
 }
 
 void USFSubsystem::SetAutoConnectPowerReserved(int32 Reserved)
@@ -5815,7 +5809,7 @@ void USFSubsystem::SetAutoConnectPowerReserved(int32 Reserved)
 	AutoConnectRuntimeSettings.PowerReserved = FMath::Clamp(Reserved, 0, 5);
 	AutoConnectRuntimeSettings.bInitialized = true;
 	UpdateCounterDisplay();
-	UE_LOG(LogSmartFoundations, Log, TEXT("Power reserved slots set to: %d"), AutoConnectRuntimeSettings.PowerReserved);
+	UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("Power reserved slots set to: %d"), AutoConnectRuntimeSettings.PowerReserved);
 }
 
 void USFSubsystem::TriggerAutoConnectRefresh()
@@ -5828,10 +5822,10 @@ void USFSubsystem::TriggerAutoConnectRefresh()
 			Pair.Value->ForceRefresh();
 		}
 	}
-	
+
 	if (AutoConnectOrchestrators.Num() > 0)
 	{
-		UE_LOG(LogSmartFoundations, Log, TEXT("Auto-connect refresh triggered from settings change (%d orchestrators)"), AutoConnectOrchestrators.Num());
+		UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("Auto-connect refresh triggered from settings change (%d orchestrators)"), AutoConnectOrchestrators.Num());
 	}
 }
 
@@ -5877,12 +5871,12 @@ AFGHologram* USFSubsystem::TrySwapToSmartHologram(AFGHologram* OriginalHologram)
 		UE_LOG(LogSmartFoundations, Warning, TEXT("TrySwapToSmartHologram: Invalid hologram"));
 		return OriginalHologram;
 	}
-	
+
 	// NOTE: Removed name-based check as Satisfactory renames holograms after creation
 	// Child holograms are identified by the calling context in SpawnChildHologram
 	// All holograms reaching this function are intended for swapping
-	UE_LOG(LogSmartFoundations, Log, TEXT("TrySwapToSmartHologram: Proceeding with hologram swap for %s"), *OriginalHologram->GetName());
-	
+	UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("TrySwapToSmartHologram: Proceeding with hologram swap for %s"), *OriginalHologram->GetName());
+
 	// Get the build class to determine what type of building this is
 	UClass* BuildClass = OriginalHologram->GetBuildClass();
 	if (!BuildClass)
@@ -5890,13 +5884,13 @@ AFGHologram* USFSubsystem::TrySwapToSmartHologram(AFGHologram* OriginalHologram)
 		UE_LOG(LogSmartFoundations, Verbose, TEXT("TrySwapToSmartHologram: No build class for %s"), *OriginalHologram->GetName());
 		return OriginalHologram;
 	}
-	
+
 	FString BuildClassName = BuildClass->GetName();
 	FString OriginalHologramClass = OriginalHologram->GetClass()->GetName();
-	
-	UE_LOG(LogSmartFoundations, Verbose, TEXT("TrySwapToSmartHologram: %s -> BuildClass=%s"), 
+
+	UE_LOG(LogSmartFoundations, Verbose, TEXT("TrySwapToSmartHologram: %s -> BuildClass=%s"),
 		*OriginalHologramClass, *BuildClassName);
-	
+
 	// For now, implement a simple check - if it's a foundation hologram, we could swap it
 	// This is a placeholder for the full implementation
 	// The actual swapping would involve:
@@ -5904,15 +5898,15 @@ AFGHologram* USFSubsystem::TrySwapToSmartHologram(AFGHologram* OriginalHologram)
 	// 2. Copying properties from the original
 	// 3. Replacing it in the build gun system
 	// 4. Destroying the original
-	
+
 	// PHASE 4 FULL IMPLEMENTATION: Actually swap holograms
 	if (OriginalHologramClass == TEXT("Holo_Foundation_C"))
 	{
-		UE_LOG(LogSmartFoundations, Log, TEXT("SWAPPING: Foundation hologram -> ASFFoundationHologram"));
+		UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("SWAPPING: Foundation hologram -> ASFFoundationHologram"));
 		ASFFoundationHologram* CustomHologram = CreateCustomFoundationHologram(OriginalHologram);
 		if (CustomHologram)
 		{
-			UE_LOG(LogSmartFoundations, Log, TEXT("✅ Successfully created custom foundation hologram: %s"), *CustomHologram->GetName());
+			UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("✅ Successfully created custom foundation hologram: %s"), *CustomHologram->GetName());
 			return CustomHologram;
 		}
 		else
@@ -5922,25 +5916,25 @@ AFGHologram* USFSubsystem::TrySwapToSmartHologram(AFGHologram* OriginalHologram)
 	}
 	else if (Cast<AFGFactoryHologram>(OriginalHologram))
 	{
-		// NOTE: Runtime factory hologram swapping is DISABLED 
+		// NOTE: Runtime factory hologram swapping is DISABLED
 		// The build gun holds the original hologram reference, and creating a new one
 		// causes constant re-registration loops. Factory holograms need Blueprint class
 		// remapping at module load time instead.
 		// For now, EXTEND must work with vanilla holograms or use a different approach.
-		UE_LOG(LogSmartFoundations, Verbose, TEXT("Factory hologram %s - runtime swap disabled (use Blueprint class remapping)"), 
+		UE_LOG(LogSmartFoundations, Verbose, TEXT("Factory hologram %s - runtime swap disabled (use Blueprint class remapping)"),
 			*OriginalHologramClass);
 		// Return the original - don't create orphan custom holograms
 		return OriginalHologram;
 	}
-	else if (OriginalHologramClass == TEXT("Holo_ConveyorBelt_C") || 
+	else if (OriginalHologramClass == TEXT("Holo_ConveyorBelt_C") ||
 			 OriginalHologramClass == TEXT("Holo_ConveyorAttachmentSplitter_C") ||
 			 OriginalHologramClass == TEXT("Holo_ConveyorAttachmentMerger_C"))
 	{
-		UE_LOG(LogSmartFoundations, Log, TEXT("SWAPPING: Logistics hologram (%s) -> ASFLogisticsHologram"), *OriginalHologramClass);
+		UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("SWAPPING: Logistics hologram (%s) -> ASFLogisticsHologram"), *OriginalHologramClass);
 		ASFLogisticsHologram* CustomHologram = CreateCustomLogisticsHologram(OriginalHologram);
 		if (CustomHologram)
 		{
-			UE_LOG(LogSmartFoundations, Log, TEXT("✅ Successfully created custom logistics hologram: %s"), *CustomHologram->GetName());
+			UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("✅ Successfully created custom logistics hologram: %s"), *CustomHologram->GetName());
 			return CustomHologram;
 		}
 		else
@@ -5948,7 +5942,7 @@ AFGHologram* USFSubsystem::TrySwapToSmartHologram(AFGHologram* OriginalHologram)
 			UE_LOG(LogSmartFoundations, Error, TEXT("❌ Failed to create custom logistics hologram, falling back to vanilla"));
 		}
 	}
-	
+
 	// No swap needed
 	return OriginalHologram;
 }
@@ -5964,7 +5958,7 @@ ASFFoundationHologram* USFSubsystem::CreateCustomFoundationHologram(AFGHologram*
 		UE_LOG(LogSmartFoundations, Error, TEXT("CreateCustomFoundationHologram: Invalid original hologram"));
 		return nullptr;
 	}
-	
+
 	// Get the world context from the original hologram
 	UWorld* World = OriginalHologram->GetWorld();
 	if (!World)
@@ -5972,44 +5966,44 @@ ASFFoundationHologram* USFSubsystem::CreateCustomFoundationHologram(AFGHologram*
 		UE_LOG(LogSmartFoundations, Error, TEXT("CreateCustomFoundationHologram: No world context"));
 		return nullptr;
 	}
-	
+
 	// Configure spawn parameters with DEFERRED construction
 	// This allows us to set properties before BeginPlay() is called
 	FActorSpawnParameters SpawnParams;
 	SpawnParams.Owner = OriginalHologram->GetOwner();
 	SpawnParams.Instigator = OriginalHologram->GetInstigator();
 	SpawnParams.bDeferConstruction = true;  // CRITICAL: Defer construction to set build class first
-	
+
 	ASFFoundationHologram* CustomHologram = World->SpawnActor<ASFFoundationHologram>(ASFFoundationHologram::StaticClass(), SpawnParams);
 	if (!CustomHologram)
 	{
 		UE_LOG(LogSmartFoundations, Error, TEXT("CreateCustomFoundationHologram: Failed to spawn custom hologram"));
 		return nullptr;
 	}
-	
+
 	// CRITICAL: Set build class BEFORE finishing construction to prevent assertion failure
 	if (OriginalHologram->GetBuildClass())
 	{
 		CustomHologram->SetBuildClass(OriginalHologram->GetBuildClass());
 	}
-	
+
 	// Now finish construction which will trigger BeginPlay() with proper build class set
 	CustomHologram->FinishSpawning(CustomHologram->GetActorTransform(), true);
-	
+
 	CopyHologramProperties(OriginalHologram, CustomHologram);
-	
+
 	// CRITICAL: Force material state to OK to ensure child holograms are placeable
 	// This bypasses validation that would otherwise set them to ERROR
 	CustomHologram->SetPlacementMaterialState(EHologramMaterialState::HMS_OK);
-	
+
 	// Log the forced state for debugging
-	UE_LOG(LogSmartFoundations, Log, TEXT("CreateCustomFoundationHologram: Forced material state to HMS_OK for %s"), 
+	UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("CreateCustomFoundationHologram: Forced material state to HMS_OK for %s"),
 		*CustomHologram->GetName());
-	
+
 	// NOTE: Material state should be inherited from parent once properly linked
 	// The swapped hologram needs to be added to parent's children array to inherit parent's valid state
-	
-	UE_LOG(LogSmartFoundations, Log, TEXT("CreateCustomFoundationHologram: Successfully created %s (build gun replacement pending)"), *CustomHologram->GetName());
+
+	UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("CreateCustomFoundationHologram: Successfully created %s (build gun replacement pending)"), *CustomHologram->GetName());
 	return CustomHologram;
 }
 
@@ -6020,46 +6014,46 @@ ASFFactoryHologram* USFSubsystem::CreateCustomFactoryHologram(AFGHologram* Origi
 		UE_LOG(LogSmartFoundations, Error, TEXT("CreateCustomFactoryHologram: Invalid original hologram"));
 		return nullptr;
 	}
-	
+
 	UWorld* World = OriginalHologram->GetWorld();
 	if (!World)
 	{
 		UE_LOG(LogSmartFoundations, Error, TEXT("CreateCustomFactoryHologram: No world context"));
 		return nullptr;
 	}
-	
+
 	FActorSpawnParameters SpawnParams;
 	SpawnParams.Owner = OriginalHologram->GetOwner();
 	SpawnParams.Instigator = OriginalHologram->GetInstigator();
 	SpawnParams.bDeferConstruction = true;  // CRITICAL: Defer construction to set build class first
-	
+
 	ASFFactoryHologram* CustomHologram = World->SpawnActor<ASFFactoryHologram>(ASFFactoryHologram::StaticClass(), SpawnParams);
 	if (!CustomHologram)
 	{
 		UE_LOG(LogSmartFoundations, Error, TEXT("CreateCustomFactoryHologram: Failed to spawn custom hologram"));
 		return nullptr;
 	}
-	
+
 	// CRITICAL: Set build class BEFORE finishing construction to prevent assertion failure
 	if (OriginalHologram->GetBuildClass())
 	{
 		CustomHologram->SetBuildClass(OriginalHologram->GetBuildClass());
 	}
-	
+
 	// Now finish construction which will trigger BeginPlay() with proper build class set
 	CustomHologram->FinishSpawning(CustomHologram->GetActorTransform(), true);
-	
+
 	CopyHologramProperties(OriginalHologram, CustomHologram);
-	
+
 	// CRITICAL: Force material state to OK to ensure child holograms are placeable
 	// This bypasses validation that would otherwise set them to ERROR
 	CustomHologram->SetPlacementMaterialState(EHologramMaterialState::HMS_OK);
-	
+
 	// Log the forced state for debugging
-	UE_LOG(LogSmartFoundations, Log, TEXT("CreateCustomFactoryHologram: Forced material state to HMS_OK for %s"), 
+	UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("CreateCustomFactoryHologram: Forced material state to HMS_OK for %s"),
 		*CustomHologram->GetName());
-	
-	UE_LOG(LogSmartFoundations, Log, TEXT("CreateCustomFactoryHologram: Successfully created %s (build gun replacement pending)"), *CustomHologram->GetName());
+
+	UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("CreateCustomFactoryHologram: Successfully created %s (build gun replacement pending)"), *CustomHologram->GetName());
 	return CustomHologram;
 }
 
@@ -6070,46 +6064,46 @@ ASFLogisticsHologram* USFSubsystem::CreateCustomLogisticsHologram(AFGHologram* O
 		UE_LOG(LogSmartFoundations, Error, TEXT("CreateCustomLogisticsHologram: Invalid original hologram"));
 		return nullptr;
 	}
-	
+
 	UWorld* World = OriginalHologram->GetWorld();
 	if (!World)
 	{
 		UE_LOG(LogSmartFoundations, Error, TEXT("CreateCustomLogisticsHologram: No world context"));
 		return nullptr;
 	}
-	
+
 	FActorSpawnParameters SpawnParams;
 	SpawnParams.Owner = OriginalHologram->GetOwner();
 	SpawnParams.Instigator = OriginalHologram->GetInstigator();
 	SpawnParams.bDeferConstruction = true;  // CRITICAL: Defer construction to set build class first
-	
+
 	ASFLogisticsHologram* CustomHologram = World->SpawnActor<ASFLogisticsHologram>(ASFLogisticsHologram::StaticClass(), SpawnParams);
 	if (!CustomHologram)
 	{
 		UE_LOG(LogSmartFoundations, Error, TEXT("CreateCustomLogisticsHologram: Failed to spawn custom hologram"));
 		return nullptr;
 	}
-	
+
 	// CRITICAL: Set build class BEFORE finishing construction to prevent assertion failure
 	if (OriginalHologram->GetBuildClass())
 	{
 		CustomHologram->SetBuildClass(OriginalHologram->GetBuildClass());
 	}
-	
+
 	// Now finish construction which will trigger BeginPlay() with proper build class set
 	CustomHologram->FinishSpawning(CustomHologram->GetActorTransform(), true);
-	
+
 	CopyHologramProperties(OriginalHologram, CustomHologram);
-	
+
 	// CRITICAL: Force material state to OK to ensure child holograms are placeable
 	// This bypasses validation that would otherwise set them to ERROR
 	CustomHologram->SetPlacementMaterialState(EHologramMaterialState::HMS_OK);
-	
+
 	// Log the forced state for debugging
-	UE_LOG(LogSmartFoundations, Log, TEXT("CreateCustomLogisticsHologram: Forced material state to HMS_OK for %s"), 
+	UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("CreateCustomLogisticsHologram: Forced material state to HMS_OK for %s"),
 		*CustomHologram->GetName());
-	
-	UE_LOG(LogSmartFoundations, Log, TEXT("CreateCustomLogisticsHologram: Successfully created %s (build gun replacement pending)"), *CustomHologram->GetName());
+
+	UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("CreateCustomLogisticsHologram: Successfully created %s (build gun replacement pending)"), *CustomHologram->GetName());
 	return CustomHologram;
 }
 
@@ -6120,28 +6114,28 @@ void USFSubsystem::CopyHologramProperties(AFGHologram* Source, AFGHologram* Dest
 		UE_LOG(LogSmartFoundations, Error, TEXT("CopyHologramProperties: Invalid source or destination"));
 		return;
 	}
-	
-	UE_LOG(LogSmartFoundations, Verbose, TEXT("CopyHologramProperties: Copying from %s to %s"), 
+
+	UE_LOG(LogSmartFoundations, Verbose, TEXT("CopyHologramProperties: Copying from %s to %s"),
 		*Source->GetName(), *Destination->GetName());
-	
+
 	// Copy essential hologram properties
 	Destination->SetActorLocationAndRotation(Source->GetActorLocation(), Source->GetActorRotation());
-	
+
 	// Note: Build class is already set in the creation function BEFORE BeginPlay() to prevent assertion failure
-	
+
 	// Copy recipe if available
 	if (Source->GetRecipe())
 	{
 		Destination->SetRecipe(Source->GetRecipe());
 	}
-	
+
 	// NOTE: Parent hologram reference and scroll mode cannot be directly copied
 	// These properties are managed by the hologram system internally
 	// The parent-child relationship must be established by replacing the child in the parent's children array
-	
+
 	// Copy basic hologram state (simplified for Phase 4 MVP)
 	// Note: Advanced property copying will be added in later iteration
-	
+
 	UE_LOG(LogSmartFoundations, Verbose, TEXT("CopyHologramProperties: Successfully copied basic properties (location, rotation, build class, recipe, parent)"));
 }
 
@@ -6149,15 +6143,15 @@ bool USFSubsystem::ReplaceHologramInBuildGun(AFGHologram* OriginalHologram, AFGH
 {
 	// Phase 4 MVP: Simplified implementation that always succeeds
 	// Full build gun replacement will be implemented in later iteration
-	
+
 	if (!OriginalHologram || !CustomHologram)
 	{
 		UE_LOG(LogSmartFoundations, Error, TEXT("ReplaceHologramInBuildGun: Invalid holograms"));
 		return false;
 	}
-	
-	UE_LOG(LogSmartFoundations, Log, TEXT("ReplaceHologramInBuildGun: MVP implementation - hologram replacement pending"));
-	
+
+	UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("ReplaceHologramInBuildGun: MVP implementation - hologram replacement pending"));
+
 	// For MVP, we just return true to indicate success
 	// The actual replacement logic will be added later
 	return true;
@@ -6174,20 +6168,20 @@ UClass* USFSubsystem::GetBeltClassForTier(int32 Tier, AFGPlayerController* Playe
 		UE_LOG(LogSmartFoundations, Warning, TEXT("GetBeltClassForTier: Invalid tier %d (must be 1-6)"), Tier);
 		return nullptr;
 	}
-	
+
 	// Build belt class path
 	FString BeltPath = FString::Printf(
 		TEXT("/Game/FactoryGame/Buildable/Factory/ConveyorBeltMk%d/Build_ConveyorBeltMk%d.Build_ConveyorBeltMk%d_C"),
 		Tier, Tier, Tier);
-	
+
 	UClass* BeltClass = LoadObject<UClass>(nullptr, *BeltPath);
-	
+
 	if (!BeltClass)
 	{
 		UE_LOG(LogSmartFoundations, Warning, TEXT("GetBeltClassForTier: Failed to load belt class for tier %d"), Tier);
 		return nullptr;
 	}
-	
+
 	// Check if player has unlocked this belt tier
 	if (PlayerController)
 	{
@@ -6201,13 +6195,13 @@ UClass* USFSubsystem::GetBeltClassForTier(int32 Tier, AFGPlayerController* Playe
 				TSubclassOf<AFGBuildable> BeltBuildableClass = BeltClass;
 				if (!RecipeManager->IsBuildingAvailable(BeltBuildableClass))
 				{
-					UE_LOG(LogSmartFoundations, Log, TEXT("GetBeltClassForTier: Belt tier Mk%d not unlocked yet"), Tier);
+					UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("GetBeltClassForTier: Belt tier Mk%d not unlocked yet"), Tier);
 					return nullptr;  // Belt tier not unlocked - prevents cheating
 				}
 			}
 		}
 	}
-	
+
 	return BeltClass;
 }
 
@@ -6218,40 +6212,40 @@ int32 USFSubsystem::GetHighestUnlockedBeltTier(AFGPlayerController* PlayerContro
 		UE_LOG(LogSmartFoundations, Warning, TEXT("GetHighestUnlockedBeltTier: No player controller, defaulting to Mk1"));
 		return 1;  // Default to Mk1 if no player context
 	}
-	
+
 	UWorld* World = PlayerController->GetWorld();
 	if (!World)
 	{
 		UE_LOG(LogSmartFoundations, Warning, TEXT("GetHighestUnlockedBeltTier: No world context, defaulting to Mk1"));
 		return 1;
 	}
-	
+
 	AFGRecipeManager* RecipeManager = AFGRecipeManager::Get(World);
 	if (!RecipeManager)
 	{
 		UE_LOG(LogSmartFoundations, Warning, TEXT("GetHighestUnlockedBeltTier: No recipe manager, defaulting to Mk1"));
 		return 1;
 	}
-	
+
 	// Check belt tiers from highest (Mk6) to lowest (Mk1) to find highest unlocked
 	for (int32 Tier = 6; Tier >= 1; Tier--)
 	{
 		FString BeltPath = FString::Printf(
 			TEXT("/Game/FactoryGame/Buildable/Factory/ConveyorBeltMk%d/Build_ConveyorBeltMk%d.Build_ConveyorBeltMk%d_C"),
 			Tier, Tier, Tier);
-		
+
 		UClass* BeltClass = LoadObject<UClass>(nullptr, *BeltPath);
 		if (BeltClass)
 		{
 			TSubclassOf<AFGBuildable> BeltBuildableClass = BeltClass;
 			if (RecipeManager->IsBuildingAvailable(BeltBuildableClass))
 			{
-				UE_LOG(LogSmartFoundations, Log, TEXT("GetHighestUnlockedBeltTier: Highest unlocked tier is Mk%d"), Tier);
+				UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("GetHighestUnlockedBeltTier: Highest unlocked tier is Mk%d"), Tier);
 				return Tier;  // Found highest unlocked tier
 			}
 		}
 	}
-	
+
 	// Fallback: If nothing is unlocked (shouldn't happen), return Mk1
 	UE_LOG(LogSmartFoundations, Warning, TEXT("GetHighestUnlockedBeltTier: No belts unlocked, defaulting to Mk1"));
 	return 1;
@@ -6263,26 +6257,26 @@ int32 USFSubsystem::GetHighestUnlockedPowerPoleTier(AFGPlayerController* PlayerC
 	{
 		return 1;
 	}
-	
+
 	UWorld* World = PlayerController->GetWorld();
 	if (!World)
 	{
 		return 1;
 	}
-	
+
 	AFGRecipeManager* RecipeManager = AFGRecipeManager::Get(World);
 	if (!RecipeManager)
 	{
 		return 1;
 	}
-	
+
 	// Power pole paths: Mk1, Mk2, Mk3
 	static const TCHAR* PowerPolePaths[] = {
 		TEXT("/Game/FactoryGame/Buildable/Factory/PowerPoleMk1/Build_PowerPoleMk1.Build_PowerPoleMk1_C"),
 		TEXT("/Game/FactoryGame/Buildable/Factory/PowerPoleMk2/Build_PowerPoleMk2.Build_PowerPoleMk2_C"),
 		TEXT("/Game/FactoryGame/Buildable/Factory/PowerPoleMk3/Build_PowerPoleMk3.Build_PowerPoleMk3_C"),
 	};
-	
+
 	// Check from highest (Mk3) to lowest (Mk1)
 	for (int32 Tier = 3; Tier >= 1; Tier--)
 	{
@@ -6296,7 +6290,7 @@ int32 USFSubsystem::GetHighestUnlockedPowerPoleTier(AFGPlayerController* PlayerC
 			}
 		}
 	}
-	
+
 	return 1;
 }
 
@@ -6306,19 +6300,19 @@ int32 USFSubsystem::GetHighestUnlockedWallOutletTier(AFGPlayerController* Player
 	{
 		return 1;
 	}
-	
+
 	UWorld* World = PlayerController->GetWorld();
 	if (!World)
 	{
 		return 1;
 	}
-	
+
 	AFGRecipeManager* RecipeManager = AFGRecipeManager::Get(World);
 	if (!RecipeManager)
 	{
 		return 1;
 	}
-	
+
 	// Wall outlet paths: Mk1, Mk2, Mk3. Single and double are independent asset families and
 	// unlock separately via game progression (Issue #267), so probe whichever family the caller
 	// asked for — mixing them under-reports availability for the unchecked family.
@@ -6335,7 +6329,7 @@ int32 USFSubsystem::GetHighestUnlockedWallOutletTier(AFGPlayerController* Player
 		TEXT("/Game/FactoryGame/Buildable/Factory/PowerPoleWallDouble/Build_PowerPoleWallDouble_Mk3.Build_PowerPoleWallDouble_Mk3_C"),
 	};
 	const TCHAR* const * Paths = bDouble ? WallOutletDoublePaths : WallOutletSinglePaths;
-	
+
 	// Check from highest (Mk3) to lowest (Mk1)
 	for (int32 Tier = 3; Tier >= 1; Tier--)
 	{
@@ -6349,14 +6343,14 @@ int32 USFSubsystem::GetHighestUnlockedWallOutletTier(AFGPlayerController* Player
 			}
 		}
 	}
-	
+
 	return 1;
 }
 
 UClass* USFSubsystem::GetBeltClassFromConfig(int32 ConfigTier, AFGPlayerController* PlayerController)
 {
 	int32 ActualTier = ConfigTier;
-	
+
 	// Handle "Auto" mode (0 = use highest unlocked)
 	if (ConfigTier == 0)
 	{
@@ -6367,15 +6361,15 @@ UClass* USFSubsystem::GetBeltClassFromConfig(int32 ConfigTier, AFGPlayerControll
 	{
 		UE_LOG(LogSmartFoundations, Verbose, TEXT("GetBeltClassFromConfig: Using configured tier Mk%d"), ActualTier);
 	}
-	
+
 	// Get belt class for the determined tier
 	UClass* BeltClass = GetBeltClassForTier(ActualTier, PlayerController);
-	
+
 	if (!BeltClass)
 	{
 		UE_LOG(LogSmartFoundations, Warning, TEXT("GetBeltClassFromConfig: Belt tier Mk%d unavailable or not unlocked - belt category disabled"), ActualTier);
 	}
-	
+
 	return BeltClass;
 }
 
@@ -6386,7 +6380,7 @@ bool USFSubsystem::ChargePlayerForBelt(UClass* BeltClass, AFGPlayerController* P
 		UE_LOG(LogSmartFoundations, Warning, TEXT("ChargePlayerForBelt: Invalid belt class or player controller"));
 		return false;
 	}
-	
+
 	// Get the building descriptor for this belt class
 	UWorld* World = PlayerController->GetWorld();
 	if (!World)
@@ -6394,61 +6388,61 @@ bool USFSubsystem::ChargePlayerForBelt(UClass* BeltClass, AFGPlayerController* P
 		UE_LOG(LogSmartFoundations, Warning, TEXT("ChargePlayerForBelt: No world context"));
 		return false;
 	}
-	
+
 	// Check if "No Build Cost" cheat is enabled - skip deduction but still build
 	// ONLY check GetCheatNoCost() - do NOT treat Creative Mode as free building
 	AFGGameState* GameState = World->GetGameState<AFGGameState>();
 	if (GameState && GameState->GetCheatNoCost())
 	{
-		UE_LOG(LogSmartFoundations, Log, TEXT("ChargePlayerForBelt: No Build Cost cheat enabled - skipping deduction"));
+		UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("ChargePlayerForBelt: No Build Cost cheat enabled - skipping deduction"));
 		return true;  // Allow build without charging
 	}
-	
+
 	AFGRecipeManager* RecipeManager = AFGRecipeManager::Get(World);
 	if (!RecipeManager)
 	{
 		UE_LOG(LogSmartFoundations, Warning, TEXT("ChargePlayerForBelt: No recipe manager"));
 		return false;
 	}
-	
+
 	// Find the building descriptor for this belt class
 	TSubclassOf<AFGBuildable> BeltBuildableClass = BeltClass;
 	TSubclassOf<UFGBuildingDescriptor> Descriptor = RecipeManager->FindBuildingDescriptorByClass(BeltBuildableClass);
-	
+
 	if (!Descriptor)
 	{
 		UE_LOG(LogSmartFoundations, Warning, TEXT("ChargePlayerForBelt: Could not find building descriptor for %s"), *BeltClass->GetName());
 		return false;
 	}
-	
+
 	// Get the recipe from the descriptor (recipes contain the build cost)
 	TArray<TSubclassOf<UFGRecipe>> Recipes = RecipeManager->FindRecipesByProduct(Descriptor, /*onlyAvailableRecipes*/ false, /*availableFirst*/ true);
-	
+
 	if (Recipes.Num() == 0)
 	{
 		UE_LOG(LogSmartFoundations, Warning, TEXT("ChargePlayerForBelt: No recipes found for descriptor %s"), *Descriptor->GetName());
 		return false;
 	}
-	
+
 	// Use the first recipe (there should only be one for buildings)
 	TSubclassOf<UFGRecipe> Recipe = Recipes[0];
 	const UFGRecipe* RecipeCDO = Recipe->GetDefaultObject<UFGRecipe>();
-	
+
 	if (!RecipeCDO)
 	{
 		UE_LOG(LogSmartFoundations, Warning, TEXT("ChargePlayerForBelt: Could not get recipe CDO"));
 		return false;
 	}
-	
+
 	// Get the BASE build cost per meter (ingredients are for 1 meter)
 	const TArray<FItemAmount>& BaseCost = RecipeCDO->GetIngredients();
-	
+
 	// Calculate actual cost based on belt length
 	// Belt cost in Satisfactory is 0.5 materials per meter (per wiki)
 	// Recipe ingredients represent cost for 2 meters of belt
 	// (100cm = 1m in UE units)
 	float LengthInMeters = BeltLengthCm / 100.0f;
-	
+
 	// Calculate scaled cost for this belt length
 	TArray<FItemAmount> ActualCost;
 	for (const FItemAmount& Cost : BaseCost)
@@ -6459,10 +6453,10 @@ bool USFSubsystem::ChargePlayerForBelt(UClass* BeltClass, AFGPlayerController* P
 		ScaledCost.Amount = FMath::CeilToInt(Cost.Amount * LengthInMeters * 0.5f);
 		ActualCost.Add(ScaledCost);
 	}
-	
+
 	// Get central storage subsystem (dimensional storage)
 	AFGCentralStorageSubsystem* CentralStorage = AFGCentralStorageSubsystem::Get(World);
-	
+
 	// Get player's inventory
 	AFGCharacterPlayer* Player = Cast<AFGCharacterPlayer>(PlayerController->GetPawn());
 	if (!Player)
@@ -6470,14 +6464,14 @@ bool USFSubsystem::ChargePlayerForBelt(UClass* BeltClass, AFGPlayerController* P
 		UE_LOG(LogSmartFoundations, Warning, TEXT("ChargePlayerForBelt: Player pawn not found"));
 		return false;
 	}
-	
+
 	UFGInventoryComponent* Inventory = Player->GetInventory();
 	if (!Inventory)
 	{
 		UE_LOG(LogSmartFoundations, Warning, TEXT("ChargePlayerForBelt: Player inventory not found"));
 		return false;
 	}
-	
+
 	// Check if player has enough materials (central storage + personal inventory)
 	// Match vanilla behavior: check dimensional storage first, then personal inventory
 	for (const FItemAmount& Cost : ActualCost)
@@ -6485,35 +6479,35 @@ bool USFSubsystem::ChargePlayerForBelt(UClass* BeltClass, AFGPlayerController* P
 		int32 InCentralStorage = CentralStorage ? CentralStorage->GetNumItemsFromCentralStorage(Cost.ItemClass) : 0;
 		int32 InPersonalInventory = Inventory->GetNumItems(Cost.ItemClass);
 		int32 TotalAvailable = InCentralStorage + InPersonalInventory;
-		
+
 		if (TotalAvailable < Cost.Amount)
 		{
-			UE_LOG(LogSmartFoundations, Log, TEXT("ChargePlayerForBelt: Player cannot afford %.1fm belt - missing %d %s (have %d in central + %d in inventory = %d total)"),
+			UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("ChargePlayerForBelt: Player cannot afford %.1fm belt - missing %d %s (have %d in central + %d in inventory = %d total)"),
 				LengthInMeters, Cost.Amount - TotalAvailable, *UFGItemDescriptor::GetItemName(Cost.ItemClass).ToString(),
 				InCentralStorage, InPersonalInventory, TotalAvailable);
 			return false;  // Can't afford
 		}
 	}
-	
+
 	// Remove materials (central storage first, then personal inventory)
 	// This matches vanilla building behavior
 	for (const FItemAmount& Cost : ActualCost)
 	{
 		int32 Remaining = Cost.Amount;
-		
+
 		// Try central storage first
 		if (CentralStorage && Remaining > 0)
 		{
 			int32 RemovedFromCentral = CentralStorage->TryRemoveItemsFromCentralStorage(Cost.ItemClass, Remaining);
 			Remaining -= RemovedFromCentral;
-			
+
 			if (RemovedFromCentral > 0)
 			{
 				UE_LOG(LogSmartFoundations, Verbose, TEXT("ChargePlayerForBelt: Removed %d %s from central storage"),
 					RemovedFromCentral, *UFGItemDescriptor::GetItemName(Cost.ItemClass).ToString());
 			}
 		}
-		
+
 		// Remove remainder from personal inventory
 		if (Remaining > 0)
 		{
@@ -6522,8 +6516,8 @@ bool USFSubsystem::ChargePlayerForBelt(UClass* BeltClass, AFGPlayerController* P
 				Remaining, *UFGItemDescriptor::GetItemName(Cost.ItemClass).ToString());
 		}
 	}
-	
-	UE_LOG(LogSmartFoundations, Verbose, TEXT("ChargePlayerForBelt: Successfully charged player for %.1fm %s belt"), 
+
+	UE_LOG(LogSmartFoundations, Verbose, TEXT("ChargePlayerForBelt: Successfully charged player for %.1fm %s belt"),
 		LengthInMeters, *BeltClass->GetName());
 	return true;
 }
@@ -6535,7 +6529,7 @@ bool USFSubsystem::ChargePlayerForPipe(UClass* PipeClass, AFGPlayerController* P
 		UE_LOG(LogSmartFoundations, Warning, TEXT("ChargePlayerForPipe: Invalid pipe class or player controller"));
 		return false;
 	}
-	
+
 	// Get the building descriptor for this pipe class
 	UWorld* World = PlayerController->GetWorld();
 	if (!World)
@@ -6543,61 +6537,61 @@ bool USFSubsystem::ChargePlayerForPipe(UClass* PipeClass, AFGPlayerController* P
 		UE_LOG(LogSmartFoundations, Warning, TEXT("ChargePlayerForPipe: No world context"));
 		return false;
 	}
-	
+
 	// Check if "No Build Cost" cheat is enabled - skip deduction but still build
 	// ONLY check GetCheatNoCost() - do NOT treat Creative Mode as free building
 	AFGGameState* GameState = World->GetGameState<AFGGameState>();
 	if (GameState && GameState->GetCheatNoCost())
 	{
-		UE_LOG(LogSmartFoundations, Log, TEXT("ChargePlayerForPipe: No Build Cost cheat enabled - skipping deduction"));
+		UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("ChargePlayerForPipe: No Build Cost cheat enabled - skipping deduction"));
 		return true;  // Allow build without charging
 	}
-	
+
 	AFGRecipeManager* RecipeManager = AFGRecipeManager::Get(World);
 	if (!RecipeManager)
 	{
 		UE_LOG(LogSmartFoundations, Warning, TEXT("ChargePlayerForPipe: No recipe manager"));
 		return false;
 	}
-	
+
 	// Find the building descriptor for this pipe class
 	TSubclassOf<AFGBuildable> PipeBuildableClass = PipeClass;
 	TSubclassOf<UFGBuildingDescriptor> Descriptor = RecipeManager->FindBuildingDescriptorByClass(PipeBuildableClass);
-	
+
 	if (!Descriptor)
 	{
 		UE_LOG(LogSmartFoundations, Warning, TEXT("ChargePlayerForPipe: Could not find building descriptor for %s"), *PipeClass->GetName());
 		return false;
 	}
-	
+
 	// Get the recipe from the descriptor (recipes contain the build cost)
 	TArray<TSubclassOf<UFGRecipe>> Recipes = RecipeManager->FindRecipesByProduct(Descriptor, /*onlyAvailableRecipes*/ false, /*availableFirst*/ true);
-	
+
 	if (Recipes.Num() == 0)
 	{
 		UE_LOG(LogSmartFoundations, Warning, TEXT("ChargePlayerForPipe: No recipes found for descriptor %s"), *Descriptor->GetName());
 		return false;
 	}
-	
+
 	// Use the first recipe (there should only be one for buildings)
 	TSubclassOf<UFGRecipe> Recipe = Recipes[0];
 	const UFGRecipe* RecipeCDO = Recipe->GetDefaultObject<UFGRecipe>();
-	
+
 	if (!RecipeCDO)
 	{
 		UE_LOG(LogSmartFoundations, Warning, TEXT("ChargePlayerForPipe: Could not get recipe CDO"));
 		return false;
 	}
-	
+
 	// Get the BASE build cost per segment (ingredients are for 4m segment)
 	const TArray<FItemAmount>& BaseCost = RecipeCDO->GetIngredients();
-	
+
 	// Calculate actual cost based on pipe length
 	// Pipes are charged per 4m segment (rounded up):
 	// 0-3.99m = 1 segment, 4.00-7.99m = 2 segments, etc.
 	float LengthInMeters = PipeLengthCm / 100.0f;
 	int32 Segments = FMath::CeilToInt(LengthInMeters / 4.0f);
-	
+
 	// Calculate scaled cost for this pipe length
 	TArray<FItemAmount> ActualCost;
 	for (const FItemAmount& Cost : BaseCost)
@@ -6606,10 +6600,10 @@ bool USFSubsystem::ChargePlayerForPipe(UClass* PipeClass, AFGPlayerController* P
 		ScaledCost.Amount = Cost.Amount * Segments;
 		ActualCost.Add(ScaledCost);
 	}
-	
+
 	// Get central storage subsystem (dimensional storage)
 	AFGCentralStorageSubsystem* CentralStorage = AFGCentralStorageSubsystem::Get(World);
-	
+
 	// Get player's inventory
 	AFGCharacterPlayer* Player = Cast<AFGCharacterPlayer>(PlayerController->GetPawn());
 	if (!Player)
@@ -6617,14 +6611,14 @@ bool USFSubsystem::ChargePlayerForPipe(UClass* PipeClass, AFGPlayerController* P
 		UE_LOG(LogSmartFoundations, Warning, TEXT("ChargePlayerForPipe: Player pawn not found"));
 		return false;
 	}
-	
+
 	UFGInventoryComponent* Inventory = Player->GetInventory();
 	if (!Inventory)
 	{
 		UE_LOG(LogSmartFoundations, Warning, TEXT("ChargePlayerForPipe: Player inventory not found"));
 		return false;
 	}
-	
+
 	// Check if player has enough materials (central storage + personal inventory)
 	// Match vanilla behavior: check dimensional storage first, then personal inventory
 	for (const FItemAmount& Cost : ActualCost)
@@ -6632,35 +6626,35 @@ bool USFSubsystem::ChargePlayerForPipe(UClass* PipeClass, AFGPlayerController* P
 		int32 InCentralStorage = CentralStorage ? CentralStorage->GetNumItemsFromCentralStorage(Cost.ItemClass) : 0;
 		int32 InPersonalInventory = Inventory->GetNumItems(Cost.ItemClass);
 		int32 TotalAvailable = InCentralStorage + InPersonalInventory;
-		
+
 		if (TotalAvailable < Cost.Amount)
 		{
-			UE_LOG(LogSmartFoundations, Log, TEXT("ChargePlayerForPipe: Player cannot afford %.1fm pipe - missing %d %s (have %d in central + %d in inventory = %d total)"),
+			UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("ChargePlayerForPipe: Player cannot afford %.1fm pipe - missing %d %s (have %d in central + %d in inventory = %d total)"),
 				LengthInMeters, Cost.Amount - TotalAvailable, *UFGItemDescriptor::GetItemName(Cost.ItemClass).ToString(),
 				InCentralStorage, InPersonalInventory, TotalAvailable);
 			return false;  // Can't afford
 		}
 	}
-	
+
 	// Remove materials (central storage first, then personal inventory)
 	// This matches vanilla building behavior
 	for (const FItemAmount& Cost : ActualCost)
 	{
 		int32 Remaining = Cost.Amount;
-		
+
 		// Try central storage first
 		if (CentralStorage && Remaining > 0)
 		{
 			int32 RemovedFromCentral = CentralStorage->TryRemoveItemsFromCentralStorage(Cost.ItemClass, Remaining);
 			Remaining -= RemovedFromCentral;
-			
+
 			if (RemovedFromCentral > 0)
 			{
 				UE_LOG(LogSmartFoundations, Verbose, TEXT("ChargePlayerForPipe: Removed %d %s from central storage"),
 					RemovedFromCentral, *UFGItemDescriptor::GetItemName(Cost.ItemClass).ToString());
 			}
 		}
-		
+
 		// Remove remainder from personal inventory
 		if (Remaining > 0)
 		{
@@ -6669,8 +6663,8 @@ bool USFSubsystem::ChargePlayerForPipe(UClass* PipeClass, AFGPlayerController* P
 				Remaining, *UFGItemDescriptor::GetItemName(Cost.ItemClass).ToString());
 		}
 	}
-	
-	UE_LOG(LogSmartFoundations, Verbose, TEXT("ChargePlayerForPipe: Successfully charged player for %.1fm %s pipe"), 
+
+	UE_LOG(LogSmartFoundations, Verbose, TEXT("ChargePlayerForPipe: Successfully charged player for %.1fm %s pipe"),
 		LengthInMeters, *PipeClass->GetName());
 	return true;
 }
@@ -6701,16 +6695,16 @@ void USFSubsystem::OnActorSpawned(AActor* SpawnedActor)
 			if ((bIsMultiGrid || bIsExtendActive) && !Buildable->GetBlueprintProxy())
 			{
 				// DIAGNOSTIC: Log what type of building is spawning
-				UE_LOG(LogSmartFoundations, Log, TEXT(" SMART DISMANTLE: Building spawned: %s (class: %s)"),
+				UE_LOG(LogSmartFoundations, VeryVerbose, TEXT(" SMART DISMANTLE: Building spawned: %s (class: %s)"),
 					*Buildable->GetName(), *Buildable->GetClass()->GetName());
 
 				// CRITICAL: Detect if this is a NEW build session (different hologram)
 				// If the hologram changed, we're starting a fresh grid placement
 				const bool bNewBuildSession = !CurrentProxyOwner.IsValid() || CurrentProxyOwner.Get() != ActiveHologram.Get();
-				
+
 				if (bNewBuildSession && CurrentBuildProxy.IsValid())
 				{
-					UE_LOG(LogSmartFoundations, Log, TEXT(" SMART DISMANTLE: New build session detected - clearing previous proxy %s"),
+					UE_LOG(LogSmartFoundations, VeryVerbose, TEXT(" SMART DISMANTLE: New build session detected - clearing previous proxy %s"),
 						*CurrentBuildProxy->GetName());
 					CurrentBuildProxy.Reset();
 					CurrentProxyOwner.Reset();
@@ -6735,7 +6729,7 @@ void USFSubsystem::OnActorSpawned(AActor* SpawnedActor)
 						{
 							CurrentBuildProxy = NewProxy;
 							CurrentProxyOwner = ActiveHologram.Get();
-							
+
 							// CRITICAL FIX (Issue #264): Clear the blueprint proxy flag that was set
 							// by the nested OnActorSpawned during SpawnActor above. Smart-created
 							// proxies (for grid grouping) must NOT block recipe application.
@@ -6744,8 +6738,8 @@ void USFSubsystem::OnActorSpawned(AActor* SpawnedActor)
 							{
 								RecipeManagementService->ClearBlueprintProxyFlag();
 							}
-							
-							UE_LOG(LogSmartFoundations, Log, TEXT(" SMART DISMANTLE: Created BlueprintProxy %s for grid %dx%dx%d (first building: %s)"),
+
+							UE_LOG(LogSmartFoundations, VeryVerbose, TEXT(" SMART DISMANTLE: Created BlueprintProxy %s for grid %dx%dx%d (first building: %s)"),
 								*NewProxy->GetName(), Grid.X, Grid.Y, Grid.Z, *Buildable->GetClass()->GetName());
 						}
 					}
@@ -6756,7 +6750,7 @@ void USFSubsystem::OnActorSpawned(AActor* SpawnedActor)
 				{
 					Buildable->SetBlueprintProxy(CurrentBuildProxy.Get());
 					CurrentBuildProxy->RegisterBuildable(Buildable);
-					UE_LOG(LogSmartFoundations, Log, TEXT(" SMART DISMANTLE: Registered %s (%s) with proxy %s (total: %d buildings)"),
+					UE_LOG(LogSmartFoundations, VeryVerbose, TEXT(" SMART DISMANTLE: Registered %s (%s) with proxy %s (total: %d buildings)"),
 						*Buildable->GetName(), *Buildable->GetClass()->GetName(), *CurrentBuildProxy->GetName(), CurrentBuildProxy->GetBuildables().Num());
 				}
 			}
@@ -6768,38 +6762,46 @@ void USFSubsystem::OnActorSpawned(AActor* SpawnedActor)
 	{
 		if (AFGBuildableFactory* Factory = Cast<AFGBuildableFactory>(SpawnedActor))
 		{
-			UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("🔧 EXTEND: Factory %s spawned - deferring connection wiring to next tick"), *Factory->GetName());
-				
-			// Capture weak reference to factory and service
-			TWeakObjectPtr<AFGBuildableFactory> WeakFactory = Factory;
-			TWeakObjectPtr<USFExtendService> WeakExtendService = ExtendService;
-				
-			GetWorld()->GetTimerManager().SetTimerForNextTick([WeakFactory, WeakExtendService]()
+			if (ExtendService && ExtendService->HasPendingPostBuildWiring())
 			{
-				if (WeakFactory.IsValid() && WeakExtendService.IsValid())
+				UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("🔧 EXTEND: Factory %s spawned - deferring connection wiring to next tick"), *Factory->GetName());
+
+				// Capture weak reference to factory and service
+				TWeakObjectPtr<AFGBuildableFactory> WeakFactory = Factory;
+				TWeakObjectPtr<USFExtendService> WeakExtendService = ExtendService;
+
+				GetWorld()->GetTimerManager().SetTimerForNextTick([WeakFactory, WeakExtendService]()
 				{
-					UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("🔧 EXTEND: Deferred connection wiring executing for %s"), *WeakFactory->GetName());
-					// NOTE: Child holograms (belts, lifts, pipes) are built by vanilla via AddChild
-					// We just need to wire their connections here
-					
-					// Connect chain elements (for any that need inter-chain connections)
-					WeakExtendService->ConnectAllChainElements(WeakFactory.Get());
-					
-					// Wire connections for child holograms that were built via AddChild
-					// This uses the hologram→buildable mapping from USFHologramDataRegistry
-					WeakExtendService->WireBuiltChildConnections(WeakFactory.Get());
-					
-					// DIAGNOSTIC: Capture post-build snapshot and log diff
-					WeakExtendService->CapturePostBuildSnapshotAndLogDiff();
-				}
-				else
-				{
-					UE_LOG(LogSmartFoundations, Warning, TEXT("🔧 EXTEND: Deferred connection wiring cancelled - factory or service no longer valid"));
-				}
-			});
+					if (WeakFactory.IsValid() && WeakExtendService.IsValid())
+					{
+						if (!WeakExtendService->HasPendingPostBuildWiring())
+						{
+							return;
+						}
+
+						UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("🔧 EXTEND: Deferred connection wiring executing for %s"), *WeakFactory->GetName());
+						// NOTE: Child holograms (belts, lifts, pipes) are built by vanilla via AddChild
+						// We just need to wire their connections here
+
+						// Connect chain elements (for any that need inter-chain connections)
+						WeakExtendService->ConnectAllChainElements(WeakFactory.Get());
+
+						// Wire connections for child holograms that were built via AddChild
+						// This uses the hologram→buildable mapping from USFHologramDataRegistry
+						WeakExtendService->WireBuiltChildConnections(WeakFactory.Get());
+
+						// DIAGNOSTIC: Capture post-build snapshot and log diff
+						WeakExtendService->CapturePostBuildSnapshotAndLogDiff();
+					}
+					else
+					{
+						UE_LOG(LogSmartFoundations, Warning, TEXT("🔧 EXTEND: Deferred connection wiring cancelled - factory or service no longer valid"));
+					}
+				});
+			}
 		}
 	}
-	
+
 	if (AutoConnectService && ActiveHologram.IsValid())
 	{
 		AFGBuildableConveyorAttachment* Attachment = Cast<AFGBuildableConveyorAttachment>(SpawnedActor);
@@ -6811,15 +6813,15 @@ void USFSubsystem::OnActorSpawned(AActor* SpawnedActor)
 				UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("🎯 AUTO-CONNECT BUILD: Skipping - already processing grid placement"));
 				return;  // Already processing this grid, ignore subsequent spawns
 			}
-			
+
 			if (TArray<TSharedPtr<FBeltPreviewHelper>>* PreviewsPtr = AutoConnectService->GetBeltPreviews(ActiveHologram.Get()))
 			{
 				if (PreviewsPtr->Num() > 0)
 				{
 					bProcessingGridPlacement = true;  // Lock to prevent re-entry
-					
+
 					UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("🎯 AUTO-CONNECT BUILD: Capturing %d preview(s) for deferred belt construction"), PreviewsPtr->Num());
-					
+
 					// CRITICAL: Extract all data from previews NOW before hologram is destroyed
 					struct FBeltBuildData
 					{
@@ -6831,14 +6833,14 @@ void USFSubsystem::OnActorSpawned(AActor* SpawnedActor)
 						AFGHologram* TargetDistributorHologram = nullptr;  // For manifold belts (distributor→distributor)
 						TWeakObjectPtr<UFGFactoryConnectionComponent> OutputConnector;  // For merger building belts (building output)
 					};
-					
+
 					// Collect belt data from ALL distributors in the grid (parent + children)
 					TArray<FBeltBuildData> BeltData;
 					TArray<AFGHologram*> AllDistributorHolograms;  // For belt data collection only
-					
+
 					// Start with parent
 					AllDistributorHolograms.Add(ActiveHologram.Get());
-					
+
 					// Add all children
 					const TArray<AFGHologram*>& Children = ActiveHologram->GetHologramChildren();
 					for (AFGHologram* Child : Children)
@@ -6848,46 +6850,46 @@ void USFSubsystem::OnActorSpawned(AActor* SpawnedActor)
 							AllDistributorHolograms.Add(Child);
 						}
 					}
-					
+
 					UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("🎯 AUTO-CONNECT BUILD: Collecting belt data from %d distributor(s) (parent + children)"), AllDistributorHolograms.Num());
-					
+
 					// Extract belt data from each distributor's previews
 					for (AFGHologram* Distributor : AllDistributorHolograms)
 					{
 						if (TArray<TSharedPtr<FBeltPreviewHelper>>* DistributorPreviews = AutoConnectService->GetBeltPreviews(Distributor))
 						{
 							UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("   📋 Distributor %s has %d preview(s)"), *Distributor->GetName(), DistributorPreviews->Num());
-							
+
 							for (const TSharedPtr<FBeltPreviewHelper>& Preview : *DistributorPreviews)
 							{
 								if (!Preview.IsValid()) continue;
-								
+
 								UFGFactoryConnectionComponent* Conn0 = Preview->GetOutputConnector();  // Get Connection0
 								UFGFactoryConnectionComponent* Conn1 = Preview->GetInputConnector();   // Get Connection1
 								AFGSplineHologram* PreviewHolo = Preview->GetHologram();
-								
+
 								if (!Conn0 || !Conn1 || !PreviewHolo) continue;
-								
+
 								// CRITICAL: For manifolds, connectors are swapped (Connection0=INPUT, Connection1=OUTPUT)
 								// Detect by checking connector TYPES, not positions
 								bool bConn0IsOutput = (Conn0->GetDirection() == EFactoryConnectionDirection::FCD_OUTPUT);
-								
+
 								UFGFactoryConnectionComponent* HoloOutput = bConn0IsOutput ? Conn0 : Conn1;
 								UFGFactoryConnectionComponent* BuildingInput = bConn0IsOutput ? Conn1 : Conn0;
-								
+
 								// Extract spline data from hologram's spline component
 								USplineComponent* SplineComp = PreviewHolo->FindComponentByClass<USplineComponent>();
 								if (!SplineComp) continue;
-								
+
 								FBeltBuildData Data;
 								Data.OutputConnectorName = HoloOutput->GetName();  // Store exact connector name
 								Data.InputConnector = BuildingInput;
 								Data.SourceDistributorHologram = Distributor;  // Track which hologram owns this belt
-								
+
 								// Check if this is a manifold belt (distributor→DIFFERENT distributor)
 								AActor* InputOwner = BuildingInput->GetOwner();
 								AActor* OutputOwner = HoloOutput->GetOwner();
-								
+
 								// Check if input is on a distributor hologram (manifold or merger building belt)
 								if (InputOwner && InputOwner->IsA(AFGHologram::StaticClass()))
 								{
@@ -6901,7 +6903,7 @@ void USFSubsystem::OnActorSpawned(AActor* SpawnedActor)
 											Data.InputConnectorName = BuildingInput->GetName();
 											Data.OutputConnectorName = HoloOutput->GetName();
 											Data.TargetDistributorHologram = TargetHolo;
-											UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("      🔗 MANIFOLD belt: %s → %s (Output=%s, Input=%s)"), 
+											UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("      🔗 MANIFOLD belt: %s → %s (Output=%s, Input=%s)"),
 												*Distributor->GetName(), *TargetHolo->GetName(), *Data.OutputConnectorName, *Data.InputConnectorName);
 										}
 										else
@@ -6910,12 +6912,12 @@ void USFSubsystem::OnActorSpawned(AActor* SpawnedActor)
 											// Store input connector name AND building output connector
 											Data.InputConnectorName = BuildingInput->GetName();
 											Data.OutputConnector = HoloOutput;  // Store building output connector (persists until build)
-											UE_LOG(LogSmartFoundations, Log, TEXT("      🔗 MERGER building belt: Building %s → Merger %s (Input=%s)"), 
+											UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("      🔗 MERGER building belt: Building %s → Merger %s (Input=%s)"),
 												*HoloOutput->GetName(), *Data.InputConnectorName, *Data.InputConnectorName);
 										}
 									}
 								}
-								
+
 								// Extract spline points
 								int32 NumPoints = SplineComp->GetNumberOfSplinePoints();
 								for (int32 i = 0; i < NumPoints; i++)
@@ -6926,31 +6928,31 @@ void USFSubsystem::OnActorSpawned(AActor* SpawnedActor)
 									Point.LeaveTangent = SplineComp->GetLeaveTangentAtSplinePoint(i, ESplineCoordinateSpace::Local);
 									Data.SplineData.Add(Point);
 								}
-								
+
 								BeltData.Add(Data);
 							}
 						}
 					}
-					
+
 					UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("🎯 AUTO-CONNECT BUILD: Extracted data for %d belt(s) from %d distributor(s)"), BeltData.Num(), AllDistributorHolograms.Num());
-					
+
 					// CRITICAL: Only track PARENT distributor spawn!
 					// Children are built as part of grid system but don't individually trigger OnActorSpawned
 					// We'll find child distributors via parent's spawned children when building belts
-					
+
 					// Create persistent tracking structures (static to survive across OnActorSpawned calls)
 					static TWeakObjectPtr<AFGBuildableConveyorAttachment> SpawnedParentDistributor;
 					static AFGHologram* ParentHologram = nullptr;
 					static TArray<AFGHologram*> ChildHolograms;  // CRITICAL: Store child holograms BEFORE they're destroyed
 					static TArray<FBeltBuildData> PendingBeltData;
 					static bool bWaitingForSpawn = false;
-					
+
 					// First distributor spawning - initialize tracking
 					if (!bWaitingForSpawn)
 					{
 						SpawnedParentDistributor.Reset();
 						ParentHologram = ActiveHologram.Get();  // Store parent hologram
-						
+
 						// CRITICAL: Store child holograms NOW before they're destroyed
 						ChildHolograms.Empty();
 						const TArray<AFGHologram*>& CurrentChildren = ActiveHologram->GetHologramChildren();
@@ -6961,27 +6963,27 @@ void USFSubsystem::OnActorSpawned(AActor* SpawnedActor)
 								ChildHolograms.Add(Child);
 							}
 						}
-						
+
 						PendingBeltData = BeltData;
 						bWaitingForSpawn = true;
-						
+
 						UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("🎯 AUTO-CONNECT BUILD: Waiting for parent distributor to spawn (stored %d child holograms)"), ChildHolograms.Num());
 					}
-					
+
 					// Store the parent distributor
 					SpawnedParentDistributor = Attachment;
 					bWaitingForSpawn = false;  // Parent has spawned!
-					
+
 					UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("🎯 AUTO-CONNECT BUILD: Parent distributor spawned! Building %d belt(s)"), PendingBeltData.Num());
-					UE_LOG(LogSmartFoundations, Log, TEXT("🎯 AUTO-CONNECT BUILD: Skipping legacy post-build belt construction (child holograms handle belt builds)"));
-					
+					UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("🎯 AUTO-CONNECT BUILD: Skipping legacy post-build belt construction (child holograms handle belt builds)"));
+
 					bProcessingGridPlacement = false;
 					SpawnedParentDistributor.Reset();
 					ParentHologram = nullptr;
 					ChildHolograms.Empty();
 					PendingBeltData.Empty();
 					return;
-					
+
 					GetWorld()->GetTimerManager().SetTimerForNextTick([this]()
 					{
 						UWorld* World = GetWorld();
@@ -6990,14 +6992,14 @@ void USFSubsystem::OnActorSpawned(AActor* SpawnedActor)
 							UE_LOG(LogSmartFoundations, Warning, TEXT("🎯 AUTO-CONNECT BUILD: No world context"));
 							return;
 						}
-						
+
 						// Use runtime settings (modified with U menu) - these override global config during placement
 						const auto& RuntimeSettings = AutoConnectRuntimeSettings;
-						
+
 						// Check master switch - early exit if auto-connect disabled
 						if (!RuntimeSettings.bEnabled)
 						{
-							UE_LOG(LogSmartFoundations, Log, TEXT("🎯 AUTO-CONNECT BUILD: Skipping - auto-connect disabled in runtime settings"));
+							UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("🎯 AUTO-CONNECT BUILD: Skipping - auto-connect disabled in runtime settings"));
 							bProcessingGridPlacement = false;  // Reset flag
 							SpawnedParentDistributor.Reset();
 							ParentHologram = nullptr;
@@ -7005,43 +7007,43 @@ void USFSubsystem::OnActorSpawned(AActor* SpawnedActor)
 							PendingBeltData.Empty();
 							return;
 						}
-						
-						UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("🎯 AUTO-CONNECT BUILD: Building %d belt(s) NOW (ChainDistributors=%d, BeltTierMain=%d, BeltTierToBuilding=%d)"), 
+
+						UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("🎯 AUTO-CONNECT BUILD: Building %d belt(s) NOW (ChainDistributors=%d, BeltTierMain=%d, BeltTierToBuilding=%d)"),
 							PendingBeltData.Num(), RuntimeSettings.bChainDistributors, RuntimeSettings.BeltTierMain, RuntimeSettings.BeltTierToBuilding);
-						
+
 						// Build hologram->actor map from parent and its children
 						TMap<AFGHologram*, AFGBuildableConveyorAttachment*> HologramToActorMap;
-						
+
 						if (SpawnedParentDistributor.IsValid())
 						{
 							AFGBuildableConveyorAttachment* ParentActor = SpawnedParentDistributor.Get();
 							HologramToActorMap.Add(ParentHologram, ParentActor);
-							
-							UE_LOG(LogSmartFoundations, Log, TEXT("🎯 AUTO-CONNECT BUILD: Parent actor %s at %s"), 
+
+							UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("🎯 AUTO-CONNECT BUILD: Parent actor %s at %s"),
 								*ParentActor->GetName(), *ParentActor->GetActorLocation().ToString());
-							
+
 							// Use stored child holograms (NOT GetHologramChildren - those are destroyed!)
 							UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("🎯 AUTO-CONNECT BUILD: Looking for %d child distributor actors (from stored list)"), ChildHolograms.Num());
-							
+
 							// Match child holograms to spawned actors by proximity to EACH child position
 							for (AFGHologram* ChildHolo : ChildHolograms)
 							{
 								if (!AutoConnectService->IsDistributorHologram(ChildHolo)) continue;
-								
+
 								FVector ChildHoloPos = ChildHolo->GetActorLocation();
-								UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("   🔍 Searching for distributor near child hologram %s at %s"), 
+								UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("   🔍 Searching for distributor near child hologram %s at %s"),
 									*ChildHolo->GetName(), *ChildHoloPos.ToString());
-								
+
 								// Search for distributor near THIS child hologram position
 								AFGBuildableConveyorAttachment* BestMatch = nullptr;
 								float BestDistance = 500.0f;  // Max 5m tolerance from child position
-								
+
 								for (TActorIterator<AFGBuildableConveyorAttachment> It(World); It; ++It)
 								{
 									AFGBuildableConveyorAttachment* PotentialChild = *It;
 									if (PotentialChild == ParentActor) continue;  // Skip parent
 									if (HologramToActorMap.FindKey(PotentialChild)) continue;  // Skip already matched
-									
+
 									float Dist = FVector::Dist(PotentialChild->GetActorLocation(), ChildHoloPos);
 									if (Dist < BestDistance)
 									{
@@ -7049,34 +7051,34 @@ void USFSubsystem::OnActorSpawned(AActor* SpawnedActor)
 										BestMatch = PotentialChild;
 									}
 								}
-								
+
 								if (BestMatch)
 								{
 									HologramToActorMap.Add(ChildHolo, BestMatch);
-									UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("   ✅ Matched child hologram %s → actor %s (%.1f cm apart)"), 
+									UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("   ✅ Matched child hologram %s → actor %s (%.1f cm apart)"),
 										*ChildHolo->GetName(), *BestMatch->GetName(), BestDistance);
 								}
 								else
 								{
-									UE_LOG(LogSmartFoundations, Warning, TEXT("   ❌ Could not find distributor within 500cm of child hologram %s"), 
+									UE_LOG(LogSmartFoundations, Warning, TEXT("   ❌ Could not find distributor within 500cm of child hologram %s"),
 										*ChildHolo->GetName());
 								}
 							}
 						}
-						
-						UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("🎯 AUTO-CONNECT BUILD: Mapped %d/%d distributors (holograms → actors)"), 
+
+						UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("🎯 AUTO-CONNECT BUILD: Mapped %d/%d distributors (holograms → actors)"),
 							HologramToActorMap.Num(), 1 + ChildHolograms.Num());
-						
+
 						// Build each belt from extracted data
 						int32 BuiltCount = 0;
 						int32 SkippedManifolds = 0;
 						int32 SkippedBuildings = 0;
-						
+
 						for (const FBeltBuildData& Data : PendingBeltData)
 						{
 							// Determine if this is a manifold belt (distributor→distributor)
 							bool bIsManifoldBelt = (Data.TargetDistributorHologram != nullptr && !Data.InputConnectorName.IsEmpty());
-							
+
 							// Filter based on runtime settings toggles
 							// Buildings are always built when auto-connect is enabled
 							// Only distributor chaining can be toggled separately
@@ -7085,51 +7087,51 @@ void USFSubsystem::OnActorSpawned(AActor* SpawnedActor)
 								SkippedManifolds++;
 								continue;  // Skip manifold belts if chaining disabled
 							}
-							
+
 							// Get input connector (handle manifold vs regular belts)
 							UFGFactoryConnectionComponent* BuildingInput = nullptr;
-							
+
 							// Check if this is a manifold belt (distributor→distributor)
 							if (bIsManifoldBelt)
 							{
 								// Manifold belt: Look up target distributor and find input connector by name
 								AFGBuildableConveyorAttachment** TargetDistributorPtr = HologramToActorMap.Find(Data.TargetDistributorHologram);
-								
+
 								if (TargetDistributorPtr && *TargetDistributorPtr)
 								{
 									AFGBuildableConveyorAttachment* TargetDistributor = *TargetDistributorPtr;
-									
+
 									// Connector names are stored correctly (no swapping needed)
 									// InputConnectorName = target INPUT, OutputConnectorName = source OUTPUT
 									FString TargetInputName = Data.InputConnectorName;
-									
+
 									// Get all connectors from target distributor
 									TArray<UFGFactoryConnectionComponent*> TargetConns;
 									TargetDistributor->GetComponents<UFGFactoryConnectionComponent>(TargetConns, false);
-									
+
 									// Find input connector by name
 									for (UFGFactoryConnectionComponent* Conn : TargetConns)
 									{
-										if (Conn && Conn->GetDirection() == EFactoryConnectionDirection::FCD_INPUT && 
+										if (Conn && Conn->GetDirection() == EFactoryConnectionDirection::FCD_INPUT &&
 											Conn->GetName() == TargetInputName)
 										{
 											BuildingInput = Conn;
-											UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("   🔗 MANIFOLD belt: Found input %s on target %s"), 
+											UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("   🔗 MANIFOLD belt: Found input %s on target %s"),
 												*TargetInputName, *TargetDistributor->GetName());
 											break;
 										}
 									}
-									
+
 									if (!BuildingInput)
 									{
-										UE_LOG(LogSmartFoundations, Warning, TEXT("Manifold belt: Could not find input connector '%s' on target distributor %s"), 
+										UE_LOG(LogSmartFoundations, Warning, TEXT("Manifold belt: Could not find input connector '%s' on target distributor %s"),
 											*TargetInputName, *TargetDistributor->GetName());
 										continue;
 									}
 								}
 								else
 								{
-									UE_LOG(LogSmartFoundations, Warning, TEXT("Manifold belt: Target distributor not found for hologram %s"), 
+									UE_LOG(LogSmartFoundations, Warning, TEXT("Manifold belt: Target distributor not found for hologram %s"),
 										*GetNameSafe(Data.TargetDistributorHologram));
 									continue;
 								}
@@ -7141,40 +7143,40 @@ void USFSubsystem::OnActorSpawned(AActor* SpawnedActor)
 								// Look up source distributor and find input connector by name
 								UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("   🔍 MERGER building belt detected: InputName='%s', TargetHolo=%s"),
 									*Data.InputConnectorName, Data.TargetDistributorHologram ? TEXT("SET") : TEXT("NULL"));
-								
+
 								AFGBuildableConveyorAttachment** SourceDistributorPtr = HologramToActorMap.Find(Data.SourceDistributorHologram);
-								
+
 								if (SourceDistributorPtr && *SourceDistributorPtr)
 								{
 									AFGBuildableConveyorAttachment* SourceDistributor = *SourceDistributorPtr;
-									
+
 									// Get all connectors from source distributor (merger)
 									TArray<UFGFactoryConnectionComponent*> SourceConns;
 									SourceDistributor->GetComponents<UFGFactoryConnectionComponent>(SourceConns, false);
-									
+
 									// Find input connector by name
 									for (UFGFactoryConnectionComponent* Conn : SourceConns)
 									{
-										if (Conn && Conn->GetDirection() == EFactoryConnectionDirection::FCD_INPUT && 
+										if (Conn && Conn->GetDirection() == EFactoryConnectionDirection::FCD_INPUT &&
 											Conn->GetName() == Data.InputConnectorName)
 										{
 											BuildingInput = Conn;
-											UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("   🔗 MERGER building belt: Found input %s on merger %s"), 
+											UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("   🔗 MERGER building belt: Found input %s on merger %s"),
 												*Data.InputConnectorName, *SourceDistributor->GetName());
 											break;
 										}
 									}
-									
+
 									if (!BuildingInput)
 									{
-										UE_LOG(LogSmartFoundations, Warning, TEXT("Merger building belt: Could not find input connector '%s' on merger %s"), 
+										UE_LOG(LogSmartFoundations, Warning, TEXT("Merger building belt: Could not find input connector '%s' on merger %s"),
 											*Data.InputConnectorName, *SourceDistributor->GetName());
 										continue;
 									}
 								}
 								else
 								{
-									UE_LOG(LogSmartFoundations, Warning, TEXT("Merger building belt: Source distributor not found for hologram %s"), 
+									UE_LOG(LogSmartFoundations, Warning, TEXT("Merger building belt: Source distributor not found for hologram %s"),
 										*GetNameSafe(Data.SourceDistributorHologram));
 									continue;
 								}
@@ -7189,25 +7191,25 @@ void USFSubsystem::OnActorSpawned(AActor* SpawnedActor)
 								}
 								BuildingInput = Data.InputConnector.Get();
 							}
-							
+
 							// Find the correct spawned distributor for this belt
 							AFGBuildableConveyorAttachment** SourceDistributorPtr = HologramToActorMap.Find(Data.SourceDistributorHologram);
-							
+
 							if (!SourceDistributorPtr || !*SourceDistributorPtr)
 							{
-								UE_LOG(LogSmartFoundations, Warning, TEXT("Spawned distributor not found for hologram %s"), 
+								UE_LOG(LogSmartFoundations, Warning, TEXT("Spawned distributor not found for hologram %s"),
 									*GetNameSafe(Data.SourceDistributorHologram));
 								continue;
 							}
-							
+
 							AFGBuildableConveyorAttachment* SourceDistributor = *SourceDistributorPtr;
-							UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("   🔗 Belt from distributor %s (hologram %s)"), 
+							UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("   🔗 Belt from distributor %s (hologram %s)"),
 								*SourceDistributor->GetName(), *Data.SourceDistributorHologram->GetName());
-							
+
 							// CRITICAL: For mergers, output is on BUILDING; for splitters, output is on distributor
 							UFGFactoryConnectionComponent* BestOutput = nullptr;
 							bool bIsMerger = AutoConnectService->IsMergerHologram(Data.SourceDistributorHologram);
-							
+
 							if (!bIsManifoldBelt && bIsMerger)
 							{
 								// Merger building belt: Output is on the BUILDING (use stored connector)
@@ -7216,13 +7218,13 @@ void USFSubsystem::OnActorSpawned(AActor* SpawnedActor)
 									UE_LOG(LogSmartFoundations, Warning, TEXT("Merger: Building output connector is no longer valid"));
 									continue;
 								}
-								
+
 								BestOutput = Data.OutputConnector.Get();
 								AFGBuildable* BuildingActor = Cast<AFGBuildable>(BestOutput->GetOwner());
-								
+
 								if (BestOutput && BuildingActor)
 								{
-									UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("   ✅ Merger: Output %s on building %s"), 
+									UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("   ✅ Merger: Output %s on building %s"),
 										*BestOutput->GetName(), *BuildingActor->GetName());
 								}
 								else
@@ -7236,18 +7238,18 @@ void USFSubsystem::OnActorSpawned(AActor* SpawnedActor)
 								// Splitter building belt or manifold: Output is on distributor
 								TArray<UFGFactoryConnectionComponent*> AllConns;
 								SourceDistributor->GetComponents<UFGFactoryConnectionComponent>(AllConns, false);
-								
+
 								TArray<UFGFactoryConnectionComponent*> Outputs;
 								for (UFGFactoryConnectionComponent* C : AllConns)
 								{
 									if (C && C->GetDirection() == EFactoryConnectionDirection::FCD_OUTPUT)
 										Outputs.Add(C);
 								}
-								
+
 								// Connector names are stored correctly (no swapping needed)
 								// OutputConnectorName = source OUTPUT name
 								FString SourceOutputName = Data.OutputConnectorName;
-								
+
 								for (UFGFactoryConnectionComponent* Candidate : Outputs)
 								{
 									if (Candidate && Candidate->GetName() == SourceOutputName)
@@ -7256,143 +7258,143 @@ void USFSubsystem::OnActorSpawned(AActor* SpawnedActor)
 										break;
 									}
 								}
-								
+
 								if (BestOutput)
 								{
-									UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("   Splitter/Manifold: Output %s on distributor %s"), 
+									UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("   Splitter/Manifold: Output %s on distributor %s"),
 										*BestOutput->GetName(), *SourceDistributor->GetName());
 								}
 								else
 								{
-									UE_LOG(LogSmartFoundations, Warning, TEXT("No output '%s' on distributor %s"), 
+									UE_LOG(LogSmartFoundations, Warning, TEXT("No output '%s' on distributor %s"),
 										*SourceOutputName, *SourceDistributor->GetName());
 									continue;
 								}
 							}
-							
+
 							// Get connector positions and normals for routing
 							FVector StartPos = BestOutput->GetComponentLocation();
 							FVector EndPos = BuildingInput->GetComponentLocation();
 							FVector StartNormal = BestOutput->GetConnectorNormal();
 							FVector EndNormal = BuildingInput->GetConnectorNormal();
-							
+
 							// Spawn temporary hologram for spline routing
 							FActorSpawnParameters HoloParams;
 							HoloParams.bDeferConstruction = true;
-							
+
 							ASFConveyorBeltHologram* RoutingHologram = World->SpawnActor<ASFConveyorBeltHologram>(
 								ASFConveyorBeltHologram::StaticClass(),
 								StartPos,
 								FRotator::ZeroRotator,
 								HoloParams);
-							
+
 							if (!RoutingHologram)
 							{
 								UE_LOG(LogSmartFoundations, Warning, TEXT("Failed to spawn routing hologram"));
 								continue;
 							}
-							
+
 							// Get belt class from runtime settings (respects U menu changes)
 							int32 ConfiguredTier = bIsManifoldBelt ? RuntimeSettings.BeltTierMain : RuntimeSettings.BeltTierToBuilding;
 							UClass* BeltClass = GetBeltClassFromConfig(ConfiguredTier, LastController.Get());
-							
+
 							if (!BeltClass)
 							{
-								UE_LOG(LogSmartFoundations, Warning, TEXT("Failed to load belt class for tier %d (%s) - skipping belt"), 
+								UE_LOG(LogSmartFoundations, Warning, TEXT("Failed to load belt class for tier %d (%s) - skipping belt"),
 									ConfiguredTier, bIsManifoldBelt ? TEXT("Manifold") : TEXT("Building"));
 								RoutingHologram->Destroy();
 								continue;  // Belt tier unavailable or not unlocked - belt category disabled
 							}
-							
-							UE_LOG(LogSmartFoundations, Log, TEXT("Using belt tier Mk%d from runtime settings for %s belt"), 
+
+							UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("Using belt tier Mk%d from runtime settings for %s belt"),
 								ConfiguredTier == 0 ? 5 : ConfiguredTier, bIsManifoldBelt ? TEXT("manifold") : TEXT("building"));
-							
+
 							RoutingHologram->SetBuildClass(BeltClass);
 							RoutingHologram->FinishSpawning(FTransform(FRotator::ZeroRotator, StartPos));
-							
+
 							// Route spline using connector normals
 							RoutingHologram->AutoRouteSplineWithNormals(StartPos, StartNormal, EndPos, EndNormal);
-							
+
 							// Extract spline data from hologram
 							TArray<FSplinePointData> RoutedSplineData = RoutingHologram->GetSplinePointData();
-							
+
 							if (RoutedSplineData.Num() == 0)
 							{
 								UE_LOG(LogSmartFoundations, Warning, TEXT("Hologram produced no spline data"));
 								RoutingHologram->Destroy();
 								continue;
 							}
-							
-							UE_LOG(LogSmartFoundations, Log, TEXT("🔍 BEFORE Respline: Hologram routed belt with %d spline points"), RoutedSplineData.Num());
+
+							UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("🔍 BEFORE Respline: Hologram routed belt with %d spline points"), RoutedSplineData.Num());
 							for (int32 i = 0; i < RoutedSplineData.Num(); i++)
 							{
-								UE_LOG(LogSmartFoundations, Log, TEXT("   Point %d: ArriveTangent=%.1f, LeaveTangent=%.1f"), 
-									i, 
+								UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("   Point %d: ArriveTangent=%.1f, LeaveTangent=%.1f"),
+									i,
 									RoutedSplineData[i].ArriveTangent.Size(),
 									RoutedSplineData[i].LeaveTangent.Size());
 							}
-							
+
 							// Approximate belt length from routed spline data (sum of segment lengths in cm)
 							float BeltLengthCm = 0.0f;
 							for (int32 PointIdx = 1; PointIdx < RoutedSplineData.Num(); ++PointIdx)
 							{
 								BeltLengthCm += FVector::Dist(RoutedSplineData[PointIdx - 1].Location, RoutedSplineData[PointIdx].Location);
 							}
-							
+
 							// NOTE: Belt costs are now handled by child holograms via GetCost()
 							// Vanilla deducts the combined cost when the hologram is built, so we skip
 							// manual deduction here to avoid double-charging the player.
 							// ChargePlayerForBelt is kept for legacy/fallback but not called in normal flow.
-							
+
 							// Spawn actual belt
 							AFGBuildableConveyorBelt* Belt = World->SpawnActor<AFGBuildableConveyorBelt>(
 								BeltClass,
 								StartPos,
 								FRotator::ZeroRotator);
-							
+
 							if (!Belt)
 							{
 								UE_LOG(LogSmartFoundations, Warning, TEXT("Failed to spawn belt actor"));
 								RoutingHologram->Destroy();
 								continue;
 							}
-							
+
 							// Apply hologram's spline to belt
 							AFGBuildableConveyorBelt* ResplinedBelt = AFGBuildableConveyorBelt::Respline(Belt, RoutedSplineData);
-							
+
 							// Cleanup hologram
 							RoutingHologram->Destroy();
-							
+
 							if (!ResplinedBelt)
 							{
 								UE_LOG(LogSmartFoundations, Warning, TEXT("Respline failed"));
 								Belt->Destroy();
 								continue;
 							}
-							
+
 							// Finalize belt
 							Belt->OnBuildEffectFinished();
-							
+
 							// Connect the belt endpoints
 							// AutoRouteSpline routes from StartPos (Output) to EndPos (Input)
 							// Therefore Connection0 is at Output position, Connection1 is at Input position
 							// ALL belts use the same connection order: Conn0=Output, Conn1=Input
 							ResplinedBelt->GetConnection0()->SetConnection(BestOutput);     // Output end
 							ResplinedBelt->GetConnection1()->SetConnection(BuildingInput);  // Input end
-							
+
 							if (bIsManifoldBelt)
 							{
-								UE_LOG(LogSmartFoundations, Log, TEXT("   🔗 Manifold belt connected correctly: %s→%s"),
+								UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("   🔗 Manifold belt connected correctly: %s→%s"),
 									*BestOutput->GetName(), *BuildingInput->GetName());
 							}
-							
+
 							UE_LOG(LogSmartFoundations, VeryVerbose, TEXT(" Belt spawned and connected!"));
 							BuiltCount++;
 						}
-						
-						UE_LOG(LogSmartFoundations, Log, TEXT("🎯 AUTO-CONNECT BUILD: Built %d belt(s), Skipped %d manifold(s), Skipped %d building(s)"), 
+
+						UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("🎯 AUTO-CONNECT BUILD: Built %d belt(s), Skipped %d manifold(s), Skipped %d building(s)"),
 							BuiltCount, SkippedManifolds, SkippedBuildings);
-						
+
 						// CRITICAL: Reset static variables for next placement
 						SpawnedParentDistributor.Reset();
 						ParentHologram = nullptr;
@@ -7400,13 +7402,13 @@ void USFSubsystem::OnActorSpawned(AActor* SpawnedActor)
 						PendingBeltData.Empty();
 						bWaitingForSpawn = false;
 						bProcessingGridPlacement = false;  // Unlock for next placement
-						
+
 						UE_LOG(LogSmartFoundations, VeryVerbose, TEXT(" AUTO-CONNECT BUILD: Reset tracking for next placement"));
 					});
 				}
 			}
 		}
-		
+
 		// ========================================
 		// PIPE AUTO-CONNECT CHILD DEFERRED WIRING (Issue #235)
 		// ========================================
@@ -7421,7 +7423,7 @@ void USFSubsystem::OnActorSpawned(AActor* SpawnedActor)
 				static TArray<TWeakObjectPtr<AFGBuildablePipeline>> PendingAutoConnectPipes;
 				static TWeakObjectPtr<AFGHologram> LastPipeAutoConnectHologram;
 				static FTimerHandle PipeAutoConnectWiringTimerHandle;
-				
+
 				// Reset tracking when hologram changes (if available)
 				if (ActiveHologram.IsValid())
 				{
@@ -7435,10 +7437,10 @@ void USFSubsystem::OnActorSpawned(AActor* SpawnedActor)
 				{
 					LastPipeAutoConnectHologram.Reset();
 				}
-				
+
 				// Track this pipe for deferred wiring
 				PendingAutoConnectPipes.Add(AutoConnectPipe);
-				
+
 				// Build tag list manually (TArray<FName> has no ToStringSimple)
 				FString TagList;
 				for (int32 TagIdx = 0; TagIdx < SpawnedActor->Tags.Num(); TagIdx++)
@@ -7449,19 +7451,19 @@ void USFSubsystem::OnActorSpawned(AActor* SpawnedActor)
 						TagList += TEXT(",");
 					}
 				}
-				
-				UE_LOG(LogSmartFoundations, Log, TEXT(" PIPE AUTO-CONNECT SPAWN: Tracking %s for deferred wiring (%d pending). Tags=%s"),
+
+				UE_LOG(LogSmartFoundations, VeryVerbose, TEXT(" PIPE AUTO-CONNECT SPAWN: Tracking %s for deferred wiring (%d pending). Tags=%s"),
 					*AutoConnectPipe->GetName(), PendingAutoConnectPipes.Num(), *TagList);
-				
+
 				// Set/reset timer to wire pipes on next tick (after all junctions are spawned)
 				GetWorld()->GetTimerManager().ClearTimer(PipeAutoConnectWiringTimerHandle);
 				GetWorld()->GetTimerManager().SetTimerForNextTick([this]()
 				{
-					UE_LOG(LogSmartFoundations, Log, TEXT(" PIPE AUTO-CONNECT WIRING: Processing %d pipe(s)..."), PendingAutoConnectPipes.Num());
-					
+					UE_LOG(LogSmartFoundations, VeryVerbose, TEXT(" PIPE AUTO-CONNECT WIRING: Processing %d pipe(s)..."), PendingAutoConnectPipes.Num());
+
 					int32 ConnectionsMade = 0;
 					const float ConnectionRadius = 100.0f;  // 1m tolerance for connector matching
-					
+
 					// Collect valid pipes
 					TArray<AFGBuildablePipeline*> ValidPipes;
 					for (const auto& WeakPipe : PendingAutoConnectPipes)
@@ -7471,32 +7473,32 @@ void USFSubsystem::OnActorSpawned(AActor* SpawnedActor)
 							ValidPipes.Add(WeakPipe.Get());
 						}
 					}
-					
+
 					// Wire each pipe's unconnected endpoints to nearby built connectors
 					for (AFGBuildablePipeline* Pipe : ValidPipes)
 					{
 						UFGPipeConnectionComponent* Conn0 = Pipe->GetPipeConnection0();
 						UFGPipeConnectionComponent* Conn1 = Pipe->GetPipeConnection1();
-						
+
 						// Wire Conn0 to nearby unconnected pipe connector
 						if (Conn0 && !Conn0->IsConnected())
 						{
 							FVector SearchLoc = Conn0->GetComponentLocation();
 							UFGPipeConnectionComponent* BestMatch = nullptr;
 							float BestDist = ConnectionRadius;
-							
+
 							for (TActorIterator<AFGBuildable> It(GetWorld()); It; ++It)
 							{
 								AFGBuildable* Buildable = *It;
 								if (Buildable == Pipe) continue;
-								
+
 								TArray<UFGPipeConnectionComponent*> Connectors;
 								Buildable->GetComponents<UFGPipeConnectionComponent>(Connectors);
-								
+
 								for (UFGPipeConnectionComponent* Conn : Connectors)
 								{
 									if (!Conn || Conn->IsConnected()) continue;
-									
+
 									float Dist = FVector::Dist(SearchLoc, Conn->GetComponentLocation());
 									if (Dist < BestDist)
 									{
@@ -7505,35 +7507,35 @@ void USFSubsystem::OnActorSpawned(AActor* SpawnedActor)
 									}
 								}
 							}
-							
+
 							if (BestMatch)
 							{
 								Conn0->SetConnection(BestMatch);
 								ConnectionsMade++;
-								UE_LOG(LogSmartFoundations, Log, TEXT(" PIPE AUTO-CONNECT: Wired %s.Conn0 → %s.%s (dist=%.1f)"),
+								UE_LOG(LogSmartFoundations, VeryVerbose, TEXT(" PIPE AUTO-CONNECT: Wired %s.Conn0 → %s.%s (dist=%.1f)"),
 									*Pipe->GetName(), *BestMatch->GetOwner()->GetName(), *BestMatch->GetName(), BestDist);
 							}
 						}
-						
+
 						// Wire Conn1 to nearby unconnected pipe connector
 						if (Conn1 && !Conn1->IsConnected())
 						{
 							FVector SearchLoc = Conn1->GetComponentLocation();
 							UFGPipeConnectionComponent* BestMatch = nullptr;
 							float BestDist = ConnectionRadius;
-							
+
 							for (TActorIterator<AFGBuildable> It(GetWorld()); It; ++It)
 							{
 								AFGBuildable* Buildable = *It;
 								if (Buildable == Pipe) continue;
-								
+
 								TArray<UFGPipeConnectionComponent*> Connectors;
 								Buildable->GetComponents<UFGPipeConnectionComponent>(Connectors);
-								
+
 								for (UFGPipeConnectionComponent* Conn : Connectors)
 								{
 									if (!Conn || Conn->IsConnected()) continue;
-									
+
 									float Dist = FVector::Dist(SearchLoc, Conn->GetComponentLocation());
 									if (Dist < BestDist)
 									{
@@ -7542,17 +7544,17 @@ void USFSubsystem::OnActorSpawned(AActor* SpawnedActor)
 									}
 								}
 							}
-							
+
 							if (BestMatch)
 							{
 								Conn1->SetConnection(BestMatch);
 								ConnectionsMade++;
-								UE_LOG(LogSmartFoundations, Log, TEXT(" PIPE AUTO-CONNECT: Wired %s.Conn1 → %s.%s (dist=%.1f)"),
+								UE_LOG(LogSmartFoundations, VeryVerbose, TEXT(" PIPE AUTO-CONNECT: Wired %s.Conn1 → %s.%s (dist=%.1f)"),
 									*Pipe->GetName(), *BestMatch->GetOwner()->GetName(), *BestMatch->GetName(), BestDist);
 							}
 						}
 					}
-					
+
 					// Merge pipe networks for connected pipes
 					if (ConnectionsMade > 0)
 					{
@@ -7575,13 +7577,13 @@ void USFSubsystem::OnActorSpawned(AActor* SpawnedActor)
 							}
 						}
 					}
-					
-					UE_LOG(LogSmartFoundations, Log, TEXT(" PIPE AUTO-CONNECT WIRING: Made %d connection(s)"), ConnectionsMade);
+
+					UE_LOG(LogSmartFoundations, VeryVerbose, TEXT(" PIPE AUTO-CONNECT WIRING: Made %d connection(s)"), ConnectionsMade);
 					PendingAutoConnectPipes.Empty();
 				});
 			}
 		}
-		
+
 		// ========================================
 		// PIPE JUNCTION AUTO-CONNECT BUILD (DISABLED - Issue #235)
 		// ========================================
@@ -7594,18 +7596,18 @@ void USFSubsystem::OnActorSpawned(AActor* SpawnedActor)
 			// DISABLED: Vanilla child hologram system now handles pipe building via Construct()
 			// The wiring is done in SFPipelineHologram::Construct() using FindCompatibleOverlappingConnection()
 			// Child holograms are automatically cleaned up by vanilla when parent is destroyed.
-			UE_LOG(LogSmartFoundations, Log, TEXT(" PIPE AUTO-CONNECT BUILD: Pipeline junction spawned - using vanilla child hologram system"));
+			UE_LOG(LogSmartFoundations, VeryVerbose, TEXT(" PIPE AUTO-CONNECT BUILD: Pipeline junction spawned - using vanilla child hologram system"));
 			return;  // Skip legacy deferred build system
-			
+
 			// === LEGACY CODE BELOW - KEPT FOR REFERENCE ===
 			if (bProcessingGridPlacement)
 			{
 				UE_LOG(LogSmartFoundations, VeryVerbose, TEXT(" PIPE AUTO-CONNECT BUILD: Skipping - already processing grid"));
 				return;
 			}
-			
-			UE_LOG(LogSmartFoundations, Log, TEXT(" PIPE AUTO-CONNECT BUILD: Pipeline junction spawned - construction system active"));
-			
+
+			UE_LOG(LogSmartFoundations, VeryVerbose, TEXT(" PIPE AUTO-CONNECT BUILD: Pipeline junction spawned - construction system active"));
+
 			// Get pipe previews from the pipe auto-connect manager
 			FSFPipeAutoConnectManager* PipeManager = AutoConnectService->GetPipeManager(ActiveHologram.Get());
 			if (!PipeManager)
@@ -7613,22 +7615,22 @@ void USFSubsystem::OnActorSpawned(AActor* SpawnedActor)
 				UE_LOG(LogSmartFoundations, Warning, TEXT("🔧 PIPE AUTO-CONNECT BUILD: No pipe manager found for junction"));
 				return;
 			}
-			
+
 			// Check if we have any pipe previews to build
 			const auto& BuildingPreviews = PipeManager->GetBuildingPipePreviews();
 			const auto& ManifoldPreviews = PipeManager->GetManifoldPipePreviews();
 			int32 TotalPreviews = BuildingPreviews.Num() + ManifoldPreviews.Num();
-			
+
 			if (TotalPreviews == 0)
 			{
 				UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("🔧 PIPE AUTO-CONNECT BUILD: No pipe previews to build"));
 				return;
 			}
-			
+
 			bProcessingGridPlacement = true;
-			
+
 			UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("🔧 PIPE AUTO-CONNECT BUILD: Capturing %d pipe preview(s) for deferred construction"), TotalPreviews);
-			
+
 			// CRITICAL: Extract all data from previews NOW before hologram is destroyed
 			struct FPipeBuildData
 			{
@@ -7639,7 +7641,7 @@ void USFSubsystem::OnActorSpawned(AActor* SpawnedActor)
 				AFGHologram* TargetJunctionHologram = nullptr;  // For manifold pipes
 				bool bIsManifold = false;  // True if junction→junction, false if junction→building
 				int32 PipeTier = 1;  // Mk1 for now (will use PipeTierMain or PipeTierToBuilding later)
-				
+
 				// Connector reconstruction metadata (for when hologram-side connectors are destroyed)
 				int32 StartConnectorIndex = INDEX_NONE;
 				int32 EndConnectorIndex = INDEX_NONE;
@@ -7648,14 +7650,14 @@ void USFSubsystem::OnActorSpawned(AActor* SpawnedActor)
 				AFGHologram* StartConnectorOwner = nullptr;
 				AFGHologram* EndConnectorOwner = nullptr;
 			};
-			
+
 			// Collect pipe data from ALL junctions in the grid
 			TArray<FPipeBuildData> PipeData;
 			TArray<AFGHologram*> AllJunctionHolograms;
-			
+
 			// Start with parent
 			AllJunctionHolograms.Add(ActiveHologram.Get());
-			
+
 			// Add all children
 			const TArray<AFGHologram*>& Children = ActiveHologram->GetHologramChildren();
 			for (AFGHologram* Child : Children)
@@ -7665,36 +7667,36 @@ void USFSubsystem::OnActorSpawned(AActor* SpawnedActor)
 					AllJunctionHolograms.Add(Child);
 				}
 			}
-			
+
 			UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("🔧 PIPE AUTO-CONNECT BUILD: Collecting pipe data from %d junction(s)"), AllJunctionHolograms.Num());
-			
+
 			// Extract pipe data from each junction's previews
 			for (AFGHologram* Junction : AllJunctionHolograms)
 			{
 				FSFPipeAutoConnectManager* JunctionManager = AutoConnectService->GetPipeManager(Junction);
 				if (!JunctionManager) continue;
-				
+
 				// Extract building pipe data (junction→building)
 				for (const auto& Pair : JunctionManager->GetBuildingPipePreviews())
 				{
 					if (!Pair.Value.IsValid()) continue;
 					FPipePreviewHelper* PreviewHelper = Pair.Value.Get();
-					
+
 					if (!PreviewHelper->IsPreviewValid()) continue;
-					
+
 					AFGSplineHologram* PreviewHolo = PreviewHelper->GetHologram();
 					if (!PreviewHolo) continue;
-					
+
 					FPipeBuildData Data;
 					Data.SourceJunctionHologram = Junction;
 					Data.bIsManifold = false;
 					Data.PipeTier = PreviewHelper->GetPipeTier();
-					
+
 					UFGPipeConnectionComponent* StartConn = PreviewHelper->GetStartConnection();
 					UFGPipeConnectionComponent* EndConn = PreviewHelper->GetEndConnection();
 					Data.StartConnector = StartConn;
 					Data.EndConnector = EndConn;
-					
+
 					// Record junction-side connector indices for reconstruction after hologram destruction
 					if (StartConn)
 					{
@@ -7718,13 +7720,13 @@ void USFSubsystem::OnActorSpawned(AActor* SpawnedActor)
 							Data.EndConnectorIndex = JunctionConns.IndexOfByKey(EndConn);
 						}
 					}
-					
+
 					// CRITICAL: Extract spline points - use 6-point BUILD spline, not 2-point PREVIEW!
 					if (ASFPipelineHologram* SmartPipeHolo = Cast<ASFPipelineHologram>(PreviewHolo))
 					{
 						// Use the 6-point build spline from our Smart! hologram
 						Data.SplineData = SmartPipeHolo->GetBuildSplineData();
-						UE_LOG(LogSmartFoundations, Log, TEXT("   ✅ Using 6-point BUILD spline (%d points) for pipe construction"), 
+						UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("   ✅ Using 6-point BUILD spline (%d points) for pipe construction"),
 							Data.SplineData.Num());
 					}
 					else
@@ -7742,37 +7744,37 @@ void USFSubsystem::OnActorSpawned(AActor* SpawnedActor)
 								Point.LeaveTangent = SplineComp->GetLeaveTangentAtSplinePoint(i, ESplineCoordinateSpace::Local);
 								Data.SplineData.Add(Point);
 							}
-							UE_LOG(LogSmartFoundations, Log, TEXT("   📋 Using spline component data (%d points) for vanilla hologram"), 
+							UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("   📋 Using spline component data (%d points) for vanilla hologram"),
 								NumPoints);
 						}
 					}
-					
+
 					PipeData.Add(Data);
 					UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("   📋 Building pipe: Junction %s → Building"), *Junction->GetName());
 				}
-				
+
 				// Extract manifold pipe data (junction→junction)
 				for (const auto& Pair : JunctionManager->GetManifoldPipePreviews())
 				{
 					if (!Pair.Value.IsValid()) continue;
 					FPipePreviewHelper* PreviewHelper = Pair.Value.Get();
-					
+
 					if (!PreviewHelper->IsPreviewValid()) continue;
-					
+
 					AFGSplineHologram* PreviewHolo = PreviewHelper->GetHologram();
 					if (!PreviewHolo) continue;
-					
+
 					FPipeBuildData Data;
 					Data.SourceJunctionHologram = Junction;
 					Data.TargetJunctionHologram = Pair.Key;  // Target junction key from map
 					Data.bIsManifold = true;
 					Data.PipeTier = PreviewHelper->GetPipeTier();
-					
+
 					UFGPipeConnectionComponent* StartConn = PreviewHelper->GetStartConnection();
 					UFGPipeConnectionComponent* EndConn = PreviewHelper->GetEndConnection();
 					Data.StartConnector = StartConn;
 					Data.EndConnector = EndConn;
-					
+
 					// Record junction-side connector indices for reconstruction after hologram destruction
 					if (StartConn)
 					{
@@ -7796,13 +7798,13 @@ void USFSubsystem::OnActorSpawned(AActor* SpawnedActor)
 							Data.EndConnectorIndex = JunctionConns.IndexOfByKey(EndConn);
 						}
 					}
-					
+
 					// CRITICAL: Extract spline points - use 6-point BUILD spline, not 2-point PREVIEW!
 					if (ASFPipelineHologram* SmartPipeHolo = Cast<ASFPipelineHologram>(PreviewHolo))
 					{
 						// Use the 6-point build spline from our Smart! hologram
 						Data.SplineData = SmartPipeHolo->GetBuildSplineData();
-						UE_LOG(LogSmartFoundations, Log, TEXT("   ✅ Using 6-point BUILD spline (%d points) for manifold pipe construction"), 
+						UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("   ✅ Using 6-point BUILD spline (%d points) for manifold pipe construction"),
 							Data.SplineData.Num());
 					}
 					else
@@ -7820,32 +7822,32 @@ void USFSubsystem::OnActorSpawned(AActor* SpawnedActor)
 								Point.LeaveTangent = SplineComp->GetLeaveTangentAtSplinePoint(i, ESplineCoordinateSpace::Local);
 								Data.SplineData.Add(Point);
 							}
-							UE_LOG(LogSmartFoundations, Log, TEXT("   📋 Using spline component data (%d points) for vanilla hologram"), 
+							UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("   📋 Using spline component data (%d points) for vanilla hologram"),
 								NumPoints);
 						}
 					}
-					
+
 					PipeData.Add(Data);
-					UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("   📋 Manifold pipe: Junction %s → Junction %s"), 
+					UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("   📋 Manifold pipe: Junction %s → Junction %s"),
 						*Junction->GetName(), *Pair.Key->GetName());
 				}
 			}
-			
-			UE_LOG(LogSmartFoundations, Log, TEXT(" PIPE AUTO-CONNECT BUILD: Extracted data for %d pipe(s)"), PipeData.Num());
-			
+
+			UE_LOG(LogSmartFoundations, VeryVerbose, TEXT(" PIPE AUTO-CONNECT BUILD: Extracted data for %d pipe(s)"), PipeData.Num());
+
 			// Create persistent tracking structures (static to survive across OnActorSpawned calls)
 			static TWeakObjectPtr<AFGBuildablePipelineAttachment> SpawnedParentJunction;
 			static AFGHologram* ParentJunctionHologram = nullptr;
 			static TArray<AFGHologram*> ChildJunctionHolograms;
 			static TArray<FPipeBuildData> PendingPipeData;
 			static bool bWaitingForJunctionSpawn = false;
-			
+
 			// First junction spawning - initialize tracking
 			if (!bWaitingForJunctionSpawn)
 			{
 				SpawnedParentJunction.Reset();
 				ParentJunctionHologram = ActiveHologram.Get();
-				
+
 				// Store child holograms NOW before they're destroyed
 				ChildJunctionHolograms.Empty();
 				const TArray<AFGHologram*>& CurrentChildren = ActiveHologram->GetHologramChildren();
@@ -7856,19 +7858,19 @@ void USFSubsystem::OnActorSpawned(AActor* SpawnedActor)
 						ChildJunctionHolograms.Add(Child);
 					}
 				}
-				
+
 				PendingPipeData = PipeData;
 				bWaitingForJunctionSpawn = true;
-				
+
 				UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("🔧 PIPE AUTO-CONNECT BUILD: Waiting for parent junction to spawn (stored %d children)"), ChildJunctionHolograms.Num());
 			}
-			
+
 			// Store the parent junction
 			SpawnedParentJunction = PipeAttachment;
 			bWaitingForJunctionSpawn = false;
-			
+
 			UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("🔧 PIPE AUTO-CONNECT BUILD: Parent junction spawned! Building %d pipe(s)"), PendingPipeData.Num());
-			
+
 			GetWorld()->GetTimerManager().SetTimerForNextTick([this]()
 			{
 				UWorld* World = GetWorld();
@@ -7878,34 +7880,34 @@ void USFSubsystem::OnActorSpawned(AActor* SpawnedActor)
 					bProcessingGridPlacement = false;
 					return;
 				}
-				
+
 				// Build hologram→actor map from parent and children
 				TMap<AFGHologram*, AFGBuildablePipelineAttachment*> HologramToActorMap;
-				
+
 				if (SpawnedParentJunction.IsValid())
 				{
 					AFGBuildablePipelineAttachment* ParentActor = SpawnedParentJunction.Get();
 					HologramToActorMap.Add(ParentJunctionHologram, ParentActor);
-					
-					UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("🔧 PIPE AUTO-CONNECT BUILD: Parent junction %s at %s"), 
+
+					UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("🔧 PIPE AUTO-CONNECT BUILD: Parent junction %s at %s"),
 						*ParentActor->GetName(), *ParentActor->GetActorLocation().ToString());
-					
+
 					// Match child holograms to spawned actors by proximity
 					for (AFGHologram* ChildHolo : ChildJunctionHolograms)
 					{
 						if (!AutoConnectService->IsPipelineJunctionHologram(ChildHolo)) continue;
-						
+
 						FVector ChildHoloPos = ChildHolo->GetActorLocation();
-						
+
 						AFGBuildablePipelineAttachment* BestMatch = nullptr;
 						float BestDistance = 500.0f;  // Max 5m tolerance
-						
+
 						for (TActorIterator<AFGBuildablePipelineAttachment> It(World); It; ++It)
 						{
 							AFGBuildablePipelineAttachment* PotentialChild = *It;
 							if (PotentialChild == ParentActor) continue;
 							if (HologramToActorMap.FindKey(PotentialChild)) continue;
-							
+
 							float Dist = FVector::Dist(PotentialChild->GetActorLocation(), ChildHoloPos);
 							if (Dist < BestDistance)
 							{
@@ -7913,16 +7915,16 @@ void USFSubsystem::OnActorSpawned(AActor* SpawnedActor)
 								BestMatch = PotentialChild;
 							}
 						}
-						
+
 						if (BestMatch)
 						{
 							HologramToActorMap.Add(ChildHolo, BestMatch);
-							UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("   ✅ Matched child junction %s → %s (%.1f cm)"), 
+							UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("   ✅ Matched child junction %s → %s (%.1f cm)"),
 								*ChildHolo->GetName(), *BestMatch->GetName(), BestDistance);
 						}
 					}
 				}
-				
+
 				UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("🔧 PIPE AUTO-CONNECT BUILD: Mapped %d junctions"), HologramToActorMap.Num());
 
 				// Build each pipe from extracted data
@@ -7992,15 +7994,15 @@ void USFSubsystem::OnActorSpawned(AActor* SpawnedActor)
 
 					// Get pipe class from CURRENT runtime settings (not preview's stored tier)
 					// This ensures settings changed after preview creation are respected
-					int32 ConfigTier = Data.bIsManifold 
-						? AutoConnectRuntimeSettings.PipeTierMain 
+					int32 ConfigTier = Data.bIsManifold
+						? AutoConnectRuntimeSettings.PipeTierMain
 						: AutoConnectRuntimeSettings.PipeTierToBuilding;
 					bool bWithIndicator = AutoConnectRuntimeSettings.bPipeIndicator;
 					UClass* PipeClass = GetPipeClassFromConfig(ConfigTier, bWithIndicator, LastController.Get());
 
 					if (!PipeClass)
 					{
-						UE_LOG(LogSmartFoundations, Warning, TEXT("Failed to load pipe class for config tier=%d, manifold=%d, indicator=%d - skipping pipe"), 
+						UE_LOG(LogSmartFoundations, Warning, TEXT("Failed to load pipe class for config tier=%d, manifold=%d, indicator=%d - skipping pipe"),
 							ConfigTier, Data.bIsManifold, bWithIndicator);
 						continue;
 					}
@@ -8013,19 +8015,19 @@ void USFSubsystem::OnActorSpawned(AActor* SpawnedActor)
 					// Spawn actual pipe with DEFERRED construction (set spline before BeginPlay)
 					FActorSpawnParameters SpawnParams;
 					SpawnParams.bDeferConstruction = true;
-					
+
 					AFGBuildablePipeline* Pipe = World->SpawnActor<AFGBuildablePipeline>(
 						PipeClass,
 						StartPos,
 						FRotator::ZeroRotator,
 						SpawnParams);
-					
+
 					if (!Pipe)
 					{
 						UE_LOG(LogSmartFoundations, Warning, TEXT("Failed to spawn pipe actor"));
 						continue;
 					}
-					
+
 					// Apply spline data to pipe BEFORE FinishSpawning (BeginPlay checks mSplineData.Num() >= 2)
 					// CRITICAL: Must populate mSplineData directly, not just USplineComponent
 					TArray<FSplinePointData>* PipeSplineData = Pipe->GetMutableSplinePointData();
@@ -8034,11 +8036,11 @@ void USFSubsystem::OnActorSpawned(AActor* SpawnedActor)
 						*PipeSplineData = Data.SplineData;
 						UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("   Set pipe mSplineData: %d points"), PipeSplineData->Num());
 					}
-					
+
 					// Finish spawning (triggers BeginPlay with spline configured)
 					FTransform PipeTransform(FRotator::ZeroRotator, StartPos);
 					Pipe->FinishSpawning(PipeTransform);
-					
+
 					// Finalize pipe
 					Pipe->OnBuildEffectFinished();
 
@@ -8047,30 +8049,30 @@ void USFSubsystem::OnActorSpawned(AActor* SpawnedActor)
 					Pipe->GetPipeConnection1()->SetConnection(EndConn);
 
 					// Determine actual tier from config for logging
-					int32 LogTier = Data.bIsManifold 
-						? AutoConnectRuntimeSettings.PipeTierMain 
+					int32 LogTier = Data.bIsManifold
+						? AutoConnectRuntimeSettings.PipeTierMain
 						: AutoConnectRuntimeSettings.PipeTierToBuilding;
 					if (LogTier == 0)  // Auto mode
 					{
 						LogTier = GetHighestUnlockedPipeTier(LastController.Get());
 					}
-					
+
 					if (Data.bIsManifold)
 					{
-						UE_LOG(LogSmartFoundations, Log, TEXT("   🔗 Manifold Mk%d pipe connected: %s→%s"),
+						UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("   🔗 Manifold Mk%d pipe connected: %s→%s"),
 							LogTier, *StartConn->GetName(), *EndConn->GetName());
 					}
 					else
 					{
-						UE_LOG(LogSmartFoundations, Log, TEXT("   🔗 Building Mk%d pipe connected: Junction→Building"),
+						UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("   🔗 Building Mk%d pipe connected: Junction→Building"),
 							LogTier);
 					}
-					
+
 					BuiltCount++;
 				}
-				
+
 				UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("🔧 PIPE AUTO-CONNECT BUILD: Built %d pipe(s)"), BuiltCount);
-				
+
 				// Reset static variables
 				SpawnedParentJunction.Reset();
 				ParentJunctionHologram = nullptr;
@@ -8078,38 +8080,38 @@ void USFSubsystem::OnActorSpawned(AActor* SpawnedActor)
 				PendingPipeData.Empty();
 				bWaitingForJunctionSpawn = false;
 				bProcessingGridPlacement = false;
-				
+
 				UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("🔧 PIPE AUTO-CONNECT BUILD: Reset tracking for next placement"));
 			});
 		}
 	}
-	
+
 	// ========================================
 	// STACKABLE PIPELINE SUPPORT AUTO-CONNECT BUILD (Issue #220)
 	// ========================================
 	// Vanilla doesn't build our dynamically added pipe children, so we must build them manually.
 	// When a stackable pipe support is built, find any SF_StackableChild pipe holograms and build them.
-	// 
+	//
 	// CRITICAL: This code runs for EVERY pole that gets built (parent + children).
 	// We use a static flag to ensure pipes are only built ONCE per placement operation.
 	// The flag is reset when the hologram changes.
 	FString SpawnedClassName = SpawnedActor->GetClass()->GetName();
-	
-	bool bIsStackablePipeSupport = (SpawnedClassName.Contains(TEXT("PipeSupportStackable")) || 
+
+	bool bIsStackablePipeSupport = (SpawnedClassName.Contains(TEXT("PipeSupportStackable")) ||
 	                                SpawnedClassName.Contains(TEXT("PipelineStackable"))) &&
 	                               SpawnedClassName.StartsWith(TEXT("Build_"));
-	
+
 	// Track if we've already built pipes for this placement operation
 	static TWeakObjectPtr<AFGHologram> LastPipeBuildHologram;
 	static bool bPipesAlreadyBuiltForThisPlacement = false;
-	
+
 	// Reset tracking when hologram changes
 	if (ActiveHologram.Get() != LastPipeBuildHologram.Get())
 	{
 		LastPipeBuildHologram = ActiveHologram;
 		bPipesAlreadyBuiltForThisPlacement = false;
 	}
-	
+
 	if (bIsStackablePipeSupport && ActiveHologram.IsValid() && !bPipesAlreadyBuiltForThisPlacement)
 	{
 		// Check if parent hologram has SF_StackableChild pipe children to build
@@ -8120,7 +8122,7 @@ void USFSubsystem::OnActorSpawned(AActor* SpawnedActor)
 			{
 				// PHASE 1: Build all pipes first (collect them for connection phase)
 				TArray<AFGBuildablePipeline*> BuiltPipes;
-				
+
 				for (AFGHologram* Child : *ChildrenArray)
 				{
 					if (Child && Child->Tags.Contains(FName(TEXT("SF_StackableChild"))))
@@ -8129,14 +8131,14 @@ void USFSubsystem::OnActorSpawned(AActor* SpawnedActor)
 						TArray<AActor*> ChildActors;
 						FNetConstructionID DummyID;
 						AActor* BuiltPipe = Child->Construct(ChildActors, DummyID);
-						
+
 						if (BuiltPipe)
 						{
 							if (AFGBuildablePipeline* Pipeline = Cast<AFGBuildablePipeline>(BuiltPipe))
 							{
 								BuiltPipes.Add(Pipeline);
 							}
-							UE_LOG(LogSmartFoundations, Log, TEXT("STACKABLE PIPE BUILD: Manually built pipe %s"), *BuiltPipe->GetName());
+							UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("STACKABLE PIPE BUILD: Manually built pipe %s"), *BuiltPipe->GetName());
 						}
 						else
 						{
@@ -8144,15 +8146,15 @@ void USFSubsystem::OnActorSpawned(AActor* SpawnedActor)
 						}
 					}
 				}
-				
+
 				// PHASE 2: Connect pipes to each other at shared pole locations
 				// Now that all pipes exist, we can find neighbors
 				if (BuiltPipes.Num() > 0)
 				{
-					UE_LOG(LogSmartFoundations, Log, TEXT("STACKABLE PIPE BUILD: Built %d pipe(s), now connecting..."), BuiltPipes.Num());
-					
+					UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("STACKABLE PIPE BUILD: Built %d pipe(s), now connecting..."), BuiltPipes.Num());
+
 					int32 ConnectionsMade = 0;
-					
+
 					// Helper to check if an actor is in our built list
 					auto IsNewlyBuilt = [&](AActor* Actor) -> bool
 					{
@@ -8163,18 +8165,18 @@ void USFSubsystem::OnActorSpawned(AActor* SpawnedActor)
 					for (AFGBuildablePipeline* Pipe : BuiltPipes)
 					{
 						UFGPipeConnectionComponent* Conns[] = { Pipe->GetPipeConnection0(), Pipe->GetPipeConnection1() };
-						
+
 						for (UFGPipeConnectionComponent* Conn : Conns)
 						{
 							if (!Conn || Conn->IsConnected()) continue;
-							
+
 							bool bConnected = false;
-							
+
 							// 1. Try to connect to other newly built pipes (Manual distance check, bypasses physics)
 							for (AFGBuildablePipeline* OtherPipe : BuiltPipes)
 							{
 								if (OtherPipe == Pipe) continue;
-								
+
 								UFGPipeConnectionComponent* OtherConns[] = { OtherPipe->GetPipeConnection0(), OtherPipe->GetPipeConnection1() };
 								for (UFGPipeConnectionComponent* OtherConn : OtherConns)
 								{
@@ -8186,7 +8188,7 @@ void USFSubsystem::OnActorSpawned(AActor* SpawnedActor)
 											Conn->SetConnection(OtherConn);
 											ConnectionsMade++;
 											bConnected = true;
-											UE_LOG(LogSmartFoundations, Log, TEXT("STACKABLE PIPE: Connected %s to %s (Internal)"), 
+											UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("STACKABLE PIPE: Connected %s to %s (Internal)"),
 												*Pipe->GetName(), *OtherPipe->GetName());
 											break;
 										}
@@ -8194,29 +8196,29 @@ void USFSubsystem::OnActorSpawned(AActor* SpawnedActor)
 								}
 								if (bConnected) break;
 							}
-							
+
 							// 2. If not connected, try external world pipes (Physics check for existing pipes)
 							if (!bConnected)
 							{
 								FVector SearchLoc = Conn->GetComponentLocation();
 								UFGPipeConnectionComponentBase* Neighbor = UFGPipeConnectionComponentBase::FindCompatibleOverlappingConnection(
 									Conn, SearchLoc, Pipe, 50.0f, {});
-								
+
 								// Ensure we don't reconnect to something we just built (though loop above should handle it)
 								// and ensure it's not the pipe itself
 								if (Neighbor && !Neighbor->IsConnected() && Neighbor->GetOwner() != Pipe && !IsNewlyBuilt(Neighbor->GetOwner()))
 								{
 									Conn->SetConnection(Neighbor);
 									ConnectionsMade++;
-									UE_LOG(LogSmartFoundations, Log, TEXT("STACKABLE PIPE: Connected %s to %s (External)"), 
+									UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("STACKABLE PIPE: Connected %s to %s (External)"),
 										*Pipe->GetName(), *Neighbor->GetOwner()->GetName());
 								}
 							}
 						}
 					}
-					
-					UE_LOG(LogSmartFoundations, Log, TEXT("STACKABLE PIPE BUILD: Made %d connection(s)"), ConnectionsMade);
-					
+
+					UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("STACKABLE PIPE BUILD: Made %d connection(s)"), ConnectionsMade);
+
 					// PHASE 3: Merge pipe networks
 					if (ConnectionsMade > 0)
 					{
@@ -8231,7 +8233,7 @@ void USFSubsystem::OnActorSpawned(AActor* SpawnedActor)
 								if (Conn0) NetworksToRebuild.Add(Conn0->GetPipeNetworkID());
 								if (Conn1) NetworksToRebuild.Add(Conn1->GetPipeNetworkID());
 							}
-							
+
 							for (int32 NetworkID : NetworksToRebuild)
 							{
 								if (NetworkID != INDEX_NONE)
@@ -8242,16 +8244,16 @@ void USFSubsystem::OnActorSpawned(AActor* SpawnedActor)
 									}
 								}
 							}
-							UE_LOG(LogSmartFoundations, Log, TEXT("STACKABLE PIPE BUILD: Marked %d network(s) for rebuild"), NetworksToRebuild.Num());
+							UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("STACKABLE PIPE BUILD: Marked %d network(s) for rebuild"), NetworksToRebuild.Num());
 						}
 					}
-					
+
 					bPipesAlreadyBuiltForThisPlacement = true;  // Prevent duplicate builds for subsequent poles
 				}
 			}
 		}
 	}
-	
+
 	// ========================================
 	// STACKABLE CONVEYOR POLE AUTO-CONNECT BUILD (Issue #220)
 	// ========================================
@@ -8259,12 +8261,12 @@ void USFSubsystem::OnActorSpawned(AActor* SpawnedActor)
 	// Detection by class name since we don't have a specific buildable base class
 	// NOTE: SpawnedClassName already declared above for pipe support detection
 	// CRITICAL: Must exclude holograms - only detect actual built actors (Build_* prefix)
-	
+
 	bool bIsStackableConveyorPole = (SpawnedClassName.Contains(TEXT("ConveyorPoleStackable")) ||
 	                                SpawnedClassName.Contains(TEXT("ConveyorCeilingAttachment")) ||
 	                                SpawnedClassName.Contains(TEXT("ConveyorPoleWall"))) &&
 	                                SpawnedClassName.StartsWith(TEXT("Build_"));
-	
+
 	// DISABLED: Manual belt spawning causes crashes (array index -1 in Factory_UpdateRadioactivity)
 	// Belts spawned via SpawnActor bypass vanilla's proper initialization.
 	// Belt creation should be handled by the hologram system through preview holograms.
@@ -8272,13 +8274,13 @@ void USFSubsystem::OnActorSpawned(AActor* SpawnedActor)
 	if (false && bIsStackableConveyorPole && bGStackableBeltDataCached && GCachedStackableBeltData.Num() > 0 && !bProcessingGridPlacement)
 	{
 		bProcessingGridPlacement = true;
-		
-		UE_LOG(LogSmartFoundations, Log, TEXT("STACKABLE CONVEYOR POLE AUTO-CONNECT BUILD: Using %d cached belt(s)"), GCachedStackableBeltData.Num());
-		
+
+		UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("STACKABLE CONVEYOR POLE AUTO-CONNECT BUILD: Using %d cached belt(s)"), GCachedStackableBeltData.Num());
+
 		// Move cached data to local for deferred processing
 		TArray<FStackableBeltBuildData> BeltData = MoveTemp(GCachedStackableBeltData);
 		bGStackableBeltDataCached = false;
-		
+
 		// Build belts on next tick (after all poles are spawned)
 		GetWorld()->GetTimerManager().SetTimerForNextTick([this, BeltData]()
 		{
@@ -8288,22 +8290,22 @@ void USFSubsystem::OnActorSpawned(AActor* SpawnedActor)
 				bProcessingGridPlacement = false;
 				return;
 			}
-			
+
 			int32 BuiltCount = 0;
-			
+
 			for (const auto& Data : BeltData)
 			{
 				UFGFactoryConnectionComponent* OutputConn = Data.OutputConnector.Get();
 				UFGFactoryConnectionComponent* InputConn = Data.InputConnector.Get();
-				
+
 				if (!OutputConn || !InputConn)
 				{
 					UE_LOG(LogSmartFoundations, Warning, TEXT("🚧 STACKABLE CONVEYOR POLE: Belt connectors no longer valid"));
 					continue;
 				}
-				
+
 				FVector StartPos = OutputConn->GetComponentLocation();
-				
+
 				// Get belt class from settings
 				int32 ConfigTier = AutoConnectRuntimeSettings.BeltTierMain;
 				if (ConfigTier == 0)
@@ -8311,61 +8313,61 @@ void USFSubsystem::OnActorSpawned(AActor* SpawnedActor)
 					ConfigTier = GetHighestUnlockedBeltTier(LastController.Get());
 				}
 				UClass* BeltClass = GetBeltClassForTier(ConfigTier, LastController.Get());
-				
+
 				if (!BeltClass)
 				{
 					UE_LOG(LogSmartFoundations, Warning, TEXT("🚧 STACKABLE CONVEYOR POLE: Failed to get belt class for tier %d"), ConfigTier);
 					continue;
 				}
-				
+
 				// Spawn actual belt with DEFERRED construction
 				FActorSpawnParameters SpawnParams;
 				SpawnParams.bDeferConstruction = true;
-				
+
 				AFGBuildableConveyorBelt* Belt = World->SpawnActor<AFGBuildableConveyorBelt>(
 					BeltClass,
 					StartPos,
 					FRotator::ZeroRotator,
 					SpawnParams);
-				
+
 				if (!Belt)
 				{
 					UE_LOG(LogSmartFoundations, Warning, TEXT("🚧 STACKABLE CONVEYOR POLE: Failed to spawn belt actor"));
 					continue;
 				}
-				
+
 				// Apply spline data BEFORE FinishSpawning
 				TArray<FSplinePointData>* BeltSplineData = Belt->GetMutableSplinePointData();
 				if (BeltSplineData && Data.SplineData.Num() >= 2)
 				{
 					*BeltSplineData = Data.SplineData;
 				}
-				
+
 				// Finish spawning
 				FTransform BeltTransform(FRotator::ZeroRotator, StartPos);
 				Belt->FinishSpawning(BeltTransform);
-				
+
 				// Finalize belt
 				Belt->OnBuildEffectFinished();
-				
+
 				// Connect the belt endpoints
 				Belt->GetConnection0()->SetConnection(OutputConn);
 				Belt->GetConnection1()->SetConnection(InputConn);
-				
+
 				// NOTE: Do NOT call QueueChainRebuild here!
 				// Vanilla automatically handles chain creation for spawned belts.
 				// Manual chain manipulation causes crashes in Factory_Tick.
-				
-				UE_LOG(LogSmartFoundations, Log, TEXT("🚧 STACKABLE CONVEYOR POLE: ✅ Built Mk%d belt between poles"), ConfigTier);
+
+				UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("🚧 STACKABLE CONVEYOR POLE: ✅ Built Mk%d belt between poles"), ConfigTier);
 				BuiltCount++;
 			}
-			
-			UE_LOG(LogSmartFoundations, Log, TEXT("🚧 STACKABLE CONVEYOR POLE AUTO-CONNECT BUILD: Built %d belt(s)"), BuiltCount);
-			
+
+			UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("🚧 STACKABLE CONVEYOR POLE AUTO-CONNECT BUILD: Built %d belt(s)"), BuiltCount);
+
 			bProcessingGridPlacement = false;
 		});
 	}
-	
+
 	// ========================================
 	// STACKABLE BELT CHILD: Deferred wiring + chain rebuild
 	// ========================================
@@ -8381,35 +8383,35 @@ void USFSubsystem::OnActorSpawned(AActor* SpawnedActor)
 		static TArray<TWeakObjectPtr<AFGBuildableConveyorBelt>> PendingStackableBelts;
 		static TWeakObjectPtr<AFGHologram> LastBeltBuildHologram;
 		static FTimerHandle BeltWiringTimerHandle;
-		
+
 		// Reset tracking when hologram changes
 		if (ActiveHologram.Get() != LastBeltBuildHologram.Get())
 		{
 			LastBeltBuildHologram = ActiveHologram;
 			PendingStackableBelts.Empty();
 		}
-		
+
 		// Check if this belt is from our stackable pole system
 		// Stackable belts are spawned during pole hologram construction
-		if (ActiveHologram.IsValid() && AutoConnectService && 
+		if (ActiveHologram.IsValid() && AutoConnectService &&
 		    USFAutoConnectService::IsBeltSupportHologram(ActiveHologram.Get()))
 		{
 			PendingStackableBelts.Add(StackableBelt);
-			UE_LOG(LogSmartFoundations, Log, TEXT("🚧 STACKABLE BELT SPAWN: Tracking %s for deferred wiring (%d pending)"),
+			UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("🚧 STACKABLE BELT SPAWN: Tracking %s for deferred wiring (%d pending)"),
 				*StackableBelt->GetName(), PendingStackableBelts.Num());
-			
+
 			// Set/reset timer to wire belts on next tick (after all are spawned)
 			GetWorld()->GetTimerManager().ClearTimer(BeltWiringTimerHandle);
 			GetWorld()->GetTimerManager().SetTimerForNextTick([this]()
 			{
 				if (PendingStackableBelts.Num() == 0)
 				{
-					UE_LOG(LogSmartFoundations, Log, TEXT("🚧 STACKABLE BELT CHAIN FIX: No pending belts"));
+					UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("🚧 STACKABLE BELT CHAIN FIX: No pending belts"));
 					return;
 				}
-				
-				UE_LOG(LogSmartFoundations, Log, TEXT("🚧 STACKABLE BELT CHAIN FIX: Processing %d belts..."), PendingStackableBelts.Num());
-				
+
+				UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("🚧 STACKABLE BELT CHAIN FIX: Processing %d belts..."), PendingStackableBelts.Num());
+
 				// ========================================
 				// STEP 1: Collect valid belts
 				// ========================================
@@ -8421,25 +8423,25 @@ void USFSubsystem::OnActorSpawned(AActor* SpawnedActor)
 						ValidBelts.Add(WeakBelt.Get());
 					}
 				}
-				
+
 				if (ValidBelts.Num() == 0)
 				{
-					UE_LOG(LogSmartFoundations, Log, TEXT("🚧 STACKABLE BELT CHAIN FIX: No valid belts remain"));
+					UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("🚧 STACKABLE BELT CHAIN FIX: No valid belts remain"));
 					PendingStackableBelts.Empty();
 					return;
 				}
-				
+
 				// ========================================
 				// STEP 2: Wire belts together (proximity-based)
 				// ========================================
 				int32 ConnectionsMade = 0;
 				const float ConnectionRadius = 100.0f;
-				
+
 				for (AFGBuildableConveyorBelt* Belt : ValidBelts)
 				{
 					UFGFactoryConnectionComponent* Conn0 = Belt->GetConnection0();
 					UFGFactoryConnectionComponent* Conn1 = Belt->GetConnection1();
-					
+
 					// Connect this belt's Conn0 (input) to nearest unconnected Conn1 (output)
 					if (Conn0 && !Conn0->IsConnected())
 					{
@@ -8455,14 +8457,14 @@ void USFSubsystem::OnActorSpawned(AActor* SpawnedActor)
 								{
 									OtherConn1->SetConnection(Conn0);
 									ConnectionsMade++;
-									UE_LOG(LogSmartFoundations, Log, TEXT("🚧 STACKABLE BELT CHAIN FIX: Connected %s.Conn1 -> %s.Conn0 (dist=%.1f)"),
+									UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("🚧 STACKABLE BELT CHAIN FIX: Connected %s.Conn1 -> %s.Conn0 (dist=%.1f)"),
 										*OtherBelt->GetName(), *Belt->GetName(), Dist);
 									break;
 								}
 							}
 						}
 					}
-					
+
 					// Connect this belt's Conn1 (output) to nearest unconnected Conn0 (input)
 					if (Conn1 && !Conn1->IsConnected())
 					{
@@ -8478,7 +8480,7 @@ void USFSubsystem::OnActorSpawned(AActor* SpawnedActor)
 								{
 									Conn1->SetConnection(OtherConn0);
 									ConnectionsMade++;
-									UE_LOG(LogSmartFoundations, Log, TEXT("🚧 STACKABLE BELT CHAIN FIX: Connected %s.Conn1 -> %s.Conn0 (dist=%.1f)"),
+									UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("🚧 STACKABLE BELT CHAIN FIX: Connected %s.Conn1 -> %s.Conn0 (dist=%.1f)"),
 										*Belt->GetName(), *OtherBelt->GetName(), Dist);
 									break;
 								}
@@ -8486,9 +8488,9 @@ void USFSubsystem::OnActorSpawned(AActor* SpawnedActor)
 						}
 					}
 				}
-				
-				UE_LOG(LogSmartFoundations, Log, TEXT("🚧 STACKABLE BELT CHAIN FIX: Made %d connection(s)"), ConnectionsMade);
-				
+
+				UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("🚧 STACKABLE BELT CHAIN FIX: Made %d connection(s)"), ConnectionsMade);
+
 				// Invalidate chain actors so vanilla rebuilds them with correct
 				// topology next frame. Uses chain-level API (RemoveConveyorChainActor)
 				// which is safe from timers — unlike bucket-level APIs:
@@ -8508,7 +8510,7 @@ void USFSubsystem::OnActorSpawned(AActor* SpawnedActor)
 								ChainsToRebuild.Add(Chain);
 						}
 					}
-					
+
 					for (AFGConveyorChainActor* Chain : ChainsToRebuild)
 					{
 						if (IsValid(Chain))
@@ -8516,48 +8518,48 @@ void USFSubsystem::OnActorSpawned(AActor* SpawnedActor)
 							BuildableSub->RemoveConveyorChainActor(Chain);
 						}
 					}
-					
-					UE_LOG(LogSmartFoundations, Log, TEXT("🚧 STACKABLE BELT CHAIN FIX: Invalidated %d chain(s) — vanilla rebuilds next frame"),
+
+					UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("🚧 STACKABLE BELT CHAIN FIX: Invalidated %d chain(s) — vanilla rebuilds next frame"),
 						ChainsToRebuild.Num());
 				}
-				
+
 				PendingStackableBelts.Empty();
 			});
 		}
-		
+
 		// ========================================
 		// AUTO-CONNECT BELT: Deferred manifold wiring
 		// ========================================
 		// Auto-Connect belts are built as children of distributor holograms.
 		// Manifold belts (Output1→Input1) are built BEFORE target distributors,
 		// so we need deferred wiring to connect them after all distributors are built.
-		if (ActiveHologram.IsValid() && AutoConnectService && 
+		if (ActiveHologram.IsValid() && AutoConnectService &&
 		    AutoConnectService->IsDistributorHologram(ActiveHologram.Get()))
 		{
 			static TArray<TWeakObjectPtr<AFGBuildableConveyorBelt>> PendingAutoConnectBelts;
 			static TWeakObjectPtr<AFGHologram> LastAutoConnectHologram;
 			static FTimerHandle AutoConnectWiringTimerHandle;
-			
+
 			// Reset tracking when hologram changes
 			if (ActiveHologram.Get() != LastAutoConnectHologram.Get())
 			{
 				LastAutoConnectHologram = ActiveHologram;
 				PendingAutoConnectBelts.Empty();
 			}
-			
+
 			PendingAutoConnectBelts.Add(StackableBelt);
-			UE_LOG(LogSmartFoundations, Log, TEXT("🎯 AUTO-CONNECT BELT SPAWN: Tracking %s for deferred wiring (%d pending)"),
+			UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("🎯 AUTO-CONNECT BELT SPAWN: Tracking %s for deferred wiring (%d pending)"),
 				*StackableBelt->GetName(), PendingAutoConnectBelts.Num());
-			
+
 			// Set/reset timer to wire belts on next tick (after all distributors are spawned)
 			GetWorld()->GetTimerManager().ClearTimer(AutoConnectWiringTimerHandle);
 			GetWorld()->GetTimerManager().SetTimerForNextTick([this]()
 			{
-				UE_LOG(LogSmartFoundations, Log, TEXT("🎯 AUTO-CONNECT BELT WIRING: Processing %d belt(s)..."), PendingAutoConnectBelts.Num());
-				
+				UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("🎯 AUTO-CONNECT BELT WIRING: Processing %d belt(s)..."), PendingAutoConnectBelts.Num());
+
 				int32 ConnectionsMade = 0;
 				const float ConnectionRadius = 100.0f;
-				
+
 				// Clean up invalid weak pointers and collect valid belts
 				TArray<AFGBuildableConveyorBelt*> ValidBelts;
 				for (const auto& WeakBelt : PendingAutoConnectBelts)
@@ -8567,33 +8569,33 @@ void USFSubsystem::OnActorSpawned(AActor* SpawnedActor)
 						ValidBelts.Add(WeakBelt.Get());
 					}
 				}
-				
+
 				// Wire each belt's unconnected endpoints to nearby built connectors
 				for (AFGBuildableConveyorBelt* Belt : ValidBelts)
 				{
 					UFGFactoryConnectionComponent* Conn0 = Belt->GetConnection0();  // Input
 					UFGFactoryConnectionComponent* Conn1 = Belt->GetConnection1();  // Output
-					
+
 					// Wire Conn0 (belt input) to nearby OUTPUT connector on built actors
 					if (Conn0 && !Conn0->IsConnected())
 					{
 						FVector SearchLoc = Conn0->GetComponentLocation();
 						UFGFactoryConnectionComponent* BestMatch = nullptr;
 						float BestDist = ConnectionRadius;
-						
+
 						for (TActorIterator<AFGBuildable> It(GetWorld()); It; ++It)
 						{
 							AFGBuildable* Buildable = *It;
 							if (Buildable == Belt) continue;
-							
+
 							TArray<UFGFactoryConnectionComponent*> Connectors;
 							Buildable->GetComponents<UFGFactoryConnectionComponent>(Connectors);
-							
+
 							for (UFGFactoryConnectionComponent* Conn : Connectors)
 							{
 								if (!Conn || Conn->IsConnected()) continue;
 								if (Conn->GetDirection() != EFactoryConnectionDirection::FCD_OUTPUT) continue;
-								
+
 								float Dist = FVector::Dist(SearchLoc, Conn->GetComponentLocation());
 								if (Dist < BestDist)
 								{
@@ -8602,36 +8604,36 @@ void USFSubsystem::OnActorSpawned(AActor* SpawnedActor)
 								}
 							}
 						}
-						
+
 						if (BestMatch)
 						{
 							Conn0->SetConnection(BestMatch);
 							ConnectionsMade++;
-							UE_LOG(LogSmartFoundations, Log, TEXT("🎯 AUTO-CONNECT BELT: ✅ Wired %s.Conn0 → %s.%s (dist=%.1f)"),
+							UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("🎯 AUTO-CONNECT BELT: ✅ Wired %s.Conn0 → %s.%s (dist=%.1f)"),
 								*Belt->GetName(), *BestMatch->GetOwner()->GetName(), *BestMatch->GetName(), BestDist);
 						}
 					}
-					
+
 					// Wire Conn1 (belt output) to nearby INPUT connector on built actors
 					if (Conn1 && !Conn1->IsConnected())
 					{
 						FVector SearchLoc = Conn1->GetComponentLocation();
 						UFGFactoryConnectionComponent* BestMatch = nullptr;
 						float BestDist = ConnectionRadius;
-						
+
 						for (TActorIterator<AFGBuildable> It(GetWorld()); It; ++It)
 						{
 							AFGBuildable* Buildable = *It;
 							if (Buildable == Belt) continue;
-							
+
 							TArray<UFGFactoryConnectionComponent*> Connectors;
 							Buildable->GetComponents<UFGFactoryConnectionComponent>(Connectors);
-							
+
 							for (UFGFactoryConnectionComponent* Conn : Connectors)
 							{
 								if (!Conn || Conn->IsConnected()) continue;
 								if (Conn->GetDirection() != EFactoryConnectionDirection::FCD_INPUT) continue;
-								
+
 								float Dist = FVector::Dist(SearchLoc, Conn->GetComponentLocation());
 								if (Dist < BestDist)
 								{
@@ -8640,23 +8642,23 @@ void USFSubsystem::OnActorSpawned(AActor* SpawnedActor)
 								}
 							}
 						}
-						
+
 						if (BestMatch)
 						{
 							Conn1->SetConnection(BestMatch);
 							ConnectionsMade++;
-							UE_LOG(LogSmartFoundations, Log, TEXT("🎯 AUTO-CONNECT BELT: ✅ Wired %s.Conn1 → %s.%s (dist=%.1f)"),
+							UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("🎯 AUTO-CONNECT BELT: ✅ Wired %s.Conn1 → %s.%s (dist=%.1f)"),
 								*Belt->GetName(), *BestMatch->GetOwner()->GetName(), *BestMatch->GetName(), BestDist);
 						}
 					}
 				}
-				
-				UE_LOG(LogSmartFoundations, Log, TEXT("🎯 AUTO-CONNECT BELT WIRING: Made %d connection(s)"), ConnectionsMade);
+
+				UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("🎯 AUTO-CONNECT BELT WIRING: Made %d connection(s)"), ConnectionsMade);
 				PendingAutoConnectBelts.Empty();
 			});
 		}
 	}
-	
+
 	// Handle power pole construction for auto-connect
 	// CRITICAL: Only process power poles if we have active Smart! power line previews
 	// This mirrors the belt/pipe pattern and prevents processing save-loaded poles
@@ -8669,46 +8671,46 @@ void USFSubsystem::OnActorSpawned(AActor* SpawnedActor)
 		bool bHasDeferredConnections = HasDeferredPoleConnections();
 		bool bHasPlannedPoleConnections = PlannedPoleConnections.Num() > 0;
 		bool bHasPlannedBuildingConnections = PlannedBuildingConnections.Num() > 0;
-		
+
 		// If we have ANY planned connections but nothing committed yet, commit NOW
 		// This handles the race condition where pole spawns before hologram destruction
-		if ((bHasPlannedPoleConnections || bHasPlannedBuildingConnections) && 
+		if ((bHasPlannedPoleConnections || bHasPlannedBuildingConnections) &&
 		    !bHasBuildingConnections && !bHasDeferredConnections)
 		{
-			UE_LOG(LogSmartFoundations, Log, TEXT(" OnActorSpawned: Early commit - pole spawned before hologram destruction! PlannedBuildings=%d, PlannedPoles=%d"), 
+			UE_LOG(LogSmartFoundations, VeryVerbose, TEXT(" OnActorSpawned: Early commit - pole spawned before hologram destruction! PlannedBuildings=%d, PlannedPoles=%d"),
 				PlannedBuildingConnections.Num(), PlannedPoleConnections.Num());
 			CommitBuildingConnections();
 			// Refresh the flags after commit
 			bHasBuildingConnections = CommittedBuildingConnections.Num() > 0;
 			bHasDeferredConnections = HasDeferredPoleConnections();
 		}
-		
+
 		if (!bHasBuildingConnections && !bHasDeferredConnections)
 		{
 			// No active Smart! power auto-connect session
-			UE_LOG(LogSmartFoundations, VeryVerbose, TEXT(" OnActorSpawned: Power pole %s skipped - no building connections (%d) and no deferred (%d)"), 
+			UE_LOG(LogSmartFoundations, VeryVerbose, TEXT(" OnActorSpawned: Power pole %s skipped - no building connections (%d) and no deferred (%d)"),
 				*PowerPole->GetName(), CommittedBuildingConnections.Num(), DeferredPoleConnections.Num());
 			return;
 		}
-		
-		UE_LOG(LogSmartFoundations, Log, TEXT(" OnActorSpawned: Power pole detected - Buildings=%d, DeferredPoleConnections=%d"), 
-			CommittedBuildingConnections.Num(), 
+
+		UE_LOG(LogSmartFoundations, VeryVerbose, TEXT(" OnActorSpawned: Power pole detected - Buildings=%d, DeferredPoleConnections=%d"),
+			CommittedBuildingConnections.Num(),
 			DeferredPoleConnections.Num());
-		
-		UE_LOG(LogSmartFoundations, Log, TEXT(" OnActorSpawned: Power pole built - checking for deferred auto-connections"));
-		
+
+		UE_LOG(LogSmartFoundations, VeryVerbose, TEXT(" OnActorSpawned: Power pole built - checking for deferred auto-connections"));
+
 		// Register as grid-built pole (guard above ensures we only get here for Smart! placed poles)
 		RegisterGridBuiltPowerPole(PowerPole);
-		
+
 		// Check if power connections are ready (like arrow asset system)
 		if (ArePowerConnectionsReady(PowerPole))
 		{
-			UE_LOG(LogSmartFoundations, Log, TEXT("⚡ OnActorSpawned: Power connections ready - creating auto-connections immediately"));
+			UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("⚡ OnActorSpawned: Power connections ready - creating auto-connections immediately"));
 			OnPowerPoleBuilt(PowerPole);
 		}
 		else
 		{
-			UE_LOG(LogSmartFoundations, Log, TEXT("⚡ OnActorSpawned: Power connections not ready - queuing for deferred processing"));
+			UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("⚡ OnActorSpawned: Power connections not ready - queuing for deferred processing"));
 			QueuePowerPoleForDeferredConnection(PowerPole);
 		}
 	}
@@ -8722,10 +8724,10 @@ TSubclassOf<UFGRecipe> USFSubsystem::FindRecipeForSpawnedBuilding(AFGBuildableMa
 		UE_LOG(LogSmartFoundations, Warning, TEXT("FindRecipeForSpawnedBuilding: SpawnedBuilding is invalid"));
 		return nullptr;
 	}
-	
+
 	// Get the hologram registry to search for matching holograms (now uses weak pointers)
 	const TMap<TWeakObjectPtr<AFGHologram>, FSFHologramData>& HologramRegistry = USFHologramDataRegistry::GetRegistry();
-	
+
 	// Copy registry to local array to prevent iterator invalidation during iteration
 	TArray<TPair<TWeakObjectPtr<AFGHologram>, FSFHologramData>> RegistryEntries;
 	RegistryEntries.Reserve(HologramRegistry.Num());
@@ -8733,32 +8735,32 @@ TSubclassOf<UFGRecipe> USFSubsystem::FindRecipeForSpawnedBuilding(AFGBuildableMa
 	{
 		RegistryEntries.Add(HologramPair);
 	}
-	
+
 	for (const auto& HologramPair : RegistryEntries)
 	{
 		// Use weak pointer for deterministic safety
 		TWeakObjectPtr<AFGHologram> WeakHologram = HologramPair.Key;
 		const FSFHologramData& Data = HologramPair.Value;
-		
+
 		// Check if hologram is still valid
 		if (!WeakHologram.IsValid())
 		{
 			UE_LOG(LogSmartFoundations, Warning, TEXT("FindRecipeForSpawnedBuilding: Found invalid hologram in registry"));
 			continue;
 		}
-		
+
 		// CRITICAL: Deterministic weak pointer validation (works for ANY address state)
 		if (!WeakHologram.IsValid())
 		{
 			continue;
 		}
-		
+
 		// Enhanced recipe validation
 		if (!Data.StoredRecipe || !Data.StoredRecipe.Get())
 		{
 			continue;
 		}
-		
+
 		// Check if this recipe can be produced in the spawned building
 		TArray< TSubclassOf< UObject > > Producers = UFGRecipe::GetProducedIn(Data.StoredRecipe);
 		bool bCanProduceInBuilding = false;
@@ -8770,7 +8772,7 @@ TSubclassOf<UFGRecipe> USFSubsystem::FindRecipeForSpawnedBuilding(AFGBuildableMa
 				break;
 			}
 		}
-		
+
 		if (bCanProduceInBuilding)
 		{
 			// CRITICAL: Final deterministic weak pointer validation (atomic safety)
@@ -8778,25 +8780,25 @@ TSubclassOf<UFGRecipe> USFSubsystem::FindRecipeForSpawnedBuilding(AFGBuildableMa
 			{
 				continue;
 			}
-			
+
 			// Get fresh hologram pointer (guaranteed valid by weak pointer check)
 			AFGHologram* ValidHologram = WeakHologram.Get();
-			
+
 			// Check spatial proximity (within 500cm) - now safe to access
 			float Distance = FVector::Dist(ValidHologram->GetActorLocation(), SpawnedBuilding->GetActorLocation());
 			if (Distance < 500.0f)
 			{
-				UE_LOG(LogSmartFoundations, Log, TEXT("FindRecipeForSpawnedBuilding: Found matching hologram %s at distance %f with stored recipe %s"), 
+				UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("FindRecipeForSpawnedBuilding: Found matching hologram %s at distance %f with stored recipe %s"),
 					*GetNameSafe(ValidHologram), Distance, *GetNameSafe(Data.StoredRecipe));
-				
+
 				// Clear the hologram data after successful match
 				USFHologramDataRegistry::ClearData(ValidHologram);
-				
+
 				return Data.StoredRecipe;
 			}
 		}
 	}
-	
+
 	// No matching hologram found
 	return nullptr;
 }
@@ -8811,24 +8813,24 @@ void USFSubsystem::ApplyRecipeDelayed(AFGBuildableManufacturer* ManufacturerBuil
 }
 
 // ========================================
-// Auto-Connect Production Implementation  
+// Auto-Connect Production Implementation
 // ========================================
 
 TArray<AFGBuildable*> USFSubsystem::FindNearbyBuildings(FVector Center, float Radius)
 {
 	TArray<AFGBuildable*> NearbyBuildings;
-	
+
 	UWorld* World = GetWorld();
 	if (!World)
 	{
 		UE_LOG(LogSmartFoundations, Warning, TEXT("FindNearbyBuildings: No world context"));
 		return NearbyBuildings;
 	}
-	
+
 	// Simple sphere trace to find nearby buildables
 	FCollisionShape SphereShape = FCollisionShape::MakeSphere(Radius);
 	FCollisionQueryParams QueryParams;
-	
+
 	TArray<FOverlapResult> OverlapResults;
 	bool bFoundOverlaps = World->OverlapMultiByChannel(
 		OverlapResults,
@@ -8838,7 +8840,7 @@ TArray<AFGBuildable*> USFSubsystem::FindNearbyBuildings(FVector Center, float Ra
 		SphereShape,
 		QueryParams
 	);
-	
+
 	if (bFoundOverlaps)
 	{
 		for (const FOverlapResult& Result : OverlapResults)
@@ -8850,11 +8852,11 @@ TArray<AFGBuildable*> USFSubsystem::FindNearbyBuildings(FVector Center, float Ra
 			}
 		}
 	}
-	
+
 	// Issue #269: Diagnostic logging at Log level to trace building search results
-	UE_LOG(LogSmartFoundations, Log, TEXT("FindNearbyBuildings: Center=%s Radius=%.0f Overlaps=%d Buildings=%d"),
+	UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("FindNearbyBuildings: Center=%s Radius=%.0f Overlaps=%d Buildings=%d"),
 		*Center.ToString(), Radius, OverlapResults.Num(), NearbyBuildings.Num());
-	
+
 	return NearbyBuildings;
 }
 
@@ -8878,13 +8880,13 @@ USFAutoConnectOrchestrator* USFSubsystem::GetOrCreateOrchestrator(AFGHologram* P
 	// Create new orchestrator
 	USFAutoConnectOrchestrator* NewOrchestrator = NewObject<USFAutoConnectOrchestrator>(this);
 	NewOrchestrator->Initialize(ParentHologram, AutoConnectService);
-	
+
 	// Store in map
 	AutoConnectOrchestrators.Add(ParentHologram, NewOrchestrator);
-	
-	UE_LOG(LogSmartFoundations, Log, TEXT("🎯 Created new Auto-Connect Orchestrator for %s"), 
+
+	UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("🎯 Created new Auto-Connect Orchestrator for %s"),
 		*ParentHologram->GetName());
-	
+
 	return NewOrchestrator;
 }
 
@@ -8895,14 +8897,14 @@ void USFSubsystem::OnDistributorHologramUpdated(AFGHologram* DistributorHologram
 		UE_LOG(LogSmartFoundations, Warning, TEXT("OnDistributorHologramUpdated: DistributorHologram is null"));
 		return;
 	}
-	
+
 	// Issue #198: Skip auto-connect if disabled via double-tap
 	if (bDisableSmartForNextAction)
 	{
-		UE_LOG(LogSmartFoundations, Log, TEXT("⏸️ Auto-Connect skipped - Smart disabled for current action"));
+		UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("⏸️ Auto-Connect skipped - Smart disabled for current action"));
 		return;
 	}
-	
+
 	// Use orchestrator for coordinated evaluation (Refactor: Auto-Connect Orchestrator)
 	USFAutoConnectOrchestrator* Orchestrator = GetOrCreateOrchestrator(DistributorHologram);
 	if (!Orchestrator)
@@ -8910,7 +8912,7 @@ void USFSubsystem::OnDistributorHologramUpdated(AFGHologram* DistributorHologram
 		UE_LOG(LogSmartFoundations, Warning, TEXT("Auto-Connect Orchestrator not available - skipping distributor update"));
 		return;
 	}
-	
+
 	// Issue #269 FIX: For single distributors (no Smart! grid children), use OnGridChanged()
 	// which does force-recreate evaluation. Without children, OnGridChanged never fires naturally
 	// (no grid updates), so the orchestrator only gets non-forced OnDistributorsMoved() calls
@@ -8928,7 +8930,7 @@ void USFSubsystem::OnDistributorHologramUpdated(AFGHologram* DistributorHologram
 				break;
 			}
 		}
-		
+
 		if (!bHasSmartChildren)
 		{
 			// Single distributor (no grid children) - force recreate for reliable tracking
@@ -8940,10 +8942,10 @@ void USFSubsystem::OnDistributorHologramUpdated(AFGHologram* DistributorHologram
 			Orchestrator->OnDistributorsMoved();
 		}
 	}
-	
+
 	// Also update pipe previews if this is a pipeline junction (evaluation guard prevents recursion)
 	Orchestrator->OnPipeJunctionsMoved();
-	
+
 	UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("🎯 Orchestrator: Distributors moved (parent update)"));
 }
 
@@ -9007,19 +9009,19 @@ void USFSubsystem::AnalyzeNearbyPipeSplines(float Radius)
 
 	FVector PlayerLocation = Player->GetActorLocation();
 
-	UE_LOG(LogSmartFoundations, Display, TEXT("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"));
-	UE_LOG(LogSmartFoundations, Display, TEXT("🔍 SMART! PIPE SPLINE ANALYZER"));
-	UE_LOG(LogSmartFoundations, Display, TEXT("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"));
-	UE_LOG(LogSmartFoundations, Display, TEXT("Player Location: %s"), *PlayerLocation.ToString());
-	UE_LOG(LogSmartFoundations, Display, TEXT("Search Radius: %.1fm"), Radius / 100.0f);
-	UE_LOG(LogSmartFoundations, Display, TEXT("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"));
+	UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"));
+	UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("🔍 SMART! PIPE SPLINE ANALYZER"));
+	UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"));
+	UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("Player Location: %s"), *PlayerLocation.ToString());
+	UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("Search Radius: %.1fm"), Radius / 100.0f);
+	UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"));
 
 	// Use the analyzer utility (analyzes both pipes and belts)
 	FSFSplineAnalyzer::AnalyzeNearLocation(World, PlayerLocation, Radius);
 
-	UE_LOG(LogSmartFoundations, Display, TEXT("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"));
-	UE_LOG(LogSmartFoundations, Display, TEXT("🔍 Analysis complete. Check logs for detailed spline data."));
-	UE_LOG(LogSmartFoundations, Display, TEXT("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"));
+	UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"));
+	UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("🔍 Analysis complete. Check logs for detailed spline data."));
+	UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"));
 }
 
 void USFSubsystem::OnPowerPoleBuilt(AFGBuildablePowerPole* BuiltPole)
@@ -9030,19 +9032,19 @@ void USFSubsystem::OnPowerPoleBuilt(AFGBuildablePowerPole* BuiltPole)
 		return;
 	}
 
-	UE_LOG(LogSmartFoundations, Log, TEXT("⚡ OnPowerPoleBuilt: Power pole built - creating connections"));
+	UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("⚡ OnPowerPoleBuilt: Power pole built - creating connections"));
 
 	// NOTE: Wire costs are now represented by real child wire holograms (preview children).
 	// Vanilla deducts the combined cost (pole + child wires) when the hologram is built.
 	// We must NOT manually deduct wire costs here to avoid double-charging.
 	if (!bPowerCostsDeductedThisCycle && AutoConnectService)
 	{
-		UE_LOG(LogSmartFoundations, Log, TEXT("⚡ OnPowerPoleBuilt: First pole of cycle - wire costs already deducted via child hologram aggregation"));
+		UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("⚡ OnPowerPoleBuilt: First pole of cycle - wire costs already deducted via child hologram aggregation"));
 		bPowerCostsDeductedThisCycle = true;  // Mark as handled (vanilla already deducted)
 	}
 	else if (bPowerCostsDeductedThisCycle)
 	{
-		UE_LOG(LogSmartFoundations, Log, TEXT("⚡ OnPowerPoleBuilt: Child pole - wire costs already deducted by first pole"));
+		UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("⚡ OnPowerPoleBuilt: Child pole - wire costs already deducted by first pole"));
 	}
 
 	// Forward to power auto-connect manager (with costs already deducted)
@@ -9067,10 +9069,10 @@ bool USFSubsystem::ArePowerConnectionsReady(AFGBuildablePowerPole* PowerPole)
 	// Check if power connection components are initialized
 	const TArray<UFGPowerConnectionComponent*>& PowerConnections = PowerPole->GetPowerConnections();
 	bool bReady = PowerConnections.Num() > 0;
-	
-	UE_LOG(LogSmartFoundations, Log, TEXT("⚡ ArePowerConnectionsReady: %s - Connections=%d, Ready=%s"), 
+
+	UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("⚡ ArePowerConnectionsReady: %s - Connections=%d, Ready=%s"),
 		*PowerPole->GetName(), PowerConnections.Num(), bReady ? TEXT("true") : TEXT("false"));
-	
+
 	return bReady;
 }
 
@@ -9090,11 +9092,11 @@ void USFSubsystem::QueuePowerPoleForDeferredConnection(AFGBuildablePowerPole* Po
 		{
 			CommitBuildingConnections();
 		}
-		
+
 		PendingPowerPoleConnections.Add(PowerPole);
-		UE_LOG(LogSmartFoundations, Log, TEXT("⚡ QueuePowerPoleForDeferredConnection: Added %s to queue (total: %d)"), 
+		UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("⚡ QueuePowerPoleForDeferredConnection: Added %s to queue (total: %d)"),
 			*PowerPole->GetName(), PendingPowerPoleConnections.Num());
-		
+
 		// Set timer to process deferred connections (like arrow system)
 		UWorld* World = GetWorld();
 		if (World && !PowerPoleDeferredTimer.IsValid())
@@ -9106,8 +9108,8 @@ void USFSubsystem::QueuePowerPoleForDeferredConnection(AFGBuildablePowerPole* Po
 				0.1f,  // Check every 100ms
 				true   // Loop until all processed
 			);
-			
-			UE_LOG(LogSmartFoundations, Log, TEXT("⚡ QueuePowerPoleForDeferredConnection: Set deferred timer (100ms interval)"));
+
+			UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("⚡ QueuePowerPoleForDeferredConnection: Set deferred timer (100ms interval)"));
 		}
 	}
 }
@@ -9123,17 +9125,17 @@ void USFSubsystem::ProcessDeferredPowerPoleConnections()
 			World->GetTimerManager().ClearTimer(PowerPoleDeferredTimer);
 			PowerPoleDeferredTimer.Invalidate();
 		}
-		
+
 		// Reset the cost deduction flag for next build cycle
 		bPowerCostsDeductedThisCycle = false;
-		
+
 		return;
 	}
 
 	// Process each pending pole (limit to prevent spam)
 	int32 MaxPolesPerTick = 3;
 	int32 ProcessedCount = 0;
-	
+
 	for (int32 i = PendingPowerPoleConnections.Num() - 1; i >= 0 && ProcessedCount < MaxPolesPerTick; i--)
 	{
 		TWeakObjectPtr<AFGBuildablePowerPole> WeakPole = PendingPowerPoleConnections[i];
@@ -9145,16 +9147,16 @@ void USFSubsystem::ProcessDeferredPowerPoleConnections()
 		}
 
 		AFGBuildablePowerPole* PowerPole = WeakPole.Get();
-		
+
 		// Check if connections are ready now
 		if (ArePowerConnectionsReady(PowerPole))
 		{
-			UE_LOG(LogSmartFoundations, Log, TEXT("⚡ ProcessDeferredPowerPoleConnections: %s is now ready - creating connections"), 
+			UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("⚡ ProcessDeferredPowerPoleConnections: %s is now ready - creating connections"),
 				*PowerPole->GetName());
-			
+
 			// Process the pole
 			OnPowerPoleBuilt(PowerPole);
-			
+
 			// Remove from pending queue
 			PendingPowerPoleConnections.RemoveAt(i);
 			ProcessedCount++;
@@ -9175,25 +9177,25 @@ void USFSubsystem::ProcessDeferredPowerPoleConnections()
 void USFSubsystem::RegisterGridBuiltPowerPole(AFGBuildablePowerPole* PowerPole)
 {
 	if (!PowerPole) return;
-	
+
 	// Cleanup invalid entries first
 	CleanupGridBuiltPowerPoles();
-	
+
 	// Add to registry if not already present
 	if (!GridBuiltPowerPoles.Contains(PowerPole))
 	{
 		GridBuiltPowerPoles.Add(PowerPole);
-		UE_LOG(LogSmartFoundations, Log, TEXT("⚡ RegisterGridBuiltPowerPole: Registered %s as grid-built"), *PowerPole->GetName());
+		UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("⚡ RegisterGridBuiltPowerPole: Registered %s as grid-built"), *PowerPole->GetName());
 	}
 }
 
 bool USFSubsystem::IsGridBuiltPowerPole(AFGBuildablePowerPole* PowerPole)
 {
 	if (!PowerPole) return false;
-	
+
 	// Cleanup invalid entries first
 	CleanupGridBuiltPowerPoles();
-	
+
 	return GridBuiltPowerPoles.Contains(PowerPole);
 }
 
@@ -9226,20 +9228,20 @@ void USFSubsystem::CacheStackablePipeHologramPositions(const TArray<AFGHologram*
 			PendingStackablePipeHologramPositions.Add(Support->GetActorLocation());
 		}
 	}
-	
+
 	// Store parent coordinate system for sorting spawned actors
 	if (ParentHologram)
 	{
 		PendingStackablePipeParentPosition = ParentHologram->GetActorLocation();
 		PendingStackablePipeScaleAxis = ParentHologram->GetActorForwardVector();
 	}
-	
+
 	// Set expected count and enable deferred build
 	StackablePipeSupportExpectedCount = PendingStackablePipeHologramPositions.Num();
 	StackablePipeSupportSpawnedCount = 0;
 	bStackablePipeBuildPending = (StackablePipeSupportExpectedCount >= 2);
-	
-	UE_LOG(LogSmartFoundations, Log, TEXT("🔧 STACKABLE PIPE: Cached %d hologram positions for deferred build (bPending=%d)"), 
+
+	UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("🔧 STACKABLE PIPE: Cached %d hologram positions for deferred build (bPending=%d)"),
 		StackablePipeSupportExpectedCount, bStackablePipeBuildPending);
 }
 
@@ -9264,26 +9266,26 @@ void USFSubsystem::RegisterPipeForDeferredWiring(AFGBuildablePipeline* Pipe)
 	{
 		return;
 	}
-	
+
 	// Static tracking arrays - persist across calls within a build operation
 	static TArray<TWeakObjectPtr<AFGBuildablePipeline>> PendingPipes;
 	static FTimerHandle PipeWiringTimerHandle;
-	
+
 	// Track this pipe
 	PendingPipes.Add(Pipe);
-	
-	UE_LOG(LogSmartFoundations, Log, TEXT("🔧 PIPE AUTO-CONNECT REGISTER: %s queued for deferred wiring (%d pending)"),
+
+	UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("🔧 PIPE AUTO-CONNECT REGISTER: %s queued for deferred wiring (%d pending)"),
 		*Pipe->GetName(), PendingPipes.Num());
-	
+
 	// Set/reset timer to wire pipes on next tick (after all junctions are spawned)
 	GetWorld()->GetTimerManager().ClearTimer(PipeWiringTimerHandle);
 	GetWorld()->GetTimerManager().SetTimerForNextTick([this]()
 	{
-		UE_LOG(LogSmartFoundations, Log, TEXT("🔧 PIPE AUTO-CONNECT DEFERRED WIRING: Processing %d pipe(s)..."), PendingPipes.Num());
-		
+		UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("🔧 PIPE AUTO-CONNECT DEFERRED WIRING: Processing %d pipe(s)..."), PendingPipes.Num());
+
 		int32 ConnectionsMade = 0;
 		const float ConnectionRadius = 100.0f;  // 1m tolerance for connector matching
-		
+
 		// Collect valid pipes
 		TArray<AFGBuildablePipeline*> ValidPipes;
 		for (const auto& WeakPipe : PendingPipes)
@@ -9293,34 +9295,34 @@ void USFSubsystem::RegisterPipeForDeferredWiring(AFGBuildablePipeline* Pipe)
 				ValidPipes.Add(WeakPipe.Get());
 			}
 		}
-		
+
 		// Wire each pipe's unconnected endpoints to nearby built connectors
 		for (AFGBuildablePipeline* Pipe : ValidPipes)
 		{
 			UFGPipeConnectionComponent* Conn0 = Pipe->GetPipeConnection0();
 			UFGPipeConnectionComponent* Conn1 = Pipe->GetPipeConnection1();
-			
+
 			// Wire Conn0 to nearby unconnected pipe connector
 			if (Conn0 && !Conn0->IsConnected())
 			{
 				FVector SearchLoc = Conn0->GetComponentLocation();
 				UFGPipeConnectionComponent* BestMatch = nullptr;
 				float BestDist = ConnectionRadius;
-				
+
 				for (TActorIterator<AFGBuildable> It(GetWorld()); It; ++It)
 				{
 					AFGBuildable* Buildable = *It;
 					if (Buildable == Pipe) continue;
-					
+
 					TArray<UFGPipeConnectionComponent*> Connectors;
 					Buildable->GetComponents<UFGPipeConnectionComponent>(Connectors);
-					
+
 					for (UFGPipeConnectionComponent* Conn : Connectors)
 					{
 						if (!Conn || Conn->IsConnected()) continue;
-						
+
 						float Dist = FVector::Dist(SearchLoc, Conn->GetComponentLocation());
-						
+
 						// Special case for floor holes (passthroughs): their connector is at the center,
 						// but the pipe ends at the foundation surface. Allow vertical gap for exact XY matches.
 						if (Buildable->IsA(AFGBuildablePassthrough::StaticClass()))
@@ -9328,7 +9330,7 @@ void USFSubsystem::RegisterPipeForDeferredWiring(AFGBuildablePipeline* Pipe)
 							FVector ConnLoc = Conn->GetComponentLocation();
 							float DistXY = FVector::Dist2D(SearchLoc, ConnLoc);
 							float DistZ = FMath::Abs(SearchLoc.Z - ConnLoc.Z);
-							
+
 							// If perfectly aligned vertically and within typical foundation thickness
 							if (DistXY < 10.0f && DistZ <= 450.0f)
 							{
@@ -9336,7 +9338,7 @@ void USFSubsystem::RegisterPipeForDeferredWiring(AFGBuildablePipeline* Pipe)
 								Dist = DistXY;
 							}
 						}
-						
+
 						if (Dist < BestDist)
 						{
 							BestDist = Dist;
@@ -9344,12 +9346,12 @@ void USFSubsystem::RegisterPipeForDeferredWiring(AFGBuildablePipeline* Pipe)
 						}
 					}
 				}
-				
+
 				if (BestMatch)
 				{
 					Conn0->SetConnection(BestMatch);
 					ConnectionsMade++;
-					UE_LOG(LogSmartFoundations, Log, TEXT("PIPE AUTO-CONNECT: Wired %s.Conn0 → %s.%s (dist=%.1f)"),
+					UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("PIPE AUTO-CONNECT: Wired %s.Conn0 → %s.%s (dist=%.1f)"),
 						*Pipe->GetName(), *BestMatch->GetOwner()->GetName(), *BestMatch->GetName(), BestDist);
 				}
 				else
@@ -9358,28 +9360,28 @@ void USFSubsystem::RegisterPipeForDeferredWiring(AFGBuildablePipeline* Pipe)
 						*Pipe->GetName(), *SearchLoc.ToString());
 				}
 			}
-			
+
 			// Wire Conn1 to nearby unconnected pipe connector
 			if (Conn1 && !Conn1->IsConnected())
 			{
 				FVector SearchLoc = Conn1->GetComponentLocation();
 				UFGPipeConnectionComponent* BestMatch = nullptr;
 				float BestDist = ConnectionRadius;
-				
+
 				for (TActorIterator<AFGBuildable> It(GetWorld()); It; ++It)
 				{
 					AFGBuildable* Buildable = *It;
 					if (Buildable == Pipe) continue;
-					
+
 					TArray<UFGPipeConnectionComponent*> Connectors;
 					Buildable->GetComponents<UFGPipeConnectionComponent>(Connectors);
-					
+
 					for (UFGPipeConnectionComponent* Conn : Connectors)
 					{
 						if (!Conn || Conn->IsConnected()) continue;
-						
+
 						float Dist = FVector::Dist(SearchLoc, Conn->GetComponentLocation());
-						
+
 						// Special case for floor holes (passthroughs): their connector is at the center,
 						// but the pipe ends at the foundation surface. Allow vertical gap for exact XY matches.
 						if (Buildable->IsA(AFGBuildablePassthrough::StaticClass()))
@@ -9387,7 +9389,7 @@ void USFSubsystem::RegisterPipeForDeferredWiring(AFGBuildablePipeline* Pipe)
 							FVector ConnLoc = Conn->GetComponentLocation();
 							float DistXY = FVector::Dist2D(SearchLoc, ConnLoc);
 							float DistZ = FMath::Abs(SearchLoc.Z - ConnLoc.Z);
-							
+
 							// If perfectly aligned vertically and within typical foundation thickness
 							if (DistXY < 10.0f && DistZ <= 450.0f)
 							{
@@ -9395,7 +9397,7 @@ void USFSubsystem::RegisterPipeForDeferredWiring(AFGBuildablePipeline* Pipe)
 								Dist = DistXY;
 							}
 						}
-						
+
 						if (Dist < BestDist)
 						{
 							BestDist = Dist;
@@ -9403,17 +9405,17 @@ void USFSubsystem::RegisterPipeForDeferredWiring(AFGBuildablePipeline* Pipe)
 						}
 					}
 				}
-				
+
 				if (BestMatch)
 				{
 					Conn1->SetConnection(BestMatch);
 					ConnectionsMade++;
-					UE_LOG(LogSmartFoundations, Log, TEXT("🔧 PIPE AUTO-CONNECT: ✅ Wired %s.Conn1 → %s.%s (dist=%.1f)"),
+					UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("🔧 PIPE AUTO-CONNECT: ✅ Wired %s.Conn1 → %s.%s (dist=%.1f)"),
 						*Pipe->GetName(), *BestMatch->GetOwner()->GetName(), *BestMatch->GetName(), BestDist);
 				}
 			}
 		}
-		
+
 		// Merge pipe networks for connected pipes
 		if (ConnectionsMade > 0)
 		{
@@ -9436,8 +9438,8 @@ void USFSubsystem::RegisterPipeForDeferredWiring(AFGBuildablePipeline* Pipe)
 				}
 			}
 		}
-		
-		UE_LOG(LogSmartFoundations, Log, TEXT("🔧 PIPE AUTO-CONNECT DEFERRED WIRING: Made %d connection(s) for %d pipe(s)"), 
+
+		UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("🔧 PIPE AUTO-CONNECT DEFERRED WIRING: Made %d connection(s) for %d pipe(s)"),
 			ConnectionsMade, ValidPipes.Num());
 		PendingPipes.Empty();
 	});
@@ -9454,12 +9456,12 @@ void USFSubsystem::QueueChainRebuild(AFGBuildableConveyorBelt* Belt)
 	{
 		return;
 	}
-	
+
 	PendingChainRebuilds.Add(Belt);
-	
-	UE_LOG(LogSmartFoundations, Log, TEXT("⛓️ CHAIN REBUILD: Queued %s for deferred chain rebuild (pending: %d)"),
+
+	UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("⛓️ CHAIN REBUILD: Queued %s for deferred chain rebuild (pending: %d)"),
 		*Belt->GetName(), PendingChainRebuilds.Num());
-	
+
 	// Reset the timer - this allows batching multiple belts placed in quick succession
 	UWorld* World = GetWorld();
 	if (World)
@@ -9472,7 +9474,7 @@ void USFSubsystem::QueueChainRebuild(AFGBuildableConveyorBelt* Belt)
 			0.5f,  // 500ms delay to allow all belts to be placed
 			false  // Don't loop
 		);
-		UE_LOG(LogSmartFoundations, Log, TEXT("⛓️ CHAIN REBUILD: Timer set for 0.5s"));
+		UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("⛓️ CHAIN REBUILD: Timer set for 0.5s"));
 	}
 }
 
@@ -9483,22 +9485,22 @@ TSet<AFGBuildableConveyorBelt*> USFSubsystem::CollectChainBelts(AFGBuildableConv
 	{
 		return Result;
 	}
-	
+
 	TQueue<AFGBuildableConveyorBelt*> ToVisit;
 	ToVisit.Enqueue(StartBelt);
-	
+
 	while (!ToVisit.IsEmpty())
 	{
 		AFGBuildableConveyorBelt* Current;
 		ToVisit.Dequeue(Current);
-		
+
 		if (!Current || Result.Contains(Current))
 		{
 			continue;
 		}
-		
+
 		Result.Add(Current);
-		
+
 		// Follow Conn0
 		UFGFactoryConnectionComponent* Conn0 = Current->GetConnection0();
 		if (Conn0 && Conn0->IsConnected())
@@ -9516,7 +9518,7 @@ TSet<AFGBuildableConveyorBelt*> USFSubsystem::CollectChainBelts(AFGBuildableConv
 				}
 			}
 		}
-		
+
 		// Follow Conn1
 		UFGFactoryConnectionComponent* Conn1 = Current->GetConnection1();
 		if (Conn1 && Conn1->IsConnected())
@@ -9535,7 +9537,7 @@ TSet<AFGBuildableConveyorBelt*> USFSubsystem::CollectChainBelts(AFGBuildableConv
 			}
 		}
 	}
-	
+
 	return Result;
 }
 
@@ -9545,10 +9547,10 @@ void USFSubsystem::ExecuteDeferredChainRebuild()
 	{
 		return;
 	}
-	
-	UE_LOG(LogSmartFoundations, Log, TEXT("⛓️ CHAIN REBUILD: Executing deferred rebuild for %d pending belt(s)"),
+
+	UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("⛓️ CHAIN REBUILD: Executing deferred rebuild for %d pending belt(s)"),
 		PendingChainRebuilds.Num());
-	
+
 	AFGBuildableSubsystem* Subsystem = AFGBuildableSubsystem::Get(GetWorld());
 	if (!Subsystem)
 	{
@@ -9556,7 +9558,7 @@ void USFSubsystem::ExecuteDeferredChainRebuild()
 		PendingChainRebuilds.Empty();
 		return;
 	}
-	
+
 	// Collect ALL belts from ALL pending chains
 	TSet<AFGBuildableConveyorBelt*> AllChainBelts;
 	for (const TWeakObjectPtr<AFGBuildableConveyorBelt>& WeakBelt : PendingChainRebuilds)
@@ -9567,10 +9569,10 @@ void USFSubsystem::ExecuteDeferredChainRebuild()
 			AllChainBelts.Append(ChainBelts);
 		}
 	}
-	
-	UE_LOG(LogSmartFoundations, Log, TEXT("⛓️ CHAIN REBUILD: Collected %d total belt(s) in chain(s)"),
+
+	UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("⛓️ CHAIN REBUILD: Collected %d total belt(s) in chain(s)"),
 		AllChainBelts.Num());
-	
+
 	// Remove all from subsystem
 	int32 RemovedCount = 0;
 	for (AFGBuildableConveyorBelt* Belt : AllChainBelts)
@@ -9581,10 +9583,10 @@ void USFSubsystem::ExecuteDeferredChainRebuild()
 			RemovedCount++;
 		}
 	}
-	
-	UE_LOG(LogSmartFoundations, Log, TEXT("⛓️ CHAIN REBUILD: Removed %d belt(s) from chain system"),
+
+	UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("⛓️ CHAIN REBUILD: Removed %d belt(s) from chain system"),
 		RemovedCount);
-	
+
 	// Re-add all (rebuilds with correct topology)
 	int32 AddedCount = 0;
 	for (AFGBuildableConveyorBelt* Belt : AllChainBelts)
@@ -9595,49 +9597,49 @@ void USFSubsystem::ExecuteDeferredChainRebuild()
 			AddedCount++;
 		}
 	}
-	
-	UE_LOG(LogSmartFoundations, Log, TEXT("⛓️ CHAIN REBUILD: Re-added %d belt(s) to chain system"),
+
+	UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("⛓️ CHAIN REBUILD: Re-added %d belt(s) to chain system"),
 		AddedCount);
-	
+
 	// Clear pending
 	PendingChainRebuilds.Empty();
-	
-	UE_LOG(LogSmartFoundations, Log, TEXT("⛓️ CHAIN REBUILD: Complete"));
+
+	UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("⛓️ CHAIN REBUILD: Complete"));
 }
 
 void USFSubsystem::CacheStackableBeltPreviewsForBuild()
 {
 	// Uses file-scope global cache: GCachedStackableBeltData, bGStackableBeltDataCached
 	// OnActorSpawned consumes this cache when pole is built
-	
+
 	if (!AutoConnectService || !ActiveHologram.IsValid())
 	{
 		UE_LOG(LogSmartFoundations, Warning, TEXT("🚧 STACKABLE BELT CACHE: Missing service or hologram"));
 		return;
 	}
-	
+
 	// Get belt previews from the AutoConnectService
 	TArray<TSharedPtr<FBeltPreviewHelper>>* BeltPreviews = AutoConnectService->GetBeltPreviews(ActiveHologram.Get());
 	if (!BeltPreviews || BeltPreviews->Num() == 0)
 	{
-		UE_LOG(LogSmartFoundations, Log, TEXT("🚧 STACKABLE BELT CACHE: No belt previews to cache"));
+		UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("🚧 STACKABLE BELT CACHE: No belt previews to cache"));
 		return;
 	}
-	
+
 	GCachedStackableBeltData.Empty();
-	
+
 	for (const TSharedPtr<FBeltPreviewHelper>& PreviewHelper : *BeltPreviews)
 	{
 		if (!PreviewHelper.IsValid() || !PreviewHelper->IsPreviewValid()) continue;
-		
+
 		AFGSplineHologram* PreviewHolo = PreviewHelper->GetHologram();
 		if (!PreviewHolo) continue;
-		
+
 		FStackableBeltBuildData Data;
 		Data.BeltTier = PreviewHelper->GetBeltTier();
 		Data.OutputConnector = PreviewHelper->GetOutputConnector();
 		Data.InputConnector = PreviewHelper->GetInputConnector();
-		
+
 		// Extract spline data from the preview hologram
 		USplineComponent* SplineComp = PreviewHolo->FindComponentByClass<USplineComponent>();
 		if (SplineComp)
@@ -9652,17 +9654,17 @@ void USFSubsystem::CacheStackableBeltPreviewsForBuild()
 				Data.SplineData.Add(Point);
 			}
 		}
-		
+
 		if (Data.SplineData.Num() >= 2)
 		{
 			GCachedStackableBeltData.Add(Data);
 		}
 	}
-	
+
 	bGStackableBeltDataCached = GCachedStackableBeltData.Num() > 0;
-	
+
 	if (bGStackableBeltDataCached)
 	{
-		UE_LOG(LogSmartFoundations, Log, TEXT("🚧 STACKABLE BELT CACHE: Cached %d belt(s) from hologram previews"), GCachedStackableBeltData.Num());
+		UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("🚧 STACKABLE BELT CACHE: Cached %d belt(s) from hologram previews"), GCachedStackableBeltData.Num());
 	}
 }

--- a/Source/SmartFoundations/Private/UI/SmartSettingsFormWidget.cpp
+++ b/Source/SmartFoundations/Private/UI/SmartSettingsFormWidget.cpp
@@ -30,7 +30,7 @@
 void USmartSettingsFormWidget::NativeConstruct()
 {
     Super::NativeConstruct();
-    
+
     UE_LOG(LogSmartFoundations, Log, TEXT("Settings Form: NativeConstruct called"));
 
     // Check if Blueprint widgets are bound
@@ -39,19 +39,19 @@ void USmartSettingsFormWidget::NativeConstruct()
         UE_LOG(LogSmartFoundations, Error, TEXT("Settings Form: BackgroundPanel not bound from Blueprint"));
         return;
     }
-    
+
     if (!TitleText)
     {
         UE_LOG(LogSmartFoundations, Error, TEXT("Settings Form: TitleText not bound from Blueprint"));
         return;
     }
-    
+
     if (!ContentContainer)
     {
         UE_LOG(LogSmartFoundations, Error, TEXT("Settings Form: ContentContainer not bound from Blueprint"));
         return;
     }
-    
+
     if (!CloseButton)
     {
         UE_LOG(LogSmartFoundations, Error, TEXT("Settings Form: CloseButton not bound from Blueprint"));
@@ -60,18 +60,18 @@ void USmartSettingsFormWidget::NativeConstruct()
 
     // Set up button handlers
     CloseButton->OnClicked.AddDynamic(this, &USmartSettingsFormWidget::OnCloseButtonClicked);
-    
+
     if (ApplyBtn)
     {
         ApplyBtn->OnClicked.AddDynamic(this, &USmartSettingsFormWidget::OnApplyButtonClicked);
     }
-    
+
     // Issue #165: Reset button - zeros spacing, steps, stagger, and rotation
     if (ResetBtn)
     {
         ResetBtn->OnClicked.AddDynamic(this, &USmartSettingsFormWidget::OnResetButtonClicked);
     }
-    
+
     // Set up confirmation dialog button handlers
     if (ConfirmYesButton)
     {
@@ -81,16 +81,16 @@ void USmartSettingsFormWidget::NativeConstruct()
     {
         ConfirmNoButton->OnClicked.AddDynamic(this, &USmartSettingsFormWidget::OnConfirmNoClicked);
     }
-    
+
     // Hide confirmation dialog by default
     if (ConfirmationSizeBox)
     {
         ConfirmationSizeBox->SetVisibility(ESlateVisibility::Collapsed);
     }
-    
+
     // Set default title
     TitleText->SetText(LOCTEXT("Panel_Title", "Smart! Panel"));
-    
+
     // Configure widget to block all mouse input
     SetIsFocusable(true);
 
@@ -109,17 +109,17 @@ void USmartSettingsFormWidget::NativeConstruct()
             SpinBox->SetMinFractionalDigits(0);
             SpinBox->SetMaxFractionalDigits(0);
             SpinBox->SetMinDesiredWidth(400.0f);  // Wider for easier interaction
-            
+
             // Increase font size for readability
             FSlateFontInfo FontInfo = SpinBox->GetFont();
             FontInfo.Size = 18;
             SpinBox->SetFont(FontInfo);
-            
+
             SpinBox->OnValueCommitted.AddDynamic(this, &USmartSettingsFormWidget::OnSpinBoxValueCommitted);
             SpinBox->OnValueChanged.AddDynamic(this, &USmartSettingsFormWidget::OnGridSpinBoxValueChanged);
         }
     };
-    
+
     // Configure Spacing/Steps/Stagger SpinBox inputs (allow negative, float values)
     auto ConfigureFloatSpinBox = [this](USpinBox* SpinBox)
     {
@@ -134,12 +134,12 @@ void USmartSettingsFormWidget::NativeConstruct()
             SpinBox->SetMinFractionalDigits(1);
             SpinBox->SetMaxFractionalDigits(1);
             SpinBox->SetMinDesiredWidth(400.0f);  // Wider for easier interaction
-            
+
             // Increase font size for readability
             FSlateFontInfo FontInfo = SpinBox->GetFont();
             FontInfo.Size = 18;
             SpinBox->SetFont(FontInfo);
-            
+
             SpinBox->OnValueCommitted.AddDynamic(this, &USmartSettingsFormWidget::OnSpinBoxValueCommitted);
             SpinBox->OnValueChanged.AddDynamic(this, &USmartSettingsFormWidget::OnSpinBoxValueChanged);
         }
@@ -149,7 +149,7 @@ void USmartSettingsFormWidget::NativeConstruct()
     ConfigureGridSpinBox(GridXInput);
     ConfigureGridSpinBox(GridYInput);
     ConfigureGridSpinBox(GridZInput);
-    
+
     // Spacing/Steps/Stagger inputs: minimum 0, float values in meters
     ConfigureFloatSpinBox(SpacingXInput);
     ConfigureFloatSpinBox(SpacingYInput);
@@ -160,7 +160,7 @@ void USmartSettingsFormWidget::NativeConstruct()
     ConfigureFloatSpinBox(StaggerYInput);
     ConfigureFloatSpinBox(StaggerZXInput);
     ConfigureFloatSpinBox(StaggerZYInput);
-    
+
     // Configure Rotation SpinBox (degrees, not meters)
     auto ConfigureRotationSpinBox = [this](USpinBox* SpinBox)
     {
@@ -175,17 +175,17 @@ void USmartSettingsFormWidget::NativeConstruct()
             SpinBox->SetMinFractionalDigits(1);
             SpinBox->SetMaxFractionalDigits(1);
             SpinBox->SetMinDesiredWidth(400.0f);
-            
+
             FSlateFontInfo FontInfo = SpinBox->GetFont();
             FontInfo.Size = 18;
             SpinBox->SetFont(FontInfo);
-            
+
             SpinBox->OnValueCommitted.AddDynamic(this, &USmartSettingsFormWidget::OnSpinBoxValueCommitted);
             SpinBox->OnValueChanged.AddDynamic(this, &USmartSettingsFormWidget::OnSpinBoxValueChanged);
         }
     };
     ConfigureRotationSpinBox(RotationZInput);
-    
+
     // Configure SizeBox widths for all SpinBoxes (override blueprint constraints)
     auto ConfigureSizeBox = [](USizeBox* SizeBox)
     {
@@ -194,7 +194,7 @@ void USmartSettingsFormWidget::NativeConstruct()
             SizeBox->SetWidthOverride(150.0f);
         }
     };
-    
+
     ConfigureSizeBox(GridXInputSizeBox);
     ConfigureSizeBox(GridYInputSizeBox);
     ConfigureSizeBox(GridZInputSizeBox);
@@ -208,22 +208,22 @@ void USmartSettingsFormWidget::NativeConstruct()
     ConfigureSizeBox(StaggerZXInputSizeBox);
     ConfigureSizeBox(StaggerZYInputSizeBox);
     ConfigureSizeBox(RotationZInputSizeBox);
-    
+
     // Configure ComboBox styles to use standard Box instead of RoundedBox
     // Also copies the WidgetStyle (button appearance) from a reference ComboBox
     auto ConfigureComboBoxStyle = [](UComboBoxString* ComboBox, UComboBoxString* ReferenceComboBox = nullptr)
     {
         if (!ComboBox) return;
-        
+
         // Copy WidgetStyle from reference if provided (for consistent button appearance)
         if (ReferenceComboBox)
         {
             ComboBox->SetWidgetStyle(ReferenceComboBox->GetWidgetStyle());
         }
-        
+
         // Get the current item style and modify the brushes to use Box instead of RoundedBox
         FTableRowStyle ItemStyle = ComboBox->GetItemStyle();
-        
+
         // Change active/inactive brushes from RoundedBox to Box
         ItemStyle.ActiveBrush.DrawAs = ESlateBrushDrawType::Box;
         ItemStyle.ActiveHoveredBrush.DrawAs = ESlateBrushDrawType::Box;
@@ -233,10 +233,10 @@ void USmartSettingsFormWidget::NativeConstruct()
         ItemStyle.EvenRowBackgroundHoveredBrush.DrawAs = ESlateBrushDrawType::Box;
         ItemStyle.OddRowBackgroundBrush.DrawAs = ESlateBrushDrawType::Box;
         ItemStyle.OddRowBackgroundHoveredBrush.DrawAs = ESlateBrushDrawType::Box;
-        
+
         ComboBox->SetItemStyle(ItemStyle);
     };
-    
+
     ConfigureComboBoxStyle(RecipeComboBox);
     ConfigureComboBoxStyle(BeltTierMainComboBox);
     ConfigureComboBoxStyle(BeltTierToBuildingComboBox);
@@ -247,7 +247,7 @@ void USmartSettingsFormWidget::NativeConstruct()
     ConfigureComboBoxStyle(BeltRoutingModeComboBox, PipeRoutingModeComboBox);  // Copy style from Pipe Routing Mode
     ConfigureComboBoxStyle(PowerGridAxisComboBox);
     ConfigureComboBoxStyle(PowerReservedComboBox);
-    
+
     // Bind Apply Immediately checkbox
     // NOTE: Do NOT set checkbox state here - PopulateFromCounterState() is called BEFORE NativeConstruct
     // and correctly initializes bApplyImmediately from global config. Setting it here would reset to false.
@@ -280,13 +280,13 @@ void USmartSettingsFormWidget::NativeConstruct()
     {
         RecipeComboBox->OnSelectionChanged.AddDynamic(this, &USmartSettingsFormWidget::OnRecipeSelectionChanged);
     }
-    
+
     // Bind clear recipe button
     if (ClearRecipeButton)
     {
         ClearRecipeButton->OnClicked.AddDynamic(this, &USmartSettingsFormWidget::OnClearRecipeButtonClicked);
     }
-    
+
     // Bind belt auto-connect controls
     if (BeltEnabledCheckBox)
     {
@@ -312,7 +312,7 @@ void USmartSettingsFormWidget::NativeConstruct()
     {
         BeltRoutingModeComboBox->OnSelectionChanged.AddDynamic(this, &USmartSettingsFormWidget::OnBeltRoutingModeChanged);
     }
-    
+
     // Bind pipe auto-connect controls
     if (PipeEnabledCheckBox)
     {
@@ -334,7 +334,7 @@ void USmartSettingsFormWidget::NativeConstruct()
     {
         PipeRoutingModeComboBox->OnSelectionChanged.AddDynamic(this, &USmartSettingsFormWidget::OnPipeRoutingModeChanged);
     }
-    
+
     // Bind power auto-connect controls
     if (PowerEnabledCheckBox)
     {
@@ -387,21 +387,21 @@ void USmartSettingsFormWidget::NativeConstruct()
             LogoOffset = SmartLogoSlot->GetPosition() - BackgroundPos;
         }
     }
-    
+
     // ========== DARK THEME STYLING ==========
-    
+
     // Dark background on BackgroundPanel
     if (BackgroundPanel)
     {
         BackgroundPanel->SetBrushColor(FLinearColor(0.02f, 0.02f, 0.04f, 0.92f));
     }
-    
+
     // Orange accent on title
     if (TitleText)
     {
         TitleText->SetColorAndOpacity(FSlateColor(FLinearColor(1.0f, 0.6f, 0.2f, 1.0f)));
     }
-    
+
     // Orange accent on existing section headers
     if (AutoConnectHeaderText)
     {
@@ -411,22 +411,22 @@ void USmartSettingsFormWidget::NativeConstruct()
     {
         RecipeHeaderText->SetColorAndOpacity(FSlateColor(FLinearColor(1.0f, 0.6f, 0.2f, 1.0f)));
     }
-    
+
     // Set all TextBlocks in ContentContainer to light gray for dark background
     if (ContentContainer)
     {
         const FSlateColor LightTextColor(FLinearColor(0.9f, 0.9f, 0.9f, 1.0f));
-        
+
         // Recursive lambda to set text color on all UTextBlock descendants
         TFunction<void(UWidget*)> SetTextColors = [&](UWidget* Parent)
         {
             if (!Parent) return;
-            
+
             if (UTextBlock* TextBlock = Cast<UTextBlock>(Parent))
             {
                 TextBlock->SetColorAndOpacity(LightTextColor);
             }
-            
+
             if (UPanelWidget* Panel = Cast<UPanelWidget>(Parent))
             {
                 for (int32 i = 0; i < Panel->GetChildrenCount(); i++)
@@ -435,9 +435,9 @@ void USmartSettingsFormWidget::NativeConstruct()
                 }
             }
         };
-        
+
         SetTextColors(ContentContainer);
-        
+
         // Re-apply orange accent on headers (overridden by recursive pass)
         if (AutoConnectHeaderText)
         {
@@ -452,9 +452,9 @@ void USmartSettingsFormWidget::NativeConstruct()
             GridWarningText->SetColorAndOpacity(FSlateColor(FLinearColor(1.0f, 0.3f, 0.3f, 1.0f)));
         }
     }
-    
+
     UE_LOG(LogSmartFoundations, Log, TEXT("Settings Form: Blueprint widgets bound successfully"));
-    
+
     // === Localize Blueprint Labels ===
     // Override default text set in the Widget Blueprint with LOCTEXT for runtime localization.
     // Uses GetWidgetFromName() to find TextBlock widgets by their Blueprint name.
@@ -466,7 +466,7 @@ void USmartSettingsFormWidget::NativeConstruct()
                 TB->SetText(Text);
             }
         };
-        
+
         // Button labels
         SetLabel(TEXT("ApplyBtnText"), LOCTEXT("Panel_Btn_Apply", "Apply"));
         SetLabel(TEXT("ResetBtnText"), LOCTEXT("Panel_Btn_Reset", "Reset"));
@@ -474,56 +474,56 @@ void USmartSettingsFormWidget::NativeConstruct()
         SetLabel(TEXT("ClearRecipeButtonText"), LOCTEXT("Panel_Btn_ClearRecipe", "Clear"));
         SetLabel(TEXT("ConfirmYesText"), LOCTEXT("Panel_Btn_Continue", "Continue"));
         SetLabel(TEXT("ConfirmNoText"), LOCTEXT("Panel_Btn_Cancel", "Cancel"));
-        
+
         // Apply Immediately label
         SetLabel(TEXT("ApplyImmediatelyLabel"), LOCTEXT("Panel_ApplyImmediately", "Apply Immediately:"));
-        
+
         // Section headers
         SetLabel(TEXT("GridSectionHeader"), LOCTEXT("Panel_Section_Grid", "Grid"));
         SetLabel(TEXT("SpacingSectionHeader"), LOCTEXT("Panel_Section_Spacing", "Spacing"));
         SetLabel(TEXT("StepsSectionHeader"), LOCTEXT("Panel_Section_Steps", "Steps"));
         SetLabel(TEXT("StaggerSectionHeader"), LOCTEXT("Panel_Section_Stagger", "Stagger"));
         SetLabel(TEXT("RotationSectionHeader"), LOCTEXT("Panel_Section_Rotation", "Rotation"));
-        
+
         // Grid row labels
         SetLabel(TEXT("GridXLabel"), LOCTEXT("Panel_GridX", "Grid [X]:"));
         SetLabel(TEXT("GridYLabel"), LOCTEXT("Panel_GridY", "Grid [Y]:"));
         SetLabel(TEXT("GridZLabel"), LOCTEXT("Panel_GridZ", "Grid [Z]:"));
-        
+
         // Spacing row labels
         SetLabel(TEXT("SpacingXLabel"), LOCTEXT("Panel_SpacingX", "Spacing [X]:"));
         SetLabel(TEXT("SpacingYLabel"), LOCTEXT("Panel_SpacingY", "Spacing [Y]:"));
         SetLabel(TEXT("SpacingZLabel"), LOCTEXT("Panel_SpacingZ", "Spacing [Z]:"));
-        
+
         // Spacing unit labels
         SetLabel(TEXT("SpacingXUnit"), LOCTEXT("Panel_Unit_Meters", "m"));
         SetLabel(TEXT("SpacingYUnit"), LOCTEXT("Panel_Unit_Meters", "m"));
         SetLabel(TEXT("SpacingZUnit"), LOCTEXT("Panel_Unit_Meters", "m"));
-        
+
         // Steps row labels
         SetLabel(TEXT("StepsXLabel"), LOCTEXT("Panel_StepsX", "Steps [X]:"));
         SetLabel(TEXT("StepsYLabel"), LOCTEXT("Panel_StepsY", "Steps [Y]:"));
-        
+
         // Steps unit labels
         SetLabel(TEXT("StepsXUnit"), LOCTEXT("Panel_Unit_Meters", "m"));
         SetLabel(TEXT("StepsYUnit"), LOCTEXT("Panel_Unit_Meters", "m"));
-        
+
         // Stagger row labels
         SetLabel(TEXT("StaggerXLabel"), LOCTEXT("Panel_StaggerX", "Stagger [X]:"));
         SetLabel(TEXT("StaggerYLabel"), LOCTEXT("Panel_StaggerY", "Stagger [Y]:"));
         SetLabel(TEXT("StaggerZXLabel"), LOCTEXT("Panel_StaggerZX", "Stagger [ZX]:"));
         SetLabel(TEXT("StaggerZYLabel"), LOCTEXT("Panel_StaggerZY", "Stagger [ZY]:"));
-        
+
         // Stagger unit labels
         SetLabel(TEXT("StaggerXUnit"), LOCTEXT("Panel_Unit_Meters", "m"));
         SetLabel(TEXT("StaggerYUnit"), LOCTEXT("Panel_Unit_Meters", "m"));
         SetLabel(TEXT("StaggerZXUnit"), LOCTEXT("Panel_Unit_Meters", "m"));
         SetLabel(TEXT("StaggerZYUnit"), LOCTEXT("Panel_Unit_Meters", "m"));
-        
+
         // Rotation row label and unit
         SetLabel(TEXT("RotationZLabel"), LOCTEXT("Panel_RotationZ", "Rotation [Z]:"));
         SetLabel(TEXT("RotationZUnit"), LOCTEXT("Panel_Unit_Degrees", "\u00B0"));
-        
+
         // Belt auto-connect labels
         SetLabel(TEXT("BeltEnabledLabel"), LOCTEXT("Panel_AC_BeltEnabled", "Belt Auto-Connect:"));
         SetLabel(TEXT("BeltTierMainLabel"), LOCTEXT("Panel_AC_MainTier", "Main Tier:"));
@@ -531,20 +531,20 @@ void USmartSettingsFormWidget::NativeConstruct()
         SetLabel(TEXT("BeltChainLabel"), LOCTEXT("Panel_AC_Chain", "Chain:"));
         SetLabel(TEXT("StackableBeltDirectionLabel"), LOCTEXT("Panel_AC_Direction", "Direction:"));
         SetLabel(TEXT("BeltRoutingModeLabel"), LOCTEXT("Panel_AC_Routing", "Routing:"));
-        
+
         // Pipe auto-connect labels
         SetLabel(TEXT("PipeEnabledLabel"), LOCTEXT("Panel_AC_PipeEnabled", "Pipe Auto-Connect:"));
         SetLabel(TEXT("PipeTierMainLabel"), LOCTEXT("Panel_AC_MainTier", "Main Tier:"));
         SetLabel(TEXT("PipeTierToBuildingLabel"), LOCTEXT("Panel_AC_ToBuilding", "To Building:"));
         SetLabel(TEXT("PipeIndicatorLabel"), LOCTEXT("Panel_AC_FlowIndicator", "Flow Indicator:"));
         SetLabel(TEXT("PipeRoutingModeLabel"), LOCTEXT("Panel_AC_Routing", "Routing:"));
-        
+
         // Power auto-connect labels
         SetLabel(TEXT("PowerEnabledLabel"), LOCTEXT("Panel_AC_PowerEnabled", "Power Auto-Connect:"));
         SetLabel(TEXT("PowerGridAxisLabel"), LOCTEXT("Panel_AC_GridAxis", "Grid Axis:"));
         SetLabel(TEXT("PowerReservedLabel"), LOCTEXT("Panel_AC_Reserved", "Reserved:"));
     }
-    
+
     // === Extend Mode Overrides ===
     // Applied AFTER default setup since PopulateFromCounterState runs before NativeConstruct.
     // Hides unsupported transforms: Grid Z, Spacing Z, all Stagger.
@@ -555,7 +555,7 @@ void USmartSettingsFormWidget::NativeConstruct()
         {
             TitleText->SetText(LOCTEXT("Panel_Title_Extend", "Smart! Extend"));
         }
-        
+
         // Helper to collapse a named widget in the tree
         auto CollapseByName = [this](const TCHAR* WidgetName)
         {
@@ -564,21 +564,21 @@ void USmartSettingsFormWidget::NativeConstruct()
                 W->SetVisibility(ESlateVisibility::Collapsed);
             }
         };
-        
+
         // Hide Grid Z row (not used in Extend)
         CollapseByName(TEXT("GridZRow"));
-        
+
         // Hide Spacing Z row (not used in Extend)
         CollapseByName(TEXT("SpacingZRow"));
-        
+
         // Hide entire Stagger section (blocked during Extend)
         CollapseByName(TEXT("StaggerSectionHeader"));
         CollapseByName(TEXT("StaggerXRow"));
         CollapseByName(TEXT("StaggerYRow"));
         CollapseByName(TEXT("StaggerZXRow"));
         CollapseByName(TEXT("StaggerZYRow"));
-        
-        UE_LOG(LogSmartFoundations, Log, TEXT("Settings Form: Extend mode overrides applied - title, Grid Z, Spacing Z, Stagger hidden"));
+
+        UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("Settings Form: Extend mode overrides applied - title, Grid Z, Spacing Z, Stagger hidden"));
     }
 }
 
@@ -589,10 +589,10 @@ void USmartSettingsFormWidget::PopulateFromCounterState(USFSubsystem* Subsystem)
         UE_LOG(LogSmartFoundations, Error, TEXT("Settings Form: Cannot populate - Subsystem is null"));
         return;
     }
-    
+
     // Cache subsystem reference for apply button
     CachedSubsystem = Subsystem;
-    
+
     // Initialize Apply Immediately from global config
     const FSmart_ConfigStruct& Config = Subsystem->GetCachedConfig();
     bApplyImmediately = Config.bApplyImmediately;
@@ -600,24 +600,24 @@ void USmartSettingsFormWidget::PopulateFromCounterState(USFSubsystem* Subsystem)
     {
         ApplyImmediatelyCheckBox->SetIsChecked(bApplyImmediately);
     }
-    
+
     // Get current counter state
     const FSFCounterState& State = Subsystem->GetCounterState();
-    
+
     // Cache the initial state for cancel/revert on Escape
     LastAppliedState = State;
-    
+
     // Populate Grid values (show absolute value, track direction separately)
     // Direction is determined by sign: positive = true, negative = false
     bGridXPositive = State.GridCounters.X >= 0;
     bGridYPositive = State.GridCounters.Y >= 0;
     bGridZPositive = State.GridCounters.Z >= 0;
-    
+
     // Cache direction state for cancel/revert
     bLastAppliedGridXPositive = bGridXPositive;
     bLastAppliedGridYPositive = bGridYPositive;
     bLastAppliedGridZPositive = bGridZPositive;
-    
+
     // Populate Grid values using SpinBox SetValue (absolute count)
     if (GridXInput)
     {
@@ -631,12 +631,12 @@ void USmartSettingsFormWidget::PopulateFromCounterState(USFSubsystem* Subsystem)
     {
         GridZInput->SetValue(static_cast<float>(FMath::Abs(State.GridCounters.Z)));
     }
-    
+
     // Update direction toggle labels
     UpdateGridDirectionLabel(GridXDirLabel, bGridXPositive);
     UpdateGridDirectionLabel(GridYDirLabel, bGridYPositive);
     UpdateGridDirectionLabel(GridZDirLabel, bGridZPositive);
-    
+
     // Populate Spacing values (display in meters, internal state is centimeters)
     if (SpacingXInput)
     {
@@ -650,7 +650,7 @@ void USmartSettingsFormWidget::PopulateFromCounterState(USFSubsystem* Subsystem)
     {
         SpacingZInput->SetValue(State.SpacingZ / 100.0f);
     }
-    
+
     // Populate Steps values (display in meters, internal state is centimeters)
     if (StepsXInput)
     {
@@ -660,7 +660,7 @@ void USmartSettingsFormWidget::PopulateFromCounterState(USFSubsystem* Subsystem)
     {
         StepsYInput->SetValue(State.StepsY / 100.0f);
     }
-    
+
     // Populate Stagger values (display in meters, internal state is centimeters)
     if (StaggerXInput)
     {
@@ -678,22 +678,22 @@ void USmartSettingsFormWidget::PopulateFromCounterState(USFSubsystem* Subsystem)
     {
         StaggerZYInput->SetValue(State.StaggerZY / 100.0f);
     }
-    
+
     // Rotation (degrees, not cm - no conversion needed)
     if (RotationZInput)
     {
         RotationZInput->SetValue(State.RotationZ);
     }
-    
-    UE_LOG(LogSmartFoundations, Log, TEXT("Settings Form: Populated from CounterState - Grid[%d,%d,%d] Spacing[%d,%d,%d] Steps[%d,%d] Stagger[%d,%d,%d,%d] Rotation[%.1f]"),
+
+    UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("Settings Form: Populated from CounterState - Grid[%d,%d,%d] Spacing[%d,%d,%d] Steps[%d,%d] Stagger[%d,%d,%d,%d] Rotation[%.1f]"),
         State.GridCounters.X, State.GridCounters.Y, State.GridCounters.Z,
         State.SpacingX, State.SpacingY, State.SpacingZ,
         State.StepsX, State.StepsY,
         State.StaggerX, State.StaggerY, State.StaggerZX, State.StaggerZY,
         State.RotationZ);
-    
+
     // Log widget binding status
-    UE_LOG(LogSmartFoundations, Log, TEXT("Settings Form: Widget bindings - GridX=%d SpacingX=%d StepsX=%d StaggerX=%d"),
+    UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("Settings Form: Widget bindings - GridX=%d SpacingX=%d StepsX=%d StaggerX=%d"),
         GridXInput != nullptr, SpacingXInput != nullptr, StepsXInput != nullptr, StaggerXInput != nullptr);
 
     // Save Extend mode flag — actual UI overrides applied in NativeConstruct (after default setup)
@@ -750,7 +750,7 @@ void USmartSettingsFormWidget::PopulateFromCounterState(USFSubsystem* Subsystem)
     // Recipe is determined by the source building, and auto-connect is handled by Extend wiring.
     if (bIsExtendMode)
     {
-        UE_LOG(LogSmartFoundations, Log, TEXT("Settings Form: Extend mode - skipping auto-connect and recipe sections"));
+        UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("Settings Form: Extend mode - skipping auto-connect and recipe sections"));
         return;
     }
 
@@ -788,7 +788,7 @@ void USmartSettingsFormWidget::PopulateFromCounterState(USFSubsystem* Subsystem)
     FString AutoConnectLines;
     bool bHasAnyAutoConnectContext = false;
 
-    UE_LOG(LogSmartFoundations, Log, TEXT("Settings Form: Checking auto-connect context..."));
+    UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("Settings Form: Checking auto-connect context..."));
 
     if (USFAutoConnectService* AutoConnectService = SubsystemPtr->GetAutoConnectService())
     {
@@ -803,13 +803,13 @@ void USmartSettingsFormWidget::PopulateFromCounterState(USFSubsystem* Subsystem)
             const bool bIsStackablePipeSupport = AutoConnectService->IsStackablePipelineSupportHologram(ActiveHologram);
             const bool bIsPassthroughPipe = USFAutoConnectService::IsPassthroughPipeHologram(ActiveHologram);
 
-            UE_LOG(LogSmartFoundations, Log, TEXT("Settings Form: Hologram=%s, IsDistributor=%d, IsPipeJunction=%d, IsPowerPole=%d, IsBeltSupport=%d, IsStackablePipeSupport=%d, IsPassthroughPipe=%d"),
+            UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("Settings Form: Hologram=%s, IsDistributor=%d, IsPipeJunction=%d, IsPowerPole=%d, IsBeltSupport=%d, IsStackablePipeSupport=%d, IsPassthroughPipe=%d"),
                 *ActiveHologram->GetClass()->GetName(), bIsDistributor, bIsPipeJunction, bIsPowerPole, bIsStackableConveyorPole, bIsStackablePipeSupport, bIsPassthroughPipe);
 
             if (bIsDistributor)
             {
                 bHasAnyAutoConnectContext = true;
-                
+
                 // Show belt auto-connect controls instead of summary text
                 if (BeltAutoConnectContainer)
                 {
@@ -832,7 +832,7 @@ void USmartSettingsFormWidget::PopulateFromCounterState(USFSubsystem* Subsystem)
             if (bIsPipeJunction)
             {
                 bHasAnyAutoConnectContext = true;
-                
+
                 // Show pipe auto-connect controls instead of summary text
                 if (PipeAutoConnectContainer)
                 {
@@ -859,7 +859,7 @@ void USmartSettingsFormWidget::PopulateFromCounterState(USFSubsystem* Subsystem)
             if (bIsPowerPole)
             {
                 bHasAnyAutoConnectContext = true;
-                
+
                 // Show power auto-connect controls instead of summary text
                 if (PowerAutoConnectContainer)
                 {
@@ -885,7 +885,7 @@ void USmartSettingsFormWidget::PopulateFromCounterState(USFSubsystem* Subsystem)
             if (bIsStackableConveyorPole)
             {
                 bHasAnyAutoConnectContext = true;
-                
+
                 // Show stackable conveyor pole auto-connect controls
                 if (BeltAutoConnectContainer)
                 {
@@ -911,7 +911,7 @@ void USmartSettingsFormWidget::PopulateFromCounterState(USFSubsystem* Subsystem)
             if (bIsStackablePipeSupport || bIsPassthroughPipe)
             {
                 bHasAnyAutoConnectContext = true;
-                
+
                 // Show pipe auto-connect controls (shared for stackable pipe supports and floor holes)
                 if (PipeAutoConnectContainer)
                 {
@@ -958,7 +958,7 @@ void USmartSettingsFormWidget::PopulateFromCounterState(USFSubsystem* Subsystem)
     SubsystemPtr->GetRecipeDisplayInfo(CurrentIndex, TotalRecipes);
     TSubclassOf<UFGRecipe> ActiveRecipe = SubsystemPtr->GetActiveRecipe();
 
-    UE_LOG(LogSmartFoundations, Log, TEXT("Settings Form: Recipe check - ActiveRecipe=%s, TotalRecipes=%d"),
+    UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("Settings Form: Recipe check - ActiveRecipe=%s, TotalRecipes=%d"),
         ActiveRecipe ? *ActiveRecipe->GetName() : TEXT("null"), TotalRecipes);
 
     bool bIsProductionBuilding = false;
@@ -970,19 +970,19 @@ void USmartSettingsFormWidget::PopulateFromCounterState(USFSubsystem* Subsystem)
             // Check if this is a production building by checking class hierarchy
             // BUT exclude auto-connect holograms (distributors, pipe junctions, power poles)
             // which may inherit from AFGBuildableFactory but don't use recipes
-            bIsProductionBuilding = HologramClass->IsChildOf(AFGBuildableFactory::StaticClass()) 
+            bIsProductionBuilding = HologramClass->IsChildOf(AFGBuildableFactory::StaticClass())
                                     && !bHasAnyAutoConnectContext;
             if (ActiveRecipe)
             {
                 bIsCompatible = SubsystemPtr->IsRecipeCompatibleWithHologram(ActiveRecipe, HologramClass);
             }
-            UE_LOG(LogSmartFoundations, Log, TEXT("Settings Form: Recipe compatibility check - HologramClass=%s, bIsProductionBuilding=%d, bIsCompatible=%d, bHasAutoConnectContext=%d"),
+            UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("Settings Form: Recipe compatibility check - HologramClass=%s, bIsProductionBuilding=%d, bIsCompatible=%d, bHasAutoConnectContext=%d"),
                 *HologramClass->GetName(), bIsProductionBuilding, bIsCompatible, bHasAnyAutoConnectContext);
         }
     }
     else
     {
-        UE_LOG(LogSmartFoundations, Log, TEXT("Settings Form: No active hologram for recipe check"));
+        UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("Settings Form: No active hologram for recipe check"));
     }
 
     // Show recipe section for production buildings (excludes auto-connect holograms)
@@ -1015,14 +1015,14 @@ void USmartSettingsFormWidget::PopulateFromCounterState(USFSubsystem* Subsystem)
             RecipeHeaderText->SetText(LOCTEXT("Panel_RecipeHeader", "Recipes"));
             RecipeHeaderText->SetVisibility(ESlateVisibility::Visible);
         }
-        
+
         // Populate recipe details container with icons
         if (RecipeDetailsContainer)
         {
             PopulateRecipeDetails(ActiveRecipe);
             RecipeDetailsContainer->SetVisibility(ESlateVisibility::Visible);
         }
-        
+
         // Populate recipe ComboBox if available
         if (RecipeComboBox && bIsProductionBuilding)
         {
@@ -1030,45 +1030,45 @@ void USmartSettingsFormWidget::PopulateFromCounterState(USFSubsystem* Subsystem)
             {
                 RecipeComboBox->ClearOptions();
                 CachedRecipeList.Empty();
-                
+
                 // Add "None Selected" as first option (index 0)
                 // CachedRecipeList[0] will be nullptr to represent no selection
                 RecipeComboBox->AddOption(LOCTEXT("Panel_Recipe_NoneSelected", "None Selected").ToString());
                 CachedRecipeList.Add(nullptr);
-                
+
                 const TArray<TSubclassOf<UFGRecipe>>& Recipes = RecipeService->GetSortedFilteredRecipes();
                 int32 SelectedIndex = 0;  // Default to "None Selected"
-                
+
                 for (int32 i = 0; i < Recipes.Num(); i++)
                 {
                     TSubclassOf<UFGRecipe> Recipe = Recipes[i];
                     FString Label = RecipeService->GetRecipeComboBoxLabel(Recipe);
                     RecipeComboBox->AddOption(Label);
                     CachedRecipeList.Add(Recipe);
-                    
+
                     // Track which one is currently active (offset by 1 for "None Selected")
                     if (Recipe == ActiveRecipe)
                     {
                         SelectedIndex = i + 1;
                     }
                 }
-                
+
                 // Set current selection
                 RecipeComboBox->SetSelectedIndex(SelectedIndex);
-                
+
                 RecipeComboBox->SetVisibility(ESlateVisibility::Visible);
-                
+
                 // Show Clear button alongside recipe controls
                 if (ClearRecipeButton)
                 {
                     ClearRecipeButton->SetVisibility(ESlateVisibility::Visible);
                 }
-                
-                UE_LOG(LogSmartFoundations, Log, TEXT("Settings Form: Populated RecipeComboBox with %d recipes (+None), selected index=%d"),
+
+                UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("Settings Form: Populated RecipeComboBox with %d recipes (+None), selected index=%d"),
                     Recipes.Num(), SelectedIndex);
             }
         }
-        
+
         // Update recipe icon for currently active recipe
         UpdateRecipeIcon(ActiveRecipe);
     }
@@ -1089,20 +1089,20 @@ void USmartSettingsFormWidget::PopulateFromCounterState(USFSubsystem* Subsystem)
             RecipeDetailsContainer->SetVisibility(ESlateVisibility::Collapsed);
         }
     }
-    
+
     // Initialize grid warning display based on current values
     UpdateGridWarningDisplay();
 }
 
 void USmartSettingsFormWidget::OnCloseButtonClicked()
 {
-    UE_LOG(LogSmartFoundations, Log, TEXT("Settings Form: Close button clicked"));
+    UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("Settings Form: Close button clicked"));
     CloseForm();
 }
 
 void USmartSettingsFormWidget::CancelAndClose()
 {
-    UE_LOG(LogSmartFoundations, Log, TEXT("Settings Form: Cancel and close (toggle key or escape)"));
+    UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("Settings Form: Cancel and close (toggle key or escape)"));
     RevertToLastAppliedState();
     CloseForm();
 }
@@ -1117,7 +1117,7 @@ void USmartSettingsFormWidget::CloseForm()
             HudService->SetHUDSuppressed(false);
         }
     }
-    
+
     // Restore game input mode and hide cursor
     APlayerController* PC = GetOwningPlayer();
     if (PC)
@@ -1126,30 +1126,30 @@ void USmartSettingsFormWidget::CloseForm()
         FInputModeGameOnly InputMode;
         PC->SetInputMode(InputMode);
     }
-    
+
     // Remove widget from viewport
     RemoveFromParent();
-    
-    UE_LOG(LogSmartFoundations, Log, TEXT("Settings Form: Closed and input restored"));
+
+    UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("Settings Form: Closed and input restored"));
 }
 
 void USmartSettingsFormWidget::OnApplyButtonClicked()
 {
-    UE_LOG(LogSmartFoundations, Log, TEXT("Settings Form: Apply button clicked"));
-    
+    UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("Settings Form: Apply button clicked"));
+
     // Don't process if we're already waiting for confirmation
     if (bWaitingForConfirmation)
     {
-        UE_LOG(LogSmartFoundations, Log, TEXT("Settings Form: Already waiting for confirmation, ignoring apply"));
+        UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("Settings Form: Already waiting for confirmation, ignoring apply"));
         return;
     }
-    
+
     if (!CachedSubsystem.IsValid())
     {
         UE_LOG(LogSmartFoundations, Error, TEXT("Settings Form: No cached subsystem reference"));
         return;
     }
-    
+
     // Check if confirmation is required for large grids
     if (RequiresApplyConfirmation())
     {
@@ -1161,33 +1161,33 @@ void USmartSettingsFormWidget::OnApplyButtonClicked()
         });
         return;
     }
-    
+
     // No confirmation needed, apply directly
     ApplyCurrentValues();
 }
 
 void USmartSettingsFormWidget::OnResetButtonClicked()
 {
-    UE_LOG(LogSmartFoundations, Log, TEXT("Settings Form: Reset button clicked - zeroing spacing, steps, stagger, and rotation"));
-    
+    UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("Settings Form: Reset button clicked - zeroing spacing, steps, stagger, and rotation"));
+
     // Zero out spacing SpinBoxes
     if (SpacingXInput) SpacingXInput->SetValue(0.0f);
     if (SpacingYInput) SpacingYInput->SetValue(0.0f);
     if (SpacingZInput) SpacingZInput->SetValue(0.0f);
-    
+
     // Zero out steps SpinBoxes
     if (StepsXInput) StepsXInput->SetValue(0.0f);
     if (StepsYInput) StepsYInput->SetValue(0.0f);
-    
+
     // Zero out stagger SpinBoxes
     if (StaggerXInput) StaggerXInput->SetValue(0.0f);
     if (StaggerYInput) StaggerYInput->SetValue(0.0f);
     if (StaggerZXInput) StaggerZXInput->SetValue(0.0f);
     if (StaggerZYInput) StaggerZYInput->SetValue(0.0f);
-    
+
     // Zero out rotation SpinBox
     if (RotationZInput) RotationZInput->SetValue(0.0f);
-    
+
     // Apply the reset values immediately (regardless of Apply Immediately mode)
     OnApplyButtonClicked();
 }
@@ -1199,10 +1199,10 @@ void USmartSettingsFormWidget::ApplyCurrentValues()
         UE_LOG(LogSmartFoundations, Error, TEXT("Settings Form: No cached subsystem reference"));
         return;
     }
-    
+
     // Parse values from editable text inputs
     FSFCounterState NewState = CachedSubsystem->GetCounterState();
-    
+
     // Read Grid values from SpinBox (absolute count, apply direction from toggle state)
     if (GridXInput)
     {
@@ -1219,7 +1219,7 @@ void USmartSettingsFormWidget::ApplyCurrentValues()
         int32 Count = FMath::Max(1, FMath::RoundToInt(GridZInput->GetValue()));
         NewState.GridCounters.Z = bGridZPositive ? Count : -Count;
     }
-    
+
     // Read Spacing values from SpinBox (meters in UI -> centimeters in state)
     if (SpacingXInput)
     {
@@ -1233,7 +1233,7 @@ void USmartSettingsFormWidget::ApplyCurrentValues()
     {
         NewState.SpacingZ = FMath::RoundToInt(SpacingZInput->GetValue() * 100.0f);
     }
-    
+
     // Read Steps values from SpinBox (meters in UI -> centimeters in state)
     if (StepsXInput)
     {
@@ -1243,7 +1243,7 @@ void USmartSettingsFormWidget::ApplyCurrentValues()
     {
         NewState.StepsY = FMath::RoundToInt(StepsYInput->GetValue() * 100.0f);
     }
-    
+
     // Read Stagger values from SpinBox (meters in UI -> centimeters in state)
     if (StaggerXInput)
     {
@@ -1261,31 +1261,31 @@ void USmartSettingsFormWidget::ApplyCurrentValues()
     {
         NewState.StaggerZY = FMath::RoundToInt(StaggerZYInput->GetValue() * 100.0f);
     }
-    
+
     // Read Rotation value from SpinBox (degrees - no conversion needed)
     if (RotationZInput)
     {
         NewState.RotationZ = RotationZInput->GetValue();
     }
-    
+
     // Log parsed values before applying
-    UE_LOG(LogSmartFoundations, Log, TEXT("Settings Form: Parsed values - Grid[%d,%d,%d] Spacing[%d,%d,%d] Steps[%d,%d] Stagger[%d,%d,%d,%d] Rotation[%.1f]"),
+    UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("Settings Form: Parsed values - Grid[%d,%d,%d] Spacing[%d,%d,%d] Steps[%d,%d] Stagger[%d,%d,%d,%d] Rotation[%.1f]"),
         NewState.GridCounters.X, NewState.GridCounters.Y, NewState.GridCounters.Z,
         NewState.SpacingX, NewState.SpacingY, NewState.SpacingZ,
         NewState.StepsX, NewState.StepsY,
         NewState.StaggerX, NewState.StaggerY, NewState.StaggerZX, NewState.StaggerZY,
         NewState.RotationZ);
-    
+
     // Apply the new state (updates GridStateService, local CounterState, and triggers HUD refresh)
     CachedSubsystem->UpdateCounterState(NewState);
-    
+
     // Regenerate child holograms to reflect new grid counts and reposition with new spacing/steps/stagger
     // During Extend mode, UpdateCounterState already triggers OnScaledExtendStateChanged which handles regeneration
     if (!CachedSubsystem->IsExtendModeActive())
     {
         CachedSubsystem->RegenerateChildHologramGrid();
     }
-    
+
     // Refresh recipe details to update grid totals with new grid size
     if (RecipeDetailsContainer && RecipeComboBox)
     {
@@ -1300,11 +1300,11 @@ void USmartSettingsFormWidget::ApplyCurrentValues()
             }
         }
     }
-    
+
     // Cache the applied state for cancel/revert
     CacheCurrentStateAsApplied();
-    
-    UE_LOG(LogSmartFoundations, Log, TEXT("Settings Form: State applied and grid regenerated"));
+
+    UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("Settings Form: State applied and grid regenerated"));
 }
 
 FReply USmartSettingsFormWidget::NativeOnMouseButtonDown(const FGeometry& InGeometry, const FPointerEvent& InMouseEvent)
@@ -1373,59 +1373,59 @@ void USmartSettingsFormWidget::OnRecipeSelectionChanged(FString SelectedItem, ES
     {
         return;
     }
-    
+
     if (!CachedSubsystem.IsValid() || !RecipeComboBox)
     {
         return;
     }
-    
+
     int32 SelectedIndex = RecipeComboBox->GetSelectedIndex();
     if (SelectedIndex < 0 || SelectedIndex >= CachedRecipeList.Num())
     {
         UE_LOG(LogSmartFoundations, Warning, TEXT("Settings Form: Invalid recipe selection index %d"), SelectedIndex);
         return;
     }
-    
+
     TSubclassOf<UFGRecipe> SelectedRecipe = CachedRecipeList[SelectedIndex];
-    
-    UE_LOG(LogSmartFoundations, Log, TEXT("Settings Form: Recipe selected - Index=%d, Recipe=%s"),
+
+    UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("Settings Form: Recipe selected - Index=%d, Recipe=%s"),
         SelectedIndex, SelectedRecipe ? *SelectedRecipe->GetName() : TEXT("None"));
-    
+
     // Check if "None Selected" was chosen (index 0, nullptr recipe)
     if (SelectedIndex == 0 || !SelectedRecipe)
     {
         // Clear the recipe - same as clicking Clear button
         CachedSubsystem->ClearAllRecipes();
         CachedSubsystem->ApplyRecipeToParentHologram();
-        
+
         // Clear the recipe details
         if (RecipeDetailsContainer)
         {
             RecipeDetailsContainer->ClearChildren();
         }
-        
+
         // Hide the recipe icon
         if (RecipeIcon)
         {
             RecipeIcon->SetVisibility(ESlateVisibility::Collapsed);
         }
-        
-        UE_LOG(LogSmartFoundations, Log, TEXT("Settings Form: Recipe cleared via 'None Selected'"));
+
+        UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("Settings Form: Recipe cleared via 'None Selected'"));
         return;
     }
-    
+
     // Apply the recipe selection via subsystem
     // Note: SelectedIndex includes the "None Selected" offset, so subtract 1 for actual recipe index
     if (USFRecipeManagementService* RecipeService = CachedSubsystem->GetRecipeManagementService())
     {
         RecipeService->SetActiveRecipeByIndex(SelectedIndex - 1);
-        
+
         // Update the recipe details container with icons
         if (RecipeDetailsContainer)
         {
             PopulateRecipeDetails(SelectedRecipe);
         }
-        
+
         // Update recipe icon
         UpdateRecipeIcon(SelectedRecipe);
     }
@@ -1433,39 +1433,39 @@ void USmartSettingsFormWidget::OnRecipeSelectionChanged(FString SelectedItem, ES
 
 void USmartSettingsFormWidget::OnClearRecipeButtonClicked()
 {
-    UE_LOG(LogSmartFoundations, Log, TEXT("Settings Form: Clear Recipe button clicked"));
-    
+    UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("Settings Form: Clear Recipe button clicked"));
+
     if (!CachedSubsystem.IsValid())
     {
         return;
     }
-    
+
     // Use the existing ClearAllRecipes method on the subsystem
     // This is the same logic triggered by Num0 when in Recipe mode (U held)
     CachedSubsystem->ClearAllRecipes();
-    
+
     // Apply the clear to the parent hologram and trigger child regeneration
     CachedSubsystem->ApplyRecipeToParentHologram();
-    
+
     // Clear the ComboBox selection
     if (RecipeComboBox)
     {
         RecipeComboBox->ClearSelection();
     }
-    
+
     // Clear the recipe details
     if (RecipeDetailsContainer)
     {
         RecipeDetailsContainer->ClearChildren();
     }
-    
+
     // Hide the recipe icon
     if (RecipeIcon)
     {
         RecipeIcon->SetVisibility(ESlateVisibility::Collapsed);
     }
-    
-    UE_LOG(LogSmartFoundations, Log, TEXT("Settings Form: Recipe cleared via ClearAllRecipes"));
+
+    UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("Settings Form: Recipe cleared via ClearAllRecipes"));
 }
 
 void USmartSettingsFormWidget::UpdateRecipeIcon(TSubclassOf<UFGRecipe> Recipe)
@@ -1474,18 +1474,18 @@ void USmartSettingsFormWidget::UpdateRecipeIcon(TSubclassOf<UFGRecipe> Recipe)
     {
         return;
     }
-    
+
     if (!Recipe)
     {
         RecipeIcon->SetVisibility(ESlateVisibility::Collapsed);
         return;
     }
-    
+
     if (!CachedSubsystem.IsValid())
     {
         return;
     }
-    
+
     if (USFRecipeManagementService* RecipeService = CachedSubsystem->GetRecipeManagementService())
     {
         UTexture2D* IconTexture = RecipeService->GetRecipePrimaryProductIcon(Recipe);
@@ -1509,30 +1509,30 @@ void USmartSettingsFormWidget::PopulateRecipeDetails(TSubclassOf<UFGRecipe> Reci
     {
         return;
     }
-    
+
     // Clear existing children
     RecipeDetailsContainer->ClearChildren();
-    
+
     if (!Recipe || !CachedSubsystem.IsValid())
     {
         return;
     }
-    
+
     UFGRecipe* RecipeCDO = Recipe->GetDefaultObject<UFGRecipe>();
     if (!RecipeCDO)
     {
         return;
     }
-    
+
     // Colors matching HUD style
     const FLinearColor OutputColor(0.7f, 0.9f, 0.7f, 1.0f);   // Light green for outputs
     const FLinearColor InputColor(0.9f, 0.8f, 0.7f, 1.0f);    // Light tan for inputs
-    
+
     // Get manufacturing duration to calculate per-minute rates
     // Duration is in seconds, so items per minute = (Amount / Duration) * 60
     const float ManufacturingDuration = UFGRecipe::GetManufacturingDuration(Recipe);
     const float CyclesPerMinute = (ManufacturingDuration > 0.0f) ? (60.0f / ManufacturingDuration) : 0.0f;
-    
+
     // Get grid size to calculate total output for the entire grid
     // Grid total = GridX * GridY * GridZ buildings
     // Note: Grid values can be negative (direction), so use Abs() to get the count
@@ -1541,29 +1541,29 @@ void USmartSettingsFormWidget::PopulateRecipeDetails(TSubclassOf<UFGRecipe> Reci
     {
         FSFCounterState CounterState = CachedSubsystem->GetCounterState();
         // GridCounters is an FIntVector with X, Y, Z components - use absolute values since sign indicates direction
-        GridTotal = FMath::Max(1, FMath::Abs(CounterState.GridCounters.X)) * 
-                    FMath::Max(1, FMath::Abs(CounterState.GridCounters.Y)) * 
+        GridTotal = FMath::Max(1, FMath::Abs(CounterState.GridCounters.X)) *
+                    FMath::Max(1, FMath::Abs(CounterState.GridCounters.Y)) *
                     FMath::Max(1, FMath::Abs(CounterState.GridCounters.Z));
     }
-    
+
     // No header row needed - the ComboBox provides recipe selection
     // Go directly to output/input rows with icons
     TArray<FItemAmount> Products = RecipeCDO->GetProducts();
-    
+
     // Add output rows with icons
     for (int32 i = 0; i < Products.Num(); i++)
     {
         TSubclassOf<UFGItemDescriptor> ItemClass = Products[i].ItemClass;
         int32 Amount = Products[i].Amount;
         FString ItemName = UFGItemDescriptor::GetItemName(ItemClass).ToString();
-        
+
         // Get item icon
         UTexture2D* ItemIcon = UFGItemDescriptor::GetSmallIcon(ItemClass);
-        
+
         // Calculate per-minute rate (single building) and grid total
         float PerMinute = Amount * CyclesPerMinute;
         float GridTotalPerMinute = PerMinute * GridTotal;
-        
+
         // Format amount with per-minute rate and grid total (liquids have amounts >= 1000)
         FString AmountText;
         if (Amount >= 1000)
@@ -1578,14 +1578,14 @@ void USmartSettingsFormWidget::PopulateRecipeDetails(TSubclassOf<UFGRecipe> Reci
         {
             AmountText = FText::Format(LOCTEXT("Panel_Recipe_Output", "\u2192 Output: {0} x{1} ({2}/min) (Grid Total: {3}/min)"), FText::FromString(ItemName), FText::AsNumber(Amount), FText::AsNumber(PerMinute), FText::AsNumber(GridTotalPerMinute)).ToString();
         }
-        
+
         UWidget* OutputRow = CreateRecipeDetailRow(ItemIcon, AmountText, OutputColor);
         if (OutputRow)
         {
             RecipeDetailsContainer->AddChild(OutputRow);
         }
     }
-    
+
     // Add input rows with icons
     TArray<FItemAmount> Ingredients = RecipeCDO->GetIngredients();
     for (int32 i = 0; i < Ingredients.Num(); i++)
@@ -1593,14 +1593,14 @@ void USmartSettingsFormWidget::PopulateRecipeDetails(TSubclassOf<UFGRecipe> Reci
         TSubclassOf<UFGItemDescriptor> ItemClass = Ingredients[i].ItemClass;
         int32 Amount = Ingredients[i].Amount;
         FString ItemName = UFGItemDescriptor::GetItemName(ItemClass).ToString();
-        
+
         // Get item icon
         UTexture2D* ItemIcon = UFGItemDescriptor::GetSmallIcon(ItemClass);
-        
+
         // Calculate per-minute rate (single building) and grid total
         float PerMinute = Amount * CyclesPerMinute;
         float GridTotalPerMinute = PerMinute * GridTotal;
-        
+
         // Format amount with per-minute rate and grid total (liquids have amounts >= 1000)
         FString AmountText;
         if (Amount >= 1000)
@@ -1615,7 +1615,7 @@ void USmartSettingsFormWidget::PopulateRecipeDetails(TSubclassOf<UFGRecipe> Reci
         {
             AmountText = FText::Format(LOCTEXT("Panel_Recipe_Input", "\u2190 Input: {0} x{1} ({2}/min) (Grid Total: {3}/min)"), FText::FromString(ItemName), FText::AsNumber(Amount), FText::AsNumber(PerMinute), FText::AsNumber(GridTotalPerMinute)).ToString();
         }
-        
+
         UWidget* InputRow = CreateRecipeDetailRow(ItemIcon, AmountText, InputColor);
         if (InputRow)
         {
@@ -1632,7 +1632,7 @@ UWidget* USmartSettingsFormWidget::CreateRecipeDetailRow(UTexture2D* Icon, const
     {
         return nullptr;
     }
-    
+
     // Add icon if provided
     if (Icon)
     {
@@ -1641,14 +1641,14 @@ UWidget* USmartSettingsFormWidget::CreateRecipeDetailRow(UTexture2D* Icon, const
         {
             IconSizeBox->SetWidthOverride(24.0f);
             IconSizeBox->SetHeightOverride(24.0f);
-            
+
             UImage* IconImage = NewObject<UImage>(this);
             if (IconImage)
             {
                 IconImage->SetBrushFromTexture(Icon);
                 IconSizeBox->AddChild(IconImage);
             }
-            
+
             UHorizontalBoxSlot* IconSlot = Row->AddChildToHorizontalBox(IconSizeBox);
             if (IconSlot)
             {
@@ -1657,26 +1657,26 @@ UWidget* USmartSettingsFormWidget::CreateRecipeDetailRow(UTexture2D* Icon, const
             }
         }
     }
-    
+
     // Add text
     UTextBlock* TextWidget = NewObject<UTextBlock>(this);
     if (TextWidget)
     {
         TextWidget->SetText(FText::FromString(Text));
         TextWidget->SetColorAndOpacity(FSlateColor(TextColor));
-        
+
         // Set font to match HUD style
         FSlateFontInfo FontInfo = TextWidget->GetFont();
         FontInfo.Size = 14;
         TextWidget->SetFont(FontInfo);
-        
+
         UHorizontalBoxSlot* TextSlot = Row->AddChildToHorizontalBox(TextWidget);
         if (TextSlot)
         {
             TextSlot->SetVerticalAlignment(VAlign_Center);
         }
     }
-    
+
     return Row;
 }
 
@@ -1706,14 +1706,14 @@ int32 USmartSettingsFormWidget::DisplayStringToBeltTier(const FString& DisplaySt
     {
         return 0;
     }
-    
+
     // Parse "Mk1", "Mk2", etc.
     if (DisplayString.StartsWith(TEXT("Mk")))
     {
         FString TierStr = DisplayString.RightChop(2);
         return FCString::Atoi(*TierStr);
     }
-    
+
     return 0;
 }
 
@@ -1723,11 +1723,11 @@ void USmartSettingsFormWidget::PopulateBeltTierComboBoxes()
     {
         return;
     }
-    
+
     // Get highest unlocked belt tier
     AFGPlayerController* PC = Cast<AFGPlayerController>(GetOwningPlayer());
     int32 HighestUnlocked = CachedSubsystem->GetHighestUnlockedBeltTier(PC);
-    
+
     // Build list of available tiers: Auto (0), then Mk1 through highest unlocked
     CachedBeltTiers.Empty();
     CachedBeltTiers.Add(0);  // Auto
@@ -1735,7 +1735,7 @@ void USmartSettingsFormWidget::PopulateBeltTierComboBoxes()
     {
         CachedBeltTiers.Add(Tier);
     }
-    
+
     // Populate Main tier ComboBox
     if (BeltTierMainComboBox)
     {
@@ -1745,7 +1745,7 @@ void USmartSettingsFormWidget::PopulateBeltTierComboBoxes()
             BeltTierMainComboBox->AddOption(BeltTierToDisplayString(Tier));
         }
     }
-    
+
     // Populate To Building tier ComboBox
     if (BeltTierToBuildingComboBox)
     {
@@ -1755,8 +1755,8 @@ void USmartSettingsFormWidget::PopulateBeltTierComboBoxes()
             BeltTierToBuildingComboBox->AddOption(BeltTierToDisplayString(Tier));
         }
     }
-    
-    UE_LOG(LogSmartFoundations, Log, TEXT("Settings Form: Populated belt tier ComboBoxes with %d options (highest unlocked: Mk%d)"),
+
+    UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("Settings Form: Populated belt tier ComboBoxes with %d options (highest unlocked: Mk%d)"),
         CachedBeltTiers.Num(), HighestUnlocked);
 }
 
@@ -1766,15 +1766,15 @@ void USmartSettingsFormWidget::UpdateBeltAutoConnectControls()
     {
         return;
     }
-    
+
     const auto& Settings = CachedSubsystem->GetAutoConnectRuntimeSettings();
-    
+
     // Update Enabled checkbox
     if (BeltEnabledCheckBox)
     {
         BeltEnabledCheckBox->SetIsChecked(Settings.bEnabled);
     }
-    
+
     // Update Main tier ComboBox
     if (BeltTierMainComboBox)
     {
@@ -1785,14 +1785,14 @@ void USmartSettingsFormWidget::UpdateBeltAutoConnectControls()
         }
         BeltTierMainComboBox->SetSelectedIndex(Index);
     }
-    
+
     // Update To Building tier ComboBox
     if (BeltTierToBuildingComboBox)
     {
         // Restore original event binding (in case it was repurposed for stackable poles)
         BeltTierToBuildingComboBox->OnSelectionChanged.Clear();
         BeltTierToBuildingComboBox->OnSelectionChanged.AddDynamic(this, &USmartSettingsFormWidget::OnBeltTierToBuildingChanged);
-        
+
         int32 Index = CachedBeltTiers.Find(Settings.BeltTierToBuilding);
         if (Index == INDEX_NONE)
         {
@@ -1800,14 +1800,14 @@ void USmartSettingsFormWidget::UpdateBeltAutoConnectControls()
         }
         BeltTierToBuildingComboBox->SetSelectedIndex(Index);
     }
-    
+
     // Update Chain checkbox
     if (BeltChainCheckBox)
     {
         BeltChainCheckBox->SetIsChecked(Settings.bChainDistributors);
         BeltChainCheckBox->SetVisibility(ESlateVisibility::Visible);
     }
-    
+
     // Restore visibility for regular belt controls, hide stackable-only controls
     if (BeltTierToBuildingLabel)
     {
@@ -1825,7 +1825,7 @@ void USmartSettingsFormWidget::UpdateBeltAutoConnectControls()
     {
         BeltChainLabel->SetVisibility(ESlateVisibility::Visible);
     }
-    
+
     // Update Routing Mode ComboBox
     if (BeltRoutingModeComboBox)
     {
@@ -1833,7 +1833,7 @@ void USmartSettingsFormWidget::UpdateBeltAutoConnectControls()
         BeltRoutingModeComboBox->AddOption(TEXT("Default"));
         BeltRoutingModeComboBox->AddOption(TEXT("Curve"));
         BeltRoutingModeComboBox->AddOption(TEXT("Straight"));
-        
+
         int32 ModeIndex = FMath::Clamp(Settings.BeltRoutingMode, 0, 2);
         BeltRoutingModeComboBox->SetSelectedIndex(ModeIndex);
     }
@@ -1841,8 +1841,8 @@ void USmartSettingsFormWidget::UpdateBeltAutoConnectControls()
     {
         BeltRoutingModeRow->SetVisibility(ESlateVisibility::Visible);
     }
-    
-    UE_LOG(LogSmartFoundations, Log, TEXT("Settings Form: Updated belt controls - Enabled=%d, Main=%d, ToBuilding=%d, Chain=%d, RoutingMode=%d"),
+
+    UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("Settings Form: Updated belt controls - Enabled=%d, Main=%d, ToBuilding=%d, Chain=%d, RoutingMode=%d"),
         Settings.bEnabled, Settings.BeltTierMain, Settings.BeltTierToBuilding, Settings.bChainDistributors, Settings.BeltRoutingMode);
 }
 
@@ -1852,10 +1852,10 @@ void USmartSettingsFormWidget::OnBeltEnabledChanged(bool bIsChecked)
     {
         return;
     }
-    
+
     CachedSubsystem->SetAutoConnectBeltEnabled(bIsChecked);
-    UE_LOG(LogSmartFoundations, Log, TEXT("Settings Form: Belt auto-connect enabled changed to %d"), bIsChecked);
-    
+    UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("Settings Form: Belt auto-connect enabled changed to %d"), bIsChecked);
+
     if (bApplyImmediately)
     {
         CachedSubsystem->TriggerAutoConnectRefresh();
@@ -1868,16 +1868,16 @@ void USmartSettingsFormWidget::OnBeltTierMainChanged(FString SelectedItem, ESele
     {
         return;  // Ignore programmatic changes
     }
-    
+
     if (!CachedSubsystem.IsValid())
     {
         return;
     }
-    
+
     int32 Tier = DisplayStringToBeltTier(SelectedItem);
     CachedSubsystem->SetAutoConnectBeltTierMain(Tier);
-    UE_LOG(LogSmartFoundations, Log, TEXT("Settings Form: Belt tier main changed to %d (%s)"), Tier, *SelectedItem);
-    
+    UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("Settings Form: Belt tier main changed to %d (%s)"), Tier, *SelectedItem);
+
     if (bApplyImmediately)
     {
         CachedSubsystem->TriggerAutoConnectRefresh();
@@ -1890,16 +1890,16 @@ void USmartSettingsFormWidget::OnBeltTierToBuildingChanged(FString SelectedItem,
     {
         return;  // Ignore programmatic changes
     }
-    
+
     if (!CachedSubsystem.IsValid())
     {
         return;
     }
-    
+
     int32 Tier = DisplayStringToBeltTier(SelectedItem);
     CachedSubsystem->SetAutoConnectBeltTierToBuilding(Tier);
-    UE_LOG(LogSmartFoundations, Log, TEXT("Settings Form: Belt tier to building changed to %d (%s)"), Tier, *SelectedItem);
-    
+    UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("Settings Form: Belt tier to building changed to %d (%s)"), Tier, *SelectedItem);
+
     if (bApplyImmediately)
     {
         CachedSubsystem->TriggerAutoConnectRefresh();
@@ -1912,9 +1912,9 @@ void USmartSettingsFormWidget::OnBeltChainChanged(bool bIsChecked)
     {
         return;
     }
-    
+
     CachedSubsystem->SetAutoConnectBeltChain(bIsChecked);
-    UE_LOG(LogSmartFoundations, Log, TEXT("Settings Form: Belt chain changed to %d"), bIsChecked);
+    UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("Settings Form: Belt chain changed to %d"), bIsChecked);
 }
 
 void USmartSettingsFormWidget::OnStackableBeltDirectionChanged(FString SelectedItem, ESelectInfo::Type SelectionType)
@@ -1923,22 +1923,22 @@ void USmartSettingsFormWidget::OnStackableBeltDirectionChanged(FString SelectedI
     {
         return;  // Ignore programmatic changes
     }
-    
+
     if (!CachedSubsystem.IsValid())
     {
         return;
     }
-    
+
     // Convert "Forward"/"Backward" to 0/1
     int32 Direction = 0;  // Default to Forward
     if (SelectedItem == TEXT("Backward"))
     {
         Direction = 1;
     }
-    
+
     CachedSubsystem->SetAutoConnectStackableBeltDirection(Direction);
-    UE_LOG(LogSmartFoundations, Log, TEXT("Settings Form: Stackable belt direction changed to %d (%s)"), Direction, *SelectedItem);
-    
+    UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("Settings Form: Stackable belt direction changed to %d (%s)"), Direction, *SelectedItem);
+
     if (bApplyImmediately)
     {
         CachedSubsystem->TriggerAutoConnectRefresh();
@@ -1951,20 +1951,20 @@ void USmartSettingsFormWidget::OnBeltRoutingModeChanged(FString SelectedItem, ES
     {
         return;  // Ignore programmatic changes
     }
-    
+
     if (!CachedSubsystem.IsValid())
     {
         return;
     }
-    
+
     // Convert display string to routing mode index
     int32 RoutingMode = 0;  // Default
     if (SelectedItem == TEXT("Curve")) RoutingMode = 1;
     else if (SelectedItem == TEXT("Straight")) RoutingMode = 2;
-    
+
     CachedSubsystem->SetAutoConnectBeltRoutingMode(RoutingMode);
-    UE_LOG(LogSmartFoundations, Log, TEXT("Settings Form: Belt routing mode changed to %d (%s)"), RoutingMode, *SelectedItem);
-    
+    UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("Settings Form: Belt routing mode changed to %d (%s)"), RoutingMode, *SelectedItem);
+
     if (bApplyImmediately)
     {
         CachedSubsystem->TriggerAutoConnectRefresh();
@@ -1997,14 +1997,14 @@ int32 USmartSettingsFormWidget::DisplayStringToPipeTier(const FString& DisplaySt
     {
         return 0;
     }
-    
+
     // Parse "Mk1", "Mk2"
     if (DisplayString.StartsWith(TEXT("Mk")))
     {
         FString TierStr = DisplayString.RightChop(2);
         return FCString::Atoi(*TierStr);
     }
-    
+
     return 0;
 }
 
@@ -2014,11 +2014,11 @@ void USmartSettingsFormWidget::PopulatePipeTierComboBoxes()
     {
         return;
     }
-    
+
     // Get highest unlocked pipe tier
     AFGPlayerController* PC = Cast<AFGPlayerController>(GetOwningPlayer());
     int32 HighestUnlocked = CachedSubsystem->GetHighestUnlockedPipeTier(PC);
-    
+
     // Build list of available tiers: Auto (0), then Mk1 through highest unlocked
     CachedPipeTiers.Empty();
     CachedPipeTiers.Add(0);  // Auto
@@ -2026,7 +2026,7 @@ void USmartSettingsFormWidget::PopulatePipeTierComboBoxes()
     {
         CachedPipeTiers.Add(Tier);
     }
-    
+
     // Populate Main tier ComboBox
     if (PipeTierMainComboBox)
     {
@@ -2036,7 +2036,7 @@ void USmartSettingsFormWidget::PopulatePipeTierComboBoxes()
             PipeTierMainComboBox->AddOption(PipeTierToDisplayString(Tier));
         }
     }
-    
+
     // Populate To Building tier ComboBox
     if (PipeTierToBuildingComboBox)
     {
@@ -2046,8 +2046,8 @@ void USmartSettingsFormWidget::PopulatePipeTierComboBoxes()
             PipeTierToBuildingComboBox->AddOption(PipeTierToDisplayString(Tier));
         }
     }
-    
-    UE_LOG(LogSmartFoundations, Log, TEXT("Settings Form: Populated pipe tier ComboBoxes with %d options (highest unlocked: Mk%d)"),
+
+    UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("Settings Form: Populated pipe tier ComboBoxes with %d options (highest unlocked: Mk%d)"),
         CachedPipeTiers.Num(), HighestUnlocked);
 }
 
@@ -2057,15 +2057,15 @@ void USmartSettingsFormWidget::UpdatePipeAutoConnectControls()
     {
         return;
     }
-    
+
     const auto& Settings = CachedSubsystem->GetAutoConnectRuntimeSettings();
-    
+
     // Update Enabled checkbox
     if (PipeEnabledCheckBox)
     {
         PipeEnabledCheckBox->SetIsChecked(Settings.bPipeAutoConnectEnabled);
     }
-    
+
     // Update Main tier ComboBox
     if (PipeTierMainComboBox)
     {
@@ -2076,7 +2076,7 @@ void USmartSettingsFormWidget::UpdatePipeAutoConnectControls()
         }
         PipeTierMainComboBox->SetSelectedIndex(Index);
     }
-    
+
     // Update To Building tier ComboBox
     if (PipeTierToBuildingComboBox)
     {
@@ -2087,21 +2087,21 @@ void USmartSettingsFormWidget::UpdatePipeAutoConnectControls()
         }
         PipeTierToBuildingComboBox->SetSelectedIndex(Index);
     }
-    
+
     // Ensure both rows are visible for standard pipe junctions
     if (PipeTierMainRow) PipeTierMainRow->SetVisibility(ESlateVisibility::Visible);
     if (PipeTierToBuildingRow) PipeTierToBuildingRow->SetVisibility(ESlateVisibility::Visible);
-    
+
     // Update Flow Indicator checkbox and row visibility
     // Only show if clean pipes are unlocked - otherwise flow indicators are implicit
     AFGPlayerController* PC = Cast<AFGPlayerController>(GetOwningPlayer());
     bool bCleanPipesUnlocked = CachedSubsystem->AreCleanPipesUnlocked(PC);
-    
+
     if (PipeIndicatorRow)
     {
         PipeIndicatorRow->SetVisibility(bCleanPipesUnlocked ? ESlateVisibility::Visible : ESlateVisibility::Collapsed);
     }
-    
+
     if (PipeIndicatorCheckBox)
     {
         // If clean pipes not unlocked, force to true (with indicators)
@@ -2114,7 +2114,7 @@ void USmartSettingsFormWidget::UpdatePipeAutoConnectControls()
             PipeIndicatorCheckBox->SetIsChecked(Settings.bPipeIndicator);
         }
     }
-    
+
     // Update Routing Mode ComboBox
     if (PipeRoutingModeComboBox)
     {
@@ -2125,12 +2125,12 @@ void USmartSettingsFormWidget::UpdatePipeAutoConnectControls()
         PipeRoutingModeComboBox->AddOption(TEXT("Curve"));
         PipeRoutingModeComboBox->AddOption(TEXT("Noodle"));
         PipeRoutingModeComboBox->AddOption(TEXT("Horiz→Vert"));
-        
+
         int32 ModeIndex = FMath::Clamp(Settings.PipeRoutingMode, 0, 5);
         PipeRoutingModeComboBox->SetSelectedIndex(ModeIndex);
     }
-    
-    UE_LOG(LogSmartFoundations, Log, TEXT("Settings Form: Updated pipe controls - Enabled=%d, Main=%d, ToBuilding=%d, Indicator=%d, RoutingMode=%d, CleanUnlocked=%d"),
+
+    UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("Settings Form: Updated pipe controls - Enabled=%d, Main=%d, ToBuilding=%d, Indicator=%d, RoutingMode=%d, CleanUnlocked=%d"),
         Settings.bPipeAutoConnectEnabled, Settings.PipeTierMain, Settings.PipeTierToBuilding, Settings.bPipeIndicator, Settings.PipeRoutingMode, bCleanPipesUnlocked);
 }
 
@@ -2140,10 +2140,10 @@ void USmartSettingsFormWidget::OnPipeEnabledChanged(bool bIsChecked)
     {
         return;
     }
-    
+
     CachedSubsystem->SetAutoConnectPipeEnabled(bIsChecked);
-    UE_LOG(LogSmartFoundations, Log, TEXT("Settings Form: Pipe auto-connect enabled changed to %d"), bIsChecked);
-    
+    UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("Settings Form: Pipe auto-connect enabled changed to %d"), bIsChecked);
+
     if (bApplyImmediately)
     {
         CachedSubsystem->TriggerAutoConnectRefresh();
@@ -2156,16 +2156,16 @@ void USmartSettingsFormWidget::OnPipeTierMainChanged(FString SelectedItem, ESele
     {
         return;  // Ignore programmatic changes
     }
-    
+
     if (!CachedSubsystem.IsValid())
     {
         return;
     }
-    
+
     int32 Tier = DisplayStringToPipeTier(SelectedItem);
     CachedSubsystem->SetAutoConnectPipeTierMain(Tier);
-    UE_LOG(LogSmartFoundations, Log, TEXT("Settings Form: Pipe tier main changed to %d (%s)"), Tier, *SelectedItem);
-    
+    UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("Settings Form: Pipe tier main changed to %d (%s)"), Tier, *SelectedItem);
+
     if (bApplyImmediately)
     {
         CachedSubsystem->TriggerAutoConnectRefresh();
@@ -2178,16 +2178,16 @@ void USmartSettingsFormWidget::OnPipeTierToBuildingChanged(FString SelectedItem,
     {
         return;  // Ignore programmatic changes
     }
-    
+
     if (!CachedSubsystem.IsValid())
     {
         return;
     }
-    
+
     int32 Tier = DisplayStringToPipeTier(SelectedItem);
     CachedSubsystem->SetAutoConnectPipeTierToBuilding(Tier);
-    UE_LOG(LogSmartFoundations, Log, TEXT("Settings Form: Pipe tier to building changed to %d (%s)"), Tier, *SelectedItem);
-    
+    UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("Settings Form: Pipe tier to building changed to %d (%s)"), Tier, *SelectedItem);
+
     if (bApplyImmediately)
     {
         CachedSubsystem->TriggerAutoConnectRefresh();
@@ -2200,9 +2200,9 @@ void USmartSettingsFormWidget::OnPipeIndicatorChanged(bool bIsChecked)
     {
         return;
     }
-    
+
     CachedSubsystem->SetAutoConnectPipeIndicator(bIsChecked);
-    UE_LOG(LogSmartFoundations, Log, TEXT("Settings Form: Pipe indicator changed to %d (%s)"), bIsChecked, bIsChecked ? TEXT("Normal") : TEXT("Clean"));
+    UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("Settings Form: Pipe indicator changed to %d (%s)"), bIsChecked, bIsChecked ? TEXT("Normal") : TEXT("Clean"));
 }
 
 void USmartSettingsFormWidget::OnPipeRoutingModeChanged(FString SelectedItem, ESelectInfo::Type SelectionType)
@@ -2211,12 +2211,12 @@ void USmartSettingsFormWidget::OnPipeRoutingModeChanged(FString SelectedItem, ES
     {
         return;  // Ignore programmatic changes
     }
-    
+
     if (!CachedSubsystem.IsValid())
     {
         return;
     }
-    
+
     // Convert display string to routing mode index
     int32 RoutingMode = 0;
     if (SelectedItem == TEXT("Auto")) RoutingMode = 0;
@@ -2225,10 +2225,10 @@ void USmartSettingsFormWidget::OnPipeRoutingModeChanged(FString SelectedItem, ES
     else if (SelectedItem == TEXT("Curve")) RoutingMode = 3;
     else if (SelectedItem == TEXT("Noodle")) RoutingMode = 4;
     else if (SelectedItem == TEXT("Horiz→Vert")) RoutingMode = 5;
-    
+
     CachedSubsystem->SetAutoConnectPipeRoutingMode(RoutingMode);
-    UE_LOG(LogSmartFoundations, Log, TEXT("Settings Form: Pipe routing mode changed to %d (%s)"), RoutingMode, *SelectedItem);
-    
+    UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("Settings Form: Pipe routing mode changed to %d (%s)"), RoutingMode, *SelectedItem);
+
     if (bApplyImmediately)
     {
         CachedSubsystem->TriggerAutoConnectRefresh();
@@ -2271,7 +2271,7 @@ void USmartSettingsFormWidget::PopulatePowerComboBoxes()
         PowerGridAxisComboBox->AddOption(TEXT("Y"));
         PowerGridAxisComboBox->AddOption(TEXT("X+Y"));
     }
-    
+
     // Populate Reserved Slots ComboBox (0-5)
     if (PowerReservedComboBox)
     {
@@ -2281,8 +2281,8 @@ void USmartSettingsFormWidget::PopulatePowerComboBoxes()
             PowerReservedComboBox->AddOption(FString::Printf(TEXT("%d"), i));
         }
     }
-    
-    UE_LOG(LogSmartFoundations, Log, TEXT("Settings Form: Populated power ComboBoxes"));
+
+    UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("Settings Form: Populated power ComboBoxes"));
 }
 
 void USmartSettingsFormWidget::UpdatePowerAutoConnectControls()
@@ -2291,28 +2291,28 @@ void USmartSettingsFormWidget::UpdatePowerAutoConnectControls()
     {
         return;
     }
-    
+
     const auto& Settings = CachedSubsystem->GetAutoConnectRuntimeSettings();
-    
+
     // Update Enabled checkbox
     if (PowerEnabledCheckBox)
     {
         PowerEnabledCheckBox->SetIsChecked(Settings.bConnectPower);
     }
-    
+
     // Update Grid Axis ComboBox
     if (PowerGridAxisComboBox)
     {
         PowerGridAxisComboBox->SetSelectedOption(PowerGridAxisToDisplayString(Settings.PowerGridAxis));
     }
-    
+
     // Update Reserved Slots ComboBox
     if (PowerReservedComboBox)
     {
         PowerReservedComboBox->SetSelectedOption(FString::Printf(TEXT("%d"), Settings.PowerReserved));
     }
-    
-    UE_LOG(LogSmartFoundations, Log, TEXT("Settings Form: Updated power controls - Enabled=%d, GridAxis=%d, Reserved=%d"),
+
+    UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("Settings Form: Updated power controls - Enabled=%d, GridAxis=%d, Reserved=%d"),
         Settings.bConnectPower, Settings.PowerGridAxis, Settings.PowerReserved);
 }
 
@@ -2322,10 +2322,10 @@ void USmartSettingsFormWidget::OnPowerEnabledChanged(bool bIsChecked)
     {
         return;
     }
-    
+
     CachedSubsystem->SetAutoConnectPowerEnabled(bIsChecked);
-    UE_LOG(LogSmartFoundations, Log, TEXT("Settings Form: Power auto-connect enabled changed to %d"), bIsChecked);
-    
+    UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("Settings Form: Power auto-connect enabled changed to %d"), bIsChecked);
+
     if (bApplyImmediately)
     {
         CachedSubsystem->TriggerAutoConnectRefresh();
@@ -2338,16 +2338,16 @@ void USmartSettingsFormWidget::OnPowerGridAxisChanged(FString SelectedItem, ESel
     {
         return;  // Ignore programmatic changes
     }
-    
+
     if (!CachedSubsystem.IsValid())
     {
         return;
     }
-    
+
     int32 Axis = DisplayStringToPowerGridAxis(SelectedItem);
     CachedSubsystem->SetAutoConnectPowerGridAxis(Axis);
-    UE_LOG(LogSmartFoundations, Log, TEXT("Settings Form: Power grid axis changed to %d (%s)"), Axis, *SelectedItem);
-    
+    UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("Settings Form: Power grid axis changed to %d (%s)"), Axis, *SelectedItem);
+
     if (bApplyImmediately)
     {
         CachedSubsystem->TriggerAutoConnectRefresh();
@@ -2360,16 +2360,16 @@ void USmartSettingsFormWidget::OnPowerReservedChanged(FString SelectedItem, ESel
     {
         return;  // Ignore programmatic changes
     }
-    
+
     if (!CachedSubsystem.IsValid())
     {
         return;
     }
-    
+
     int32 Reserved = FCString::Atoi(*SelectedItem);
     CachedSubsystem->SetAutoConnectPowerReserved(Reserved);
-    UE_LOG(LogSmartFoundations, Log, TEXT("Settings Form: Power reserved slots changed to %d"), Reserved);
-    
+    UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("Settings Form: Power reserved slots changed to %d"), Reserved);
+
     if (bApplyImmediately)
     {
         CachedSubsystem->TriggerAutoConnectRefresh();
@@ -2384,21 +2384,21 @@ void USmartSettingsFormWidget::OnGridXDirToggleClicked()
 {
     bGridXPositive = !bGridXPositive;
     UpdateGridDirectionLabel(GridXDirLabel, bGridXPositive);
-    UE_LOG(LogSmartFoundations, Log, TEXT("Settings Form: Grid X direction toggled to %s"), bGridXPositive ? TEXT("+") : TEXT("-"));
+    UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("Settings Form: Grid X direction toggled to %s"), bGridXPositive ? TEXT("+") : TEXT("-"));
 }
 
 void USmartSettingsFormWidget::OnGridYDirToggleClicked()
 {
     bGridYPositive = !bGridYPositive;
     UpdateGridDirectionLabel(GridYDirLabel, bGridYPositive);
-    UE_LOG(LogSmartFoundations, Log, TEXT("Settings Form: Grid Y direction toggled to %s"), bGridYPositive ? TEXT("+") : TEXT("-"));
+    UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("Settings Form: Grid Y direction toggled to %s"), bGridYPositive ? TEXT("+") : TEXT("-"));
 }
 
 void USmartSettingsFormWidget::OnGridZDirToggleClicked()
 {
     bGridZPositive = !bGridZPositive;
     UpdateGridDirectionLabel(GridZDirLabel, bGridZPositive);
-    UE_LOG(LogSmartFoundations, Log, TEXT("Settings Form: Grid Z direction toggled to %s"), bGridZPositive ? TEXT("+") : TEXT("-"));
+    UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("Settings Form: Grid Z direction toggled to %s"), bGridZPositive ? TEXT("+") : TEXT("-"));
 }
 
 void USmartSettingsFormWidget::UpdateGridDirectionLabel(UTextBlock* Label, bool bPositive)
@@ -2426,26 +2426,26 @@ FReply USmartSettingsFormWidget::NativeOnKeyDown(const FGeometry& InGeometry, co
         // If confirmation dialog is open, dismiss it
         if (bWaitingForConfirmation)
         {
-            UE_LOG(LogSmartFoundations, Log, TEXT("Settings Form: Escape pressed - dismissing confirmation dialog"));
+            UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("Settings Form: Escape pressed - dismissing confirmation dialog"));
             OnConfirmNoClicked();
             return FReply::Handled();
         }
-        
+
         // Otherwise, cancel unapplied changes and close form
-        UE_LOG(LogSmartFoundations, Log, TEXT("Settings Form: Escape pressed - reverting and closing"));
+        UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("Settings Form: Escape pressed - reverting and closing"));
         RevertToLastAppliedState();
         CloseForm();
         return FReply::Handled();
     }
-    
+
     // Enter key applies changes (only when a SpinBox has focus)
     if (InKeyEvent.GetKey() == EKeys::Enter && IsAnyTextInputFocused())
     {
-        UE_LOG(LogSmartFoundations, Log, TEXT("Settings Form: Enter pressed with SpinBox focused - applying"));
+        UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("Settings Form: Enter pressed with SpinBox focused - applying"));
         OnApplyButtonClicked();
         return FReply::Handled();
     }
-    
+
     // Issue #212: Tab/Shift+Tab navigates between SpinBox fields in logical order
     if (InKeyEvent.GetKey() == EKeys::Tab && IsAnyTextInputFocused())
     {
@@ -2464,7 +2464,7 @@ FReply USmartSettingsFormWidget::NativeOnKeyDown(const FGeometry& InGeometry, co
         if (StaggerZXInput) TabOrder.Add(StaggerZXInput);
         if (StaggerZYInput) TabOrder.Add(StaggerZYInput);
         if (RotationZInput) TabOrder.Add(RotationZInput);
-        
+
         // Find currently focused SpinBox
         int32 CurrentIndex = INDEX_NONE;
         for (int32 i = 0; i < TabOrder.Num(); ++i)
@@ -2475,7 +2475,7 @@ FReply USmartSettingsFormWidget::NativeOnKeyDown(const FGeometry& InGeometry, co
                 break;
             }
         }
-        
+
         if (CurrentIndex != INDEX_NONE && TabOrder.Num() > 1)
         {
             int32 NextIndex;
@@ -2489,13 +2489,13 @@ FReply USmartSettingsFormWidget::NativeOnKeyDown(const FGeometry& InGeometry, co
                 // Tab: go forward (wrap around)
                 NextIndex = (CurrentIndex + 1) % TabOrder.Num();
             }
-            
+
             TabOrder[NextIndex]->SetKeyboardFocus();
             UE_LOG(LogSmartFoundations, Verbose, TEXT("Settings Form: Tab navigation %d -> %d"), CurrentIndex, NextIndex);
             return FReply::Handled();
         }
     }
-    
+
     return Super::NativeOnKeyDown(InGeometry, InKeyEvent);
 }
 
@@ -2517,7 +2517,7 @@ void USmartSettingsFormWidget::OnGridSpinBoxValueChanged(float Value)
 {
     // Update warning display whenever grid values change
     UpdateGridWarningDisplay();
-    
+
     // Also handle immediate mode apply (if still enabled - will be auto-disabled for large grids)
     if (bApplyImmediately)
     {
@@ -2530,11 +2530,11 @@ void USmartSettingsFormWidget::OnSpinBoxValueCommitted(float Value, ETextCommit:
 {
     // Enter key is now handled globally in NativeOnKeyDown to avoid false triggers
     // from SpinBox button clicks which also fire OnEnter
-    
+
     // Only apply on focus loss in immediate mode
     if (bApplyImmediately && (CommitMethod == ETextCommit::Default || CommitMethod == ETextCommit::OnUserMovedFocus))
     {
-        UE_LOG(LogSmartFoundations, Log, TEXT("Settings Form: SpinBox focus lost (immediate mode) - applying"));
+        UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("Settings Form: SpinBox focus lost (immediate mode) - applying"));
         OnApplyButtonClicked();
     }
 }
@@ -2546,7 +2546,7 @@ void USmartSettingsFormWidget::OnSpinBoxValueCommitted(float Value, ETextCommit:
 void USmartSettingsFormWidget::OnApplyImmediatelyChanged(bool bIsChecked)
 {
     bApplyImmediately = bIsChecked;
-    UE_LOG(LogSmartFoundations, Log, TEXT("Settings Form: Apply immediately mode changed to %d"), bIsChecked);
+    UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("Settings Form: Apply immediately mode changed to %d"), bIsChecked);
 }
 
 // ========================================
@@ -2570,17 +2570,17 @@ void USmartSettingsFormWidget::RevertToLastAppliedState()
     {
         return;
     }
-    
+
     // Restore the last applied state
     CachedSubsystem->UpdateCounterState(LastAppliedState);
     CachedSubsystem->RegenerateChildHologramGrid();
-    
+
     // Restore direction state
     bGridXPositive = bLastAppliedGridXPositive;
     bGridYPositive = bLastAppliedGridYPositive;
     bGridZPositive = bLastAppliedGridZPositive;
-    
-    UE_LOG(LogSmartFoundations, Log, TEXT("Settings Form: Reverted to last applied state"));
+
+    UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("Settings Form: Reverted to last applied state"));
 }
 
 bool USmartSettingsFormWidget::IsAnyTextInputFocused() const
@@ -2589,7 +2589,7 @@ bool USmartSettingsFormWidget::IsAnyTextInputFocused() const
     {
         return SpinBox && SpinBox->HasKeyboardFocus();
     };
-    
+
     return IsSpinBoxFocused(GridXInput) ||
            IsSpinBoxFocused(GridYInput) ||
            IsSpinBoxFocused(GridZInput) ||
@@ -2614,19 +2614,19 @@ int32 USmartSettingsFormWidget::CalculateGridTotal() const
     int32 GridX = GridXInput ? FMath::Max(1, FMath::RoundToInt(GridXInput->GetValue())) : 1;
     int32 GridY = GridYInput ? FMath::Max(1, FMath::RoundToInt(GridYInput->GetValue())) : 1;
     int32 GridZ = GridZInput ? FMath::Max(1, FMath::RoundToInt(GridZInput->GetValue())) : 1;
-    
+
     return GridX * GridY * GridZ;
 }
 
 void USmartSettingsFormWidget::UpdateGridWarningDisplay()
 {
     int32 GridTotal = CalculateGridTotal();
-    
+
     // Update Grid Total text
     if (GridTotalText)
     {
         GridTotalText->SetText(FText::Format(LOCTEXT("Panel_GridTotal", "Grid Total: {0} holograms"), FText::AsNumber(GridTotal)));
-        
+
         // Set color based on warning level
         FLinearColor TextColor;
         if (GridTotal >= GRID_WARNING_THRESHOLD_DANGER)
@@ -2647,7 +2647,7 @@ void USmartSettingsFormWidget::UpdateGridWarningDisplay()
         }
         GridTotalText->SetColorAndOpacity(FSlateColor(TextColor));
     }
-    
+
     // Update warning text (avoid Unicode symbols - game font doesn't support them)
     if (GridWarningText)
     {
@@ -2674,7 +2674,7 @@ void USmartSettingsFormWidget::UpdateGridWarningDisplay()
             GridWarningText->SetVisibility(ESlateVisibility::Collapsed);
         }
     }
-    
+
     // Update Apply Immediately state based on grid size
     UpdateApplyImmediatelyState();
 }
@@ -2687,7 +2687,7 @@ bool USmartSettingsFormWidget::RequiresApplyConfirmation() const
 void USmartSettingsFormWidget::UpdateApplyImmediatelyState()
 {
     int32 GridTotal = CalculateGridTotal();
-    
+
     if (GridTotal >= GRID_WARNING_THRESHOLD_WARNING)
     {
         // Auto-disable Apply Immediately for large grids
@@ -2695,14 +2695,14 @@ void USmartSettingsFormWidget::UpdateApplyImmediatelyState()
         {
             bApplyImmediatelyWasEnabled = true;
             bApplyImmediately = false;
-            
+
             if (ApplyImmediatelyCheckBox)
             {
                 ApplyImmediatelyCheckBox->SetIsChecked(false);
                 ApplyImmediatelyCheckBox->SetIsEnabled(false);
             }
-            
-            UE_LOG(LogSmartFoundations, Log, TEXT("Settings Form: Apply Immediately auto-disabled for large grid (%d objects)"), GridTotal);
+
+            UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("Settings Form: Apply Immediately auto-disabled for large grid (%d objects)"), GridTotal);
         }
         else if (ApplyImmediatelyCheckBox)
         {
@@ -2717,19 +2717,19 @@ void USmartSettingsFormWidget::UpdateApplyImmediatelyState()
         {
             ApplyImmediatelyCheckBox->SetIsEnabled(true);
         }
-        
+
         // Restore previous state if it was auto-disabled
         if (bApplyImmediatelyWasEnabled)
         {
             bApplyImmediately = true;
             bApplyImmediatelyWasEnabled = false;
-            
+
             if (ApplyImmediatelyCheckBox)
             {
                 ApplyImmediatelyCheckBox->SetIsChecked(true);
             }
-            
-            UE_LOG(LogSmartFoundations, Log, TEXT("Settings Form: Apply Immediately restored (grid now %d objects)"), GridTotal);
+
+            UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("Settings Form: Apply Immediately restored (grid now %d objects)"), GridTotal);
         }
     }
 }
@@ -2737,16 +2737,16 @@ void USmartSettingsFormWidget::UpdateApplyImmediatelyState()
 void USmartSettingsFormWidget::ShowLargeGridConfirmation(TFunction<void()> OnConfirmed)
 {
     int32 GridTotal = CalculateGridTotal();
-    
+
     // Store callback for when user confirms
     PendingConfirmCallback = OnConfirmed;
     bWaitingForConfirmation = true;
-    
+
     // Determine warning level and message
     FString Title;
     FString Message;
     FLinearColor TitleColor;
-    
+
     if (GridTotal >= GRID_WARNING_THRESHOLD_DANGER)
     {
         Title = LOCTEXT("Panel_Confirm_ExtremeTitle", "EXTREME GRID WARNING!").ToString();
@@ -2771,7 +2771,7 @@ void USmartSettingsFormWidget::ShowLargeGridConfirmation(TFunction<void()> OnCon
         }
         return;
     }
-    
+
     // Show the confirmation dialog
     ShowConfirmationDialog(Title, Message, TitleColor);
 }
@@ -2789,22 +2789,22 @@ void USmartSettingsFormWidget::ShowConfirmationDialog(const FString& Title, cons
         bWaitingForConfirmation = false;
         return;
     }
-    
+
     // Set dialog content
     if (ConfirmationTitle)
     {
         ConfirmationTitle->SetText(FText::FromString(Title));
         ConfirmationTitle->SetColorAndOpacity(FSlateColor(TitleColor));
     }
-    
+
     if (ConfirmationMessage)
     {
         ConfirmationMessage->SetText(FText::FromString(Message));
     }
-    
+
     // Show the dialog (use SizeBox for visibility control)
     ConfirmationSizeBox->SetVisibility(ESlateVisibility::Visible);
-    
+
     // Focus the Cancel button by default (safer option)
     if (ConfirmNoButton)
     {
@@ -2823,10 +2823,10 @@ void USmartSettingsFormWidget::HideConfirmationDialog()
 
 void USmartSettingsFormWidget::OnConfirmYesClicked()
 {
-    UE_LOG(LogSmartFoundations, Log, TEXT("Settings Form: User confirmed large grid operation"));
-    
+    UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("Settings Form: User confirmed large grid operation"));
+
     HideConfirmationDialog();
-    
+
     // Execute the pending callback
     if (PendingConfirmCallback)
     {
@@ -2837,8 +2837,8 @@ void USmartSettingsFormWidget::OnConfirmYesClicked()
 
 void USmartSettingsFormWidget::OnConfirmNoClicked()
 {
-    UE_LOG(LogSmartFoundations, Log, TEXT("Settings Form: User cancelled large grid operation"));
-    
+    UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("Settings Form: User cancelled large grid operation"));
+
     HideConfirmationDialog();
     PendingConfirmCallback = nullptr;
 }
@@ -2853,21 +2853,21 @@ void USmartSettingsFormWidget::UpdateStackableBeltAutoConnectControls()
     {
         return;
     }
-    
+
     const auto& Settings = CachedSubsystem->GetAutoConnectRuntimeSettings();
-    
+
     // Log widget availability for debugging
-    UE_LOG(LogSmartFoundations, Log, TEXT("Stackable Belt Widget Status: Direction=%s, TierToBuilding=%s, Chain=%s"),
+    UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("Stackable Belt Widget Status: Direction=%s, TierToBuilding=%s, Chain=%s"),
         StackableBeltDirectionComboBox ? TEXT("Valid") : TEXT("NULL"),
         BeltTierToBuildingComboBox ? TEXT("Valid") : TEXT("NULL"),
         BeltChainCheckBox ? TEXT("Valid") : TEXT("NULL"));
-    
+
     // Update Enabled checkbox
     if (BeltEnabledCheckBox)
     {
         BeltEnabledCheckBox->SetIsChecked(Settings.bStackableBeltEnabled);
     }
-    
+
     // Update Tier ComboBox (reuse main belt tier)
     if (BeltTierMainComboBox)
     {
@@ -2878,18 +2878,18 @@ void USmartSettingsFormWidget::UpdateStackableBeltAutoConnectControls()
         }
         BeltTierMainComboBox->SetSelectedIndex(Index);
     }
-    
+
     // Use dedicated StackableBeltDirectionComboBox for direction selection
     if (StackableBeltDirectionComboBox)
     {
         StackableBeltDirectionComboBox->ClearOptions();
         StackableBeltDirectionComboBox->AddOption(TEXT("Forward"));
         StackableBeltDirectionComboBox->AddOption(TEXT("Backward"));
-        
+
         int32 DirectionIndex = Settings.StackableBeltDirection;
         StackableBeltDirectionComboBox->SetSelectedIndex(DirectionIndex);
     }
-    
+
     // Show direction row, hide irrelevant rows for stackable poles
     if (StackableBeltDirectionRow)
     {
@@ -2911,8 +2911,8 @@ void USmartSettingsFormWidget::UpdateStackableBeltAutoConnectControls()
     {
         BeltChainLabel->SetVisibility(ESlateVisibility::Collapsed);
     }
-    
-    UE_LOG(LogSmartFoundations, Log, TEXT("Settings Form: Updated stackable belt controls - Enabled=%d, Tier=%d, Direction=%d"),
+
+    UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("Settings Form: Updated stackable belt controls - Enabled=%d, Tier=%d, Direction=%d"),
         Settings.bStackableBeltEnabled, Settings.BeltTierMain, Settings.StackableBeltDirection);
 }
 
@@ -2922,15 +2922,15 @@ void USmartSettingsFormWidget::UpdateStackablePipeAutoConnectControls()
     {
         return;
     }
-    
+
     const auto& Settings = CachedSubsystem->GetAutoConnectRuntimeSettings();
-    
+
     // Update Enabled checkbox
     if (PipeEnabledCheckBox)
     {
         PipeEnabledCheckBox->SetIsChecked(Settings.bPipeAutoConnectEnabled);
     }
-    
+
     // Update To Building tier ComboBox (Stackable and Floor holes use this per user request)
     if (PipeTierToBuildingComboBox)
     {
@@ -2941,21 +2941,21 @@ void USmartSettingsFormWidget::UpdateStackablePipeAutoConnectControls()
         }
         PipeTierToBuildingComboBox->SetSelectedIndex(Index);
     }
-    
+
     // Hide irrelevant controls for stackable pipe supports
     if (PipeTierMainRow) PipeTierMainRow->SetVisibility(ESlateVisibility::Collapsed);
     if (PipeTierToBuildingRow) PipeTierToBuildingRow->SetVisibility(ESlateVisibility::Visible);
-    
+
     // Update Flow Indicator checkbox and row visibility
     // Only show if clean pipes are unlocked - otherwise flow indicators are implicit
     AFGPlayerController* PC = Cast<AFGPlayerController>(GetOwningPlayer());
     bool bCleanPipesUnlocked = CachedSubsystem->AreCleanPipesUnlocked(PC);
-    
+
     if (PipeIndicatorRow)
     {
         PipeIndicatorRow->SetVisibility(bCleanPipesUnlocked ? ESlateVisibility::Visible : ESlateVisibility::Collapsed);
     }
-    
+
     if (PipeIndicatorCheckBox)
     {
         // If clean pipes not unlocked, force to true (with indicators)
@@ -2968,7 +2968,7 @@ void USmartSettingsFormWidget::UpdateStackablePipeAutoConnectControls()
             PipeIndicatorCheckBox->SetIsChecked(Settings.bPipeIndicator);
         }
     }
-    
+
     // Update Routing Mode ComboBox (same as regular pipe controls)
     if (PipeRoutingModeComboBox)
     {
@@ -2979,12 +2979,12 @@ void USmartSettingsFormWidget::UpdateStackablePipeAutoConnectControls()
         PipeRoutingModeComboBox->AddOption(TEXT("Curve"));
         PipeRoutingModeComboBox->AddOption(TEXT("Noodle"));
         PipeRoutingModeComboBox->AddOption(TEXT("Horiz→Vert"));
-        
+
         int32 ModeIndex = FMath::Clamp(Settings.PipeRoutingMode, 0, 5);
         PipeRoutingModeComboBox->SetSelectedIndex(ModeIndex);
     }
-    
-    UE_LOG(LogSmartFoundations, Log, TEXT("Settings Form: Updated stackable/floor hole pipe controls - Enabled=%d, Tier=%d, Indicator=%d, RoutingMode=%d, CleanUnlocked=%d"),
+
+    UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("Settings Form: Updated stackable/floor hole pipe controls - Enabled=%d, Tier=%d, Indicator=%d, RoutingMode=%d, CleanUnlocked=%d"),
         Settings.bPipeAutoConnectEnabled, Settings.PipeTierToBuilding, Settings.bPipeIndicator, Settings.PipeRoutingMode, bCleanPipesUnlocked);
 }
 

--- a/Source/SmartFoundations/Private/UI/SmartUpgradePanel.cpp
+++ b/Source/SmartFoundations/Private/UI/SmartUpgradePanel.cpp
@@ -400,25 +400,25 @@ void USmartUpgradePanel::NativeConstruct()
 
 void USmartUpgradePanel::OnCloseButtonClicked()
 {
-	UE_LOG(LogSmartFoundations, Log, TEXT("Upgrade Panel: Close button clicked"));
+	UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("Upgrade Panel: Close button clicked"));
 	ClosePanel();
 }
 
 void USmartUpgradePanel::OnRefreshButtonClicked()
 {
-	UE_LOG(LogSmartFoundations, Log, TEXT("Upgrade Panel: Refresh button clicked"));
+	UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("Upgrade Panel: Refresh button clicked"));
 	RefreshAudit();
 }
 
 void USmartUpgradePanel::OnCancelButtonClicked()
 {
-	UE_LOG(LogSmartFoundations, Log, TEXT("Upgrade Panel: Cancel button clicked"));
+	UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("Upgrade Panel: Cancel button clicked"));
 	CancelAudit();
 }
 
 void USmartUpgradePanel::OnEntireMapButtonClicked()
 {
-	UE_LOG(LogSmartFoundations, Log, TEXT("Upgrade Panel: Entire Map button clicked - scanning with no radius limit"));
+	UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("Upgrade Panel: Entire Map button clicked - scanning with no radius limit"));
 	CurrentRadiusMeters = 0.0f;
 
 	// Update spinbox to show 0 (visual indicator that "entire map" is active)
@@ -450,12 +450,12 @@ void USmartUpgradePanel::OnRadiusValueChanged(float NewValue)
 		RadiusSpinBox->SetValue(CurrentRadiusMeters);
 	}
 
-	UE_LOG(LogSmartFoundations, Log, TEXT("Upgrade Panel: Radius changed to %.0fm"), CurrentRadiusMeters);
+	UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("Upgrade Panel: Radius changed to %.0fm"), CurrentRadiusMeters);
 }
 
 void USmartUpgradePanel::OnUpgradeButtonClicked()
 {
-	UE_LOG(LogSmartFoundations, Log, TEXT("Upgrade Panel: Upgrade button clicked - Family=%d Tier=%d IsRadiusTab=%d"),
+	UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("Upgrade Panel: Upgrade button clicked - Family=%d Tier=%d IsRadiusTab=%d"),
 		static_cast<int32>(SelectedFamily), SelectedTier, (ActiveTab == ESmartUpgradeTab::Radius) ? 1 : 0);
 
 	// In traversal mode, we may have items at multiple tiers - don't require SelectedTier
@@ -511,15 +511,15 @@ void USmartUpgradePanel::OnUpgradeButtonClicked()
 
 	// Get target tier from dropdown (or use cached value)
 	int32 TargetTier = GetSelectedTargetTier();
-	UE_LOG(LogSmartFoundations, Log, TEXT("Upgrade Panel: GetSelectedTargetTier returned %d, CachedTargetTier=%d"), TargetTier, CachedTargetTier);
+	UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("Upgrade Panel: GetSelectedTargetTier returned %d, CachedTargetTier=%d"), TargetTier, CachedTargetTier);
 	if (TargetTier == 0)
 	{
 		// No target selected - use max unlocked tier
 		TargetTier = CachedTargetTier;
-		UE_LOG(LogSmartFoundations, Log, TEXT("Upgrade Panel: Using CachedTargetTier=%d as fallback"), TargetTier);
+		UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("Upgrade Panel: Using CachedTargetTier=%d as fallback"), TargetTier);
 	}
 
-	UE_LOG(LogSmartFoundations, Log, TEXT("Upgrade Panel: Starting upgrade - SourceTier=%d TargetTier=%d TraversalMode=%d"),
+	UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("Upgrade Panel: Starting upgrade - SourceTier=%d TargetTier=%d TraversalMode=%d"),
 		SelectedTier, TargetTier, bIsTraversalMode);
 
 	// Validate target tier
@@ -565,7 +565,7 @@ void USmartUpgradePanel::OnUpgradeButtonClicked()
 				Params.SpecificBuildables.Add(Entry.Buildable);
 			}
 		}
-		UE_LOG(LogSmartFoundations, Log, TEXT("Upgrade Panel: Using %d buildables from traversal scan"), Params.SpecificBuildables.Num());
+		UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("Upgrade Panel: Using %d buildables from traversal scan"), Params.SpecificBuildables.Num());
 	}
 	else
 	{
@@ -590,7 +590,7 @@ void USmartUpgradePanel::OnUpgradeButtonClicked()
 
 void USmartUpgradePanel::RefreshAudit()
 {
-	UE_LOG(LogSmartFoundations, Log, TEXT("Upgrade Panel: RefreshAudit() requested"));
+	UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("Upgrade Panel: RefreshAudit() requested"));
 
 	if (USFSubsystem* Subsystem = USFSubsystem::Get(this))
 	{
@@ -604,7 +604,7 @@ void USmartUpgradePanel::RefreshAudit()
 			Params.Radius = CurrentRadiusMeters * 100.0f;  // Convert meters to cm
 			Params.bStoreEntries = true;
 
-			UE_LOG(LogSmartFoundations, Log, TEXT("Upgrade Panel: Starting audit with radius %.0fm (%.0f cm)"),
+			UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("Upgrade Panel: Starting audit with radius %.0fm (%.0f cm)"),
 				CurrentRadiusMeters, Params.Radius);
 
 			// Trigger via RCO if we're a client, otherwise direct call
@@ -620,7 +620,7 @@ void USmartUpgradePanel::RefreshAudit()
 						if (RCO->GetOuter() == PC)
 						{
 							RCO->Server_StartUpgradeAudit(Params);
-							UE_LOG(LogSmartFoundations, Log, TEXT("Upgrade Panel: Sent Refresh request via SFRCO"));
+							UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("Upgrade Panel: Sent Refresh request via SFRCO"));
 							return;
 						}
 					}
@@ -641,7 +641,7 @@ void USmartUpgradePanel::RefreshAudit()
 
 void USmartUpgradePanel::CancelAudit()
 {
-	UE_LOG(LogSmartFoundations, Log, TEXT("Upgrade Panel: CancelAudit() requested"));
+	UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("Upgrade Panel: CancelAudit() requested"));
 
 	if (USFSubsystem* Subsystem = USFSubsystem::Get(this))
 	{
@@ -662,7 +662,7 @@ void USmartUpgradePanel::CancelAudit()
 						if (RCO->GetOuter() == PC)
 						{
 							RCO->Server_CancelUpgradeAudit();
-							UE_LOG(LogSmartFoundations, Log, TEXT("Upgrade Panel: Sent Cancel request via SFRCO"));
+							UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("Upgrade Panel: Sent Cancel request via SFRCO"));
 							return;
 						}
 					}
@@ -925,7 +925,7 @@ void USmartUpgradePanel::UpdateAuditUI(const FSFUpgradeAuditResult& Result)
 
 void USmartUpgradePanel::ClosePanel()
 {
-	UE_LOG(LogSmartFoundations, Log, TEXT("Upgrade Panel: ClosePanel() called"));
+	UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("Upgrade Panel: ClosePanel() called"));
 
 	// Get player controller
 	APlayerController* PC = GetOwningPlayer();
@@ -956,7 +956,7 @@ void USmartUpgradePanel::ClosePanel()
 		Subsystem->ClearUpgradePanelWidget();
 	}
 
-	UE_LOG(LogSmartFoundations, Log, TEXT("Upgrade Panel: Closed and input restored"));
+	UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("Upgrade Panel: Closed and input restored"));
 }
 
 FReply USmartUpgradePanel::NativeOnKeyDown(const FGeometry& InGeometry, const FKeyEvent& InKeyEvent)
@@ -964,7 +964,7 @@ FReply USmartUpgradePanel::NativeOnKeyDown(const FGeometry& InGeometry, const FK
 	// Handle ESC key to close panel
 	if (InKeyEvent.GetKey() == EKeys::Escape)
 	{
-		UE_LOG(LogSmartFoundations, Log, TEXT("Upgrade Panel: ESC key pressed - closing"));
+		UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("Upgrade Panel: ESC key pressed - closing"));
 		ClosePanel();
 		return FReply::Handled();
 	}
@@ -1043,7 +1043,7 @@ FReply USmartUpgradePanel::NativeOnMouseMove(const FGeometry& InGeometry, const 
 
 void USmartUpgradePanel::OnRowSelected(ESFUpgradeFamily Family, int32 Tier)
 {
-	UE_LOG(LogSmartFoundations, Log, TEXT("Upgrade Panel: Row selected - Family=%d Tier=%d"), static_cast<int32>(Family), Tier);
+	UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("Upgrade Panel: Row selected - Family=%d Tier=%d"), static_cast<int32>(Family), Tier);
 
 	// Get player location
 	APlayerController* PC = GetOwningPlayer();
@@ -1158,7 +1158,7 @@ void USmartUpgradePanel::OnRowSelected(ESFUpgradeFamily Family, int32 Tier)
 		UpgradeButton->SetIsEnabled(true);
 	}
 
-	UE_LOG(LogSmartFoundations, Log, TEXT("Upgrade Panel: Nearest %s is %.0fm %s at %s"),
+	UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("Upgrade Panel: Nearest %s is %.0fm %s at %s"),
 		*DisplayName, DistanceMeters, *Direction, *ClosestLocation.ToString());
 }
 
@@ -1236,7 +1236,7 @@ void USmartUpgradePanel::OnUpgradeCompleted(const FSFUpgradeExecutionResult& Res
 
 void USmartUpgradePanel::OnTargetTierChanged(FString SelectedItem, ESelectInfo::Type SelectionType)
 {
-	UE_LOG(LogSmartFoundations, Log, TEXT("Upgrade Panel: Target tier changed to: %s"), *SelectedItem);
+	UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("Upgrade Panel: Target tier changed to: %s"), *SelectedItem);
 
 	// Parse tier from selection (e.g., "Mk.4" -> 4)
 	CachedTargetTier = 0;
@@ -1354,7 +1354,7 @@ void USmartUpgradePanel::PopulateTargetTierDropdown()
 		ActiveComboBox->SetVisibility(ESlateVisibility::Collapsed);
 	}
 
-	UE_LOG(LogSmartFoundations, Log, TEXT("Upgrade Panel: Populated tier dropdown - Source=%d Max=%d Options=%d"),
+	UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("Upgrade Panel: Populated tier dropdown - Source=%d Max=%d Options=%d"),
 		SelectedTier, MaxTier, bHasOptions ? (MaxTier - SelectedTier) : 0);
 }
 
@@ -1719,19 +1719,19 @@ bool USmartUpgradePanel::CalculateUpgradeCost(ESFUpgradeFamily Family, int32 Sou
 
 void USmartUpgradePanel::OnRadiusTabClicked()
 {
-	UE_LOG(LogSmartFoundations, Log, TEXT("Upgrade Panel: Radius tab clicked"));
+	UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("Upgrade Panel: Radius tab clicked"));
 	SwitchToTab(ESmartUpgradeTab::Radius);
 }
 
 void USmartUpgradePanel::OnTraversalTabClicked()
 {
-	UE_LOG(LogSmartFoundations, Log, TEXT("Upgrade Panel: Traversal tab clicked"));
+	UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("Upgrade Panel: Traversal tab clicked"));
 	SwitchToTab(ESmartUpgradeTab::Traversal);
 }
 
 void USmartUpgradePanel::OnTriageTabClicked()
 {
-	UE_LOG(LogSmartFoundations, Log, TEXT("Upgrade Panel: Triage tab clicked"));
+	UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("Upgrade Panel: Triage tab clicked"));
 	SwitchToTab(ESmartUpgradeTab::Triage);
 }
 
@@ -1822,13 +1822,13 @@ void USmartUpgradePanel::SwitchToTab(ESmartUpgradeTab NewTab)
 		UpgradeButton->SetIsEnabled(false);
 	}
 
-	UE_LOG(LogSmartFoundations, Log, TEXT("Upgrade Panel: Switched to %s tab"),
+	UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("Upgrade Panel: Switched to %s tab"),
 		bRadiusTab ? TEXT("Radius") : bTraversalTab ? TEXT("Traversal") : TEXT("Triage"));
 }
 
 void USmartUpgradePanel::OnTriageDetectClicked()
 {
-	UE_LOG(LogSmartFoundations, Log, TEXT("Upgrade Panel: Triage Detect clicked"));
+	UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("Upgrade Panel: Triage Detect clicked"));
 
 	USFSubsystem* Subsystem = USFSubsystem::Get(this);
 	if (!Subsystem)
@@ -1892,7 +1892,7 @@ void USmartUpgradePanel::OnTriageDetectClicked()
 
 void USmartUpgradePanel::OnTriageRepairClicked()
 {
-	UE_LOG(LogSmartFoundations, Log, TEXT("Upgrade Panel: Triage Repair clicked"));
+	UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("Upgrade Panel: Triage Repair clicked"));
 
 	USFSubsystem* Subsystem = USFSubsystem::Get(this);
 	if (!Subsystem)
@@ -1966,7 +1966,7 @@ void USmartUpgradePanel::OnTriageRepairClicked()
 
 void USmartUpgradePanel::OnTraversalScanClicked()
 {
-	UE_LOG(LogSmartFoundations, Log, TEXT("Upgrade Panel: Traversal Scan clicked"));
+	UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("Upgrade Panel: Traversal Scan clicked"));
 
 	// Get player controller and build gun
 	AFGPlayerController* PC = Cast<AFGPlayerController>(GetOwningPlayer());
@@ -2002,7 +2002,7 @@ void USmartUpgradePanel::OnTraversalScanClicked()
 
 				if (AnchorBuildable)
 				{
-					UE_LOG(LogSmartFoundations, Log, TEXT("Upgrade Panel: Got upgrade target from hologram: %s"),
+					UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("Upgrade Panel: Got upgrade target from hologram: %s"),
 						*AnchorBuildable->GetClass()->GetName());
 				}
 			}
@@ -2049,7 +2049,7 @@ void USmartUpgradePanel::OnTraversalScanClicked()
 
 			if (AnchorBuildable)
 			{
-				UE_LOG(LogSmartFoundations, Log, TEXT("Upgrade Panel: Found buildable near aim point: %s (dist: %.1f)"),
+				UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("Upgrade Panel: Found buildable near aim point: %s (dist: %.1f)"),
 					*AnchorBuildable->GetClass()->GetName(), ClosestDist);
 			}
 		}
@@ -2070,7 +2070,7 @@ void USmartUpgradePanel::OnTraversalScanClicked()
 
 	// Check if it's an upgradeable type
 	ESFUpgradeFamily Family = USFUpgradeTraversalService::GetUpgradeFamily(AnchorBuildable);
-	UE_LOG(LogSmartFoundations, Log, TEXT("Upgrade Panel: GetUpgradeFamily for %s returned %d"),
+	UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("Upgrade Panel: GetUpgradeFamily for %s returned %d"),
 		*AnchorBuildable->GetClass()->GetName(), (int32)Family);
 
 	if (Family == ESFUpgradeFamily::None)
@@ -2195,7 +2195,7 @@ void USmartUpgradePanel::UpdateTraversalUI(const FSFTraversalResult& Result)
 		}
 	}
 
-	UE_LOG(LogSmartFoundations, Log, TEXT("Upgrade Panel: Traversal scan complete - %d items, %d upgradeable"),
+	UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("Upgrade Panel: Traversal scan complete - %d items, %d upgradeable"),
 		Result.TotalCount, Result.UpgradeableCount);
 }
 

--- a/Source/SmartFoundations/Public/Features/Extend/SFExtendService.h
+++ b/Source/SmartFoundations/Public/Features/Extend/SFExtendService.h
@@ -2,21 +2,21 @@
 
 /**
  * SFExtendService - EXTEND Feature Service
- * 
+ *
  * Enables cloning of factory infrastructure (belts, lifts, pipes, distributors, junctions)
  * when placing a matching factory hologram over an existing factory building.
- * 
+ *
  * Architecture (as of Dec 2025):
  * - Topology capture via WalkTopology() builds FSFExtendTopology
  * - JSON-based spawning via FSFCloneTopology::SpawnChildHolograms()
  * - Child holograms added to parent via AddChild() for vanilla cost aggregation
  * - Post-build wiring via FSFWiringManifest after factory construction
- * 
+ *
  * Key Files:
  * - SFExtendService.h/.cpp - Main service (topology, previews, diagnostics)
  * - SFManifoldJSON.h/.cpp - JSON schema for topology capture/clone/spawn
  * - SFWiringManifest.h/.cpp - Post-build connection wiring
- * 
+ *
  * Legacy systems removed (Dec 2025 cleanup):
  * - Deferred build system (PendingBuilds arrays, BuildPending* functions)
  * - Manual spawning functions (SpawnExtend*Child, SpawnManifold*Child)
@@ -83,7 +83,7 @@ struct FSFCapturedConnection
     bool bIsConnected = false;
     FString ConnectedToActor;
     FString ConnectedToConnector;
-    
+
     FSFCapturedConnection() = default;
 };
 
@@ -101,7 +101,7 @@ struct FSFCapturedSplinePoint
     FVector ArriveTangent = FVector::ZeroVector;
     FVector LeaveTangent = FVector::ZeroVector;
     FRotator Rotation = FRotator::ZeroRotator;
-    
+
     FSFCapturedSplinePoint() = default;
 };
 
@@ -119,57 +119,57 @@ struct FSFCapturedBuildable
     FString Name;
     FString ClassName;
     FString Category;
-    
+
     // === Transform ===
     FVector Location = FVector::ZeroVector;
     FRotator Rotation = FRotator::ZeroRotator;
     FVector Scale = FVector::OneVector;
     FVector BoundsMin = FVector::ZeroVector;
     FVector BoundsMax = FVector::ZeroVector;
-    
+
     // === State ===
     bool bIsHidden = false;
     bool bIsPendingKill = false;
     bool bHasBegunPlay = false;
-    
+
     // === Connections (Belts/Distributors/Factories) ===
     TArray<FSFCapturedConnection> FactoryConnections;
-    
+
     // === Pipe Connections ===
     TArray<FSFCapturedConnection> PipeConnections;
-    
+
     // === Spline Data (Belts/Pipes) ===
     TArray<FSFCapturedSplinePoint> SplinePoints;
     float SplineLength = 0.0f;
     int32 SplinePointCount = 0;
-    
+
     // === Belt-specific ===
     float BeltSpeed = 0.0f;
-    
+
     // === Lift-specific ===
     float LiftHeight = 0.0f;
     bool bLiftIsReversed = false;
     FVector LiftTopLocation = FVector::ZeroVector;
     FVector LiftBottomLocation = FVector::ZeroVector;
-    
+
     // === All Properties (raw dump) ===
     TArray<FString> AllProperties;
-    
+
     // === EXTEND Topology Flags ===
     /** Is this buildable part of the source EXTEND topology? */
     bool bIsExtendSource = false;
-    
+
     /** Specific role in the EXTEND topology (if applicable) */
     FString ExtendRole;  // "SourceFactory", "InputBelt", "OutputBelt", "InputLift", "OutputLift",
                          // "InputPipe", "OutputPipe", "Splitter", "Merger", "Junction",
                          // "Pole" (future), "LiftFloorHole" (future), "PipelinePump" (future)
-    
+
     /** Chain ID this buildable belongs to (-1 if not part of a chain) */
     int32 ExtendChainId = -1;
-    
+
     /** Index within the chain (-1 if not applicable) */
     int32 ExtendChainIndex = -1;
-    
+
     FSFCapturedBuildable() = default;
 };
 
@@ -206,7 +206,7 @@ struct FSFBuildableSnapshot
 /**
  * Service for managing EXTEND feature - clones factory buildings with their
  * connected infrastructure (belts, distributors, pipes, junctions).
- * 
+ *
  * EXTEND performs 1:1 topology cloning, duplicating the exact infrastructure
  * layout rather than discovering new connections like auto-connect.
  */
@@ -300,7 +300,7 @@ public:
     /** Get the list of valid directions for the current target */
     UFUNCTION(BlueprintCallable, Category = "Smart|Extend")
     TArray<ESFExtendDirection> GetValidDirections() const;
-    
+
     /** Get the detection service (for direct access if needed) */
     UFUNCTION(BlueprintCallable, Category = "Smart|Extend")
     USFExtendDetectionService* GetDetectionService() const { return DetectionService; }
@@ -318,23 +318,23 @@ public:
     /** Clear cached topology data */
     UFUNCTION(BlueprintCallable, Category = "Smart|Extend")
     void ClearTopology();
-    
+
     /** Get the topology service (for direct access if needed) */
     UFUNCTION(BlueprintCallable, Category = "Smart|Extend")
     USFExtendTopologyService* GetTopologyService() const { return TopologyService; }
-    
+
     /** Get the hologram service (for direct access if needed) */
     UFUNCTION(BlueprintCallable, Category = "Smart|Extend")
     USFExtendHologramService* GetHologramService() const { return HologramService; }
-    
+
     /** Get the wiring service (for direct access if needed) */
     UFUNCTION(BlueprintCallable, Category = "Smart|Extend")
     USFExtendWiringService* GetWiringService() const { return WiringService; }
 
     // ==================== Extension Execution ====================
 
-    /** 
-     * Attempt to extend from a hit building 
+    /**
+     * Attempt to extend from a hit building
      * Called from TryUpgrade hook when EXTEND mode is active
      * @return true if extension preview was created
      */
@@ -344,7 +344,7 @@ public:
     /** Refresh extension previews (called during hologram update) */
     UFUNCTION(BlueprintCallable, Category = "Smart|Extend")
     void RefreshExtension(AFGHologram* SourceHologram, bool bForceRefresh = false);
-    
+
     /** Clean up all extension child holograms */
     UFUNCTION(BlueprintCallable, Category = "Smart|Extend")
     void CleanupExtension(AFGHologram* SourceHologram);
@@ -376,7 +376,9 @@ public:
      */
     UFUNCTION(BlueprintCallable, Category = "Smart|Extend")
     void WireBuiltChildConnections(AFGBuildableFactory* NewFactory);
-    
+
+    bool HasPendingPostBuildWiring() const;
+
     /**
      * Generate wiring manifest from stored clone topology and execute all connections.
      * This is Phase 5/6 of the EXTEND workflow - called in deferred tick after build.
@@ -504,7 +506,7 @@ public:
      * @param CloneChainId The chain ID to find the clone junction
      */
     void WireManifoldPipe(AFGBuildablePipeline* BuiltPipe, UFGPipeConnectionComponentBase* SourceConnector, int32 CloneChainId);
-    
+
     /**
      * Wire a manifold belt to its source and clone distributors after building.
      * Called from SFConveyorBeltHologram::Construct() for manifold belts.
@@ -517,12 +519,12 @@ public:
     // ==================== Utility Functions ====================
 
 public:
-    
+
     /** Provide a valid floor hit result to a hologram to prevent "Surface is too uneven" errors */
     void ProvideFloorHitResult(AFGHologram* Hologram, const FVector& Location);
 
     // ==================== Build Gun Hologram Swapping ====================
-    
+
     /**
      * Swap the build gun's active hologram to our custom ASFFactoryHologram.
      * This gives us control over SetHologramLocationAndRotation for EXTEND positioning.
@@ -530,20 +532,20 @@ public:
      * @return The swapped custom hologram, or nullptr if swap failed
      */
     ASFFactoryHologram* SwapToSmartFactoryHologram(AFGHologram* VanillaHologram);
-    
+
     /**
      * Restore the original hologram when EXTEND mode ends.
      * Called from ClearExtendState.
      */
     void RestoreOriginalHologram();
-    
+
 protected:
     /** Check if a building is a valid factory for extension (delegates to DetectionService) */
     bool IsValidExtendTarget(AFGBuildable* Building) const;
-    
+
     /** Get the player's build gun */
     AFGBuildGun* GetPlayerBuildGun() const;
-    
+
     /** Get the build gun's build state */
     UFGBuildGunStateBuild* GetBuildGunBuildState(AFGBuildGun* BuildGun) const;
 
@@ -575,7 +577,7 @@ private:
     /** Building we're currently extending from */
     UPROPERTY()
     TWeakObjectPtr<AFGBuildable> CurrentExtendTarget;
-    
+
     /** Our custom hologram that replaced the vanilla one (for cleanup) */
     UPROPERTY()
     TWeakObjectPtr<ASFFactoryHologram> SwappedHologram;
@@ -587,17 +589,17 @@ private:
     /** Child hologram previews for belt connections (these BUILD but may be invisible) */
     UPROPERTY()
     TArray<AFGHologram*> BeltPreviewHolograms;
-    
+
     /** Intended world positions for child holograms (engine resets them to origin, we force them back) */
     TMap<AFGHologram*, FVector> ChildIntendedPositions;
-    
+
     /** Intended world rotations for child holograms */
     TMap<AFGHologram*, FRotator> ChildIntendedRotations;
-    
+
     /** The hologram we've initialized for EXTEND (to detect when build gun creates a new one) */
     UPROPERTY()
     TWeakObjectPtr<AFGHologram> CurrentExtendHologram;
-    
+
     /** Counters for unique child hologram naming (NEVER reset - engine uses name TMap that persists) */
     int32 ExtendDistributorCounter = 0;
     int32 ExtendMergerCounter = 0;
@@ -606,87 +608,87 @@ private:
     int32 ExtendJunctionCounter = 0;
     int32 ExtendInputPipeCounter = 0;
     int32 ExtendOutputPipeCounter = 0;
-    
+
     /** Counter for unique lift hologram naming */
     int32 ExtendInputLiftCounter = 0;
     int32 ExtendOutputLiftCounter = 0;
-    
+
     /** Temporary storage for built chain elements - used by ConnectAllChainElements */
     /** Key: ChainId, Value: Map of ChainIndex to built conveyor (belt or lift) */
     TMap<int32, TMap<int32, AFGBuildableConveyorBase*>> BuiltChainElements;
-    
+
     /** Track which chains are input vs output for connection direction */
     TMap<int32, bool> ChainIsInputMap;
-    
+
     // ==================== Hologram Connection Wiring (prevents child pole spawning) ====================
-    
+
     /** Map from source buildable (pipe, junction) to its cloned hologram */
     TMap<AActor*, AFGHologram*> SourceToHologramMap;
-    
+
     /** Per-chain tracking of pipe holograms in spawn order (ChainId → array of pipe holograms) */
     TMap<int32, TArray<ASFPipelineHologram*>> PipeChainHologramMap;
-    
+
     /** Junction hologram for each pipe chain (ChainId → junction hologram) */
     TMap<int32, class ASFPipelineJunctionChildHologram*> PipeChainJunctionMap;
-    
+
     /** Per-chain tracking of belt holograms in spawn order (ChainId → array of belt holograms) */
     TMap<int32, TArray<class ASFConveyorBeltHologram*>> BeltChainHologramMap;
-    
+
     /** Per-chain tracking of lift holograms in spawn order (ChainId → array of lift holograms) */
     TMap<int32, TArray<class ASFConveyorLiftHologram*>> LiftChainHologramMap;
-    
+
     /** Unified chain map for all conveyors (belts + lifts) indexed by position (ChainId → ChainIndex → Hologram) */
     TMap<int32, TMap<int32, AFGHologram*>> UnifiedConveyorChainMap;
-    
+
     /** Distributor hologram for each belt chain (ChainId → distributor hologram) */
     TMap<int32, AFGHologram*> BeltChainDistributorMap;
-    
+
     /** Manifold belt hologram for each chain (ChainId → manifold belt hologram) */
     TMap<int32, ASFConveyorBeltHologram*> ManifoldBeltHolograms;
-    
+
     /** Built conveyor buildables per chain, indexed by position (ChainId → (Index → Conveyor)) */
     TMap<int32, TMap<int32, AFGBuildableConveyorBase*>> BuiltConveyorsByChain;
-    
+
     /** Built distributor buildables per chain (populated during Construct(), used by WireBuiltChildConnections) */
     TMap<int32, AFGBuildable*> BuiltDistributorsByChain;
-    
+
     /** Built junction buildables per pipe chain (populated during Construct(), used by WireBuiltChildConnections) */
     TMap<int32, AFGBuildable*> BuiltJunctionsByChain;
-    
+
     /** Built pipe buildables per chain, indexed by position (ChainId → (Index → Pipe)) */
     TMap<int32, TMap<int32, AFGBuildablePipeline*>> BuiltPipesByChain;
-    
+
     /** Track chain direction for built chains (true = input chain, false = output chain) */
     TMap<int32, bool> BuiltChainIsInputMap;
-    
+
     /** Track pipe chain direction separately (true = input chain, false = output chain) */
     TMap<int32, bool> BuiltPipeChainIsInputMap;
-    
+
     /** Source (original) distributors per chain - for manifold connections (ChainId → source distributor) */
     TMap<int32, AFGBuildable*> SourceDistributorsByChain;
-    
+
     /** Source (original) junctions per pipe chain - for manifold connections (ChainId → source junction) */
     TMap<int32, AFGBuildable*> SourceJunctionsByChain;
-    
+
     /** Distributor connector name per chain (ChainId → ConnectorName like "Output1", "Output2") */
     /** Used during Construct() to find the correct output on the cloned distributor */
     TMap<int32, FName> DistributorConnectorNameByChain;
-    
+
     /** Wire up pipe hologram connections after all holograms in a chain are spawned */
     void WirePipeChainConnections(int32 ChainId, AFGHologram* ParentHologram, bool bIsInputChain);
-    
+
     /** Wire up belt hologram connections after all holograms in a chain are spawned */
     void WireBeltChainConnections(int32 ChainId, AFGHologram* ParentHologram, bool bIsInputChain);
-    
+
     /** Find a pipe connection component on a hologram by index (0 or 1) */
     UFGPipeConnectionComponentBase* FindPipeConnectionByIndex(AFGHologram* Hologram, int32 Index) const;
-    
+
     /** Find a factory connection component on a hologram by index (0 or 1) */
     UFGFactoryConnectionComponent* FindFactoryConnectionByIndex(AFGHologram* Hologram, int32 Index) const;
-    
+
     /** Clear all connection wiring tracking maps */
     void ClearConnectionWiringMaps();
-    
+
     /** Building we just built from - prevents immediate re-activation on same building after build */
     UPROPERTY()
     TWeakObjectPtr<AFGBuildable> LastBuiltFromBuilding;
@@ -727,7 +729,7 @@ private:
 
     /** Validate belt/pipe constraints between consecutive clones */
     bool ValidateScaledExtendConstraints();
-    
+
     /**
      * Issue #288: Validate cloned power pole capacity for pump wiring.
      * For each clone pole, sum the connections we're planning to make:
@@ -737,33 +739,33 @@ private:
      * and scaled Extend.
      */
     bool ValidatePowerCapacity();
-    
+
     /** Flag indicating EXTEND was active and needs final cleanup when build gun leaves build mode */
     bool bNeedsFinalCleanup = false;
-    
+
     /** Whether the user has committed to Extend by performing a scale action.
      *  Before committing, looking away deactivates Extend normally (allows middle-click sampling).
      *  After committing, sticky extend keeps Extend alive when looking away. */
     bool bExtendCommitted = false;
-    
+
     /** Counter snapshot taken when Extend activates.
      *  Restored when Extend deactivates so normal scaling isn't polluted with Extend's counters. */
     FSFCounterState PreExtendCounterSnapshot;
     bool bHasCounterSnapshot = false;
-    
+
     // ==================== JSON-Based Wiring (Phase 5/6) ====================
-    
+
     /** Stored clone topology for post-build wiring (Phase 5) */
     TSharedPtr<FSFCloneTopology> StoredCloneTopology;
-    
+
     /** Map of clone_id -> spawned hologram for post-build wiring (cleared after build) */
     TMap<FString, AFGHologram*> JsonSpawnedHolograms;
-    
+
     /** Map of clone_id -> built actor (populated during Construct(), used for wiring) */
     TMap<FString, AActor*> JsonBuiltActors;
-    
+
     // ==================== Power Extend Tracking (Issue #229) ====================
-    
+
     /** Source power pole data for post-build wiring, keyed by clone_id (e.g., "power_pole_0") */
     struct FSFSourcePoleWiringData
     {
@@ -773,36 +775,36 @@ private:
         int32 MaxConnections = 4;
     };
     TMap<FString, FSFSourcePoleWiringData> PowerPoleWiringData;
-    
+
 public:
     /** Register a built actor with its clone_id (called from hologram Construct()) */
     void RegisterJsonBuiltActor(const FString& CloneId, AActor* BuiltActor);
-    
+
     /** Get a built actor by its clone_id (for pre-tick wiring in ConfigureComponents) */
     AFGBuildable* GetBuiltActorByCloneId(const FString& CloneId) const;
-    
+
     /** Get a source buildable by its actor name (for lane segments connecting to existing buildables) */
     AFGBuildable* GetSourceBuildableByName(const FString& ActorName) const;
-    
+
 public:
     // ==================== Diagnostic Capture ====================
-    
+
     /** Capture all buildables within radius of player for diagnostic comparison */
     FSFBuildableSnapshot CaptureNearbyBuildables(float Radius = 15000.0f);  // 150m default
-    
+
     /** Capture the "before" snapshot when preview phase starts */
     void CapturePreviewSnapshot();
-    
+
     /** Capture the "after" snapshot and log diff when all builds complete */
     void CapturePostBuildSnapshotAndLogDiff();
-    
+
     /** Log comparison between two snapshots */
     void LogSnapshotDiff(const FSFBuildableSnapshot& Before, const FSFBuildableSnapshot& After);
 
 private:
     /** Snapshot captured during preview phase */
     FSFBuildableSnapshot PreviewSnapshot;
-    
+
     /** Whether preview snapshot has been captured */
     bool bHasPreviewSnapshot = false;
 };

--- a/docs/Features/README.md
+++ b/docs/Features/README.md
@@ -25,7 +25,7 @@ When these documents conflict with older archive notes, trust the current source
 | SmartUpgrade | [SmartUpgrade/IMPL_SmartUpgrade_CurrentFlow.md](SmartUpgrade/IMPL_SmartUpgrade_CurrentFlow.md) | Active |
 | SmartDismantle | [SmartDismantle/IMPL_SmartDismantle_CurrentFlow.md](SmartDismantle/IMPL_SmartDismantle_CurrentFlow.md) | Active, limited scope |
 | SmartPanel | [SmartPanel/IMPL_SmartPanel_CurrentFlow.md](SmartPanel/IMPL_SmartPanel_CurrentFlow.md) | Active, split widgets |
-| SmartRestore | [SmartRestore/PLAN_SmartRestore_Enhanced.md](SmartRestore/PLAN_SmartRestore_Enhanced.md) | WIP, implementation seed |
+| SmartRestore | *Not yet documented* | WIP, implementation seed |
 
 ## Cleanup Notes
 

--- a/docs/Reference/FicsitApp/ficsit.app.SmartFoundations.md
+++ b/docs/Reference/FicsitApp/ficsit.app.SmartFoundations.md
@@ -1,6 +1,6 @@
 # <img src="https://github.com/SmartFoundations/SmartIssueTracker/blob/main/images/Smart-Logo.png?raw=true" width="150" alt="Smart! Logo"> Smart! Mod
 
-![Status](https://img.shields.io/badge/Status-Released-brightgreen) ![Version](https://img.shields.io/badge/Version-29.2.4-blue) ![Engine](https://img.shields.io/badge/Engine-UE%205.3-blue) ![SML](https://img.shields.io/badge/SML-3.11.x-blue) ![Multiplayer](https://img.shields.io/badge/Multiplayer-Testing-orange) ![AI Assisted Development Used](https://img.shields.io/badge/AI%20Assisted%20Development%20Used-Disclosure%20Below-blue)
+![Status](https://img.shields.io/badge/Status-Released-brightgreen) ![Version](https://img.shields.io/badge/Version-29.2.5-blue) ![Engine](https://img.shields.io/badge/Engine-UE%205.3-blue) ![SML](https://img.shields.io/badge/SML-3.11.x-blue) ![Multiplayer](https://img.shields.io/badge/Multiplayer-Testing-orange) ![AI Assisted Development Used](https://img.shields.io/badge/AI%20Assisted%20Development%20Used-Disclosure%20Below-blue)
 
 > **Multiplayer note:** Smart! is primarily developed for single-player. Multiplayer is under active testing with partial success, but is not currently considered fully supported.
 
@@ -73,6 +73,22 @@ Smart! is useful if you enjoy designing factories but do not enjoy repeating the
 - A fully supported multiplayer experience today.
 - Perfect compatibility with every modded buildable or every other building-assist mod.
 
+### Source Availability
+
+Smart! is **source-available**, not open source. The source code is published to support community transparency, code review, and pull request contributions. It is **not** published for reuse in other projects or redistribution of modified builds.
+
+**What you can do:**
+- View and study the source code for learning
+- Submit contributions via pull requests
+- Build locally for testing contributions
+
+**What requires permission:**
+- Redistribution of modified builds
+- Reuse in other mods or projects
+- Publication of derivative Smart!-like mods
+
+See [LICENSE.md](https://github.com/majormer/SmartFoundations/blob/main/LICENSE.md) for the full terms. Source available as of April 26, 2026.
+
 ---
 
 ## ⚡ The 60-Second Version
@@ -85,21 +101,17 @@ Smart! is useful if you enjoy designing factories but do not enjoy repeating the
 
 ---
 
-## 📰 What's New in v29.2.4
+## 📰 What's New in v29
 
-**Current Release:** v29.2.4 — Smart Upgrade Conveyor Repair and Triage Recovery
+**Current Release:** v29.2.5 — See [full changelog](https://github.com/majormer/SmartFoundations/blob/main/CHANGELOG.md) for all patch details
 
-### Smart Upgrade Fixes
+### Major Feature: Scaled Extend
 
-- **Large conveyor upgrades are safer.** Belt and lift mass upgrades on dense factories no longer leave connected-looking conveyors that stop moving items after a save/reload. The fix was validated through a clean pre-upgrade save, full mass upgrade, immediate item flow, clean diagnostics, save, reload, preserved item flow, and clean post-load diagnostics. (Issue #303)
-- **Belts and lifts upgrade as connected conveyor runs.** Smart Upgrade now treats connected belts and lifts as one conveyor domain for selection and cost handling, reducing partial upgrades where one piece of a run changes tier while the rest stays behind.
-- **Triage can repair loadable bad saves.** The Smart Upgrade Triage panel can now repair loaded saves with broken conveyor chain state. Save before using Repair, then save, reload, and run Detect again.
-- **Cleanup timing is safer.** Smart! avoids risky automatic deep repair immediately after upgrades while the game is still settling conveyor state. Deeper repair is explicit through Triage after load.
+The defining feature of version 29 is **Scaled Extend** — the fusion of Scaling and Extending for rapid factory duplication. Scale Extend across multiple clones and rows, with automatic lane segments chaining between adjacent clones' distributors. This represents a fundamental transformation of what Smart! can do.
 
-### Documentation and Onboarding
+### Recent Patch Updates
 
-- The Smart! ficsit.app page has been refreshed with a clearer first-time onboarding flow.
-- Internal Smart Upgrade and Chain Actor documentation was updated so future conveyor fixes follow the validated repair path.
+For detailed information about recent fixes and improvements in v29.2.5 and earlier patch releases, see the [full changelog](https://github.com/majormer/SmartFoundations/blob/main/CHANGELOG.md).
 
 ---
 


### PR DESCRIPTION
## Release v29.2.5

### Changed
- **First release in the new public repository** - Smart! is now published as source-available code on GitHub at https://github.com/majormer/SmartFoundations. The source is available for community transparency, code review, and pull request contributions. See LICENSE.md for the full source-available license terms.

### Fixed
- **A massive amount of logging spam removed** - Smart! was generating over 500,000 log entries during normal gameplay from per-frame input diagnostics, hologram construction events, recipe service activity, and child hologram spawning during grid placement. These high-frequency logs have been moved to verbose logging, eliminating the log flood while keeping diagnostics available for troubleshooting.
- **Extend no longer runs post-build wiring during world load** - Loading a save could make Smart! run Extend's post-build wiring checks against ordinary factory buildings before you had used Extend at all. This produced confusing Extend chain-fix messages during login and did unnecessary work on restored buildings. Extend post-build wiring now only runs when there is actual pending Extend build state to process.
- **Scaled Extend pump wiring now follows the cloned topology** - When extending refinery or pump setups with multiple cloned groups, cloned pumps now connect to the power pole cloned with their own group instead of all later pumps incorrectly wiring back to the first cloned pole.

### Documentation Updates
- Updated ficsit.app documentation to focus on major version features with links to full changelog for patch details
- Added source availability section to clarify the source-available license terms
- Updated prepare-release workflow to reflect the new documentation structure