### PR TITLE
32.0.0: Full multiplayer support (Windows + Linux dedicated servers)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,23 @@ All notable changes to Smart! will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-> **Audience note:** This changelog is read by players, not developers. Entries should describe what the user experiences — what was broken, what it felt like, and what's better now. Class names, internal APIs, and implementation details belong in code comments or design docs, not here.
+> **Audience note:** This changelog is read by players, not developers. Entries should describe what the user experiences — what was broken, what it felt like, and what's better now. Class names, internal APIs, and implementation details belong in code comments or design docs, not here. Unless an entry says otherwise, changes apply to both single-player and multiplayer.
+
+---
+
+## [32.0.0] - 2026-06-11
+
+> *The multiplayer release: every Smart! feature now works in multiplayer on dedicated servers — Windows and Linux.*
+
+### Multiplayer
+
+- **Full multiplayer support** — Smart! now works in multiplayer. Grid scaling, belt/pipe/power auto-connect, Extend and Scaled Extend, Smart Upgrade, Smart Restore presets, and Smart Dismantle all build correctly when you play as a client on a dedicated server, with normal build costs charged exactly as the preview shows. Everything Smart! places is a standard, fully replicated game building — other players see it, can use it, and can dismantle it, just as if it were built by hand. (Issues #309, #334)
+- **Linux dedicated servers** — Smart! is now packaged for Linux dedicated servers alongside the existing Windows server build, which covers most hosted-server providers. For server admins: install the same Smart! version on the server and on every client (the mod manager keeps these paired). (Issue #176)
+
+### Fixed
+
+- **Smart Dismantle now removes a restored single module as one group** — restoring a preset of a single Extend module (one machine plus its distributors and belts) built fine, but the dismantle tool would only take it apart one building at a time instead of offering the whole module, unlike scaled and extended builds. Restored modules now group for one-click dismantle like everything else Smart! places. (Issue #359)
+- **Belt repairs while building and on save load** — after large Upgrade or Extend sessions, leftover internal conveyor records could make a stretch of auto-connected belt hold items without moving them (starving the machines behind it), and in rare cases crash the game when loading a save written in that state. Smart! now cleans these up as you build and upgrade, and repairs any affected belts when a save loads — including saves made on earlier versions. (Issue #360)
 
 ---
 

--- a/Config/AccessTransformers.ini
+++ b/Config/AccessTransformers.ini
@@ -15,3 +15,8 @@ Friend=(Class="AFGBuildableSubsystem", FriendClass="USFChainActorService")
 ; Friend access for child hologram lock-state maintenance without calling
 ; LockHologramPosition(), which creates build-gun UI widgets during scaling.
 Friend=(Class="AFGHologram", FriendClass="FSFHologramHelperService")
+; MP Slice 0 chunking: the game instance module hooks UFGBuildGunStateBuild::InternalExecuteDuBuildStepInput
+; (protected) to chunk an oversized client scaled-grid construct before vanilla serializes it, and slices the
+; active hologram's child list (mChildren / mChildrenNameLookupMap) at that seam.
+Friend=(Class="UFGBuildGunStateBuild", FriendClass="USFGameInstanceModule")
+Friend=(Class="AFGHologram", FriendClass="USFGameInstanceModule")

--- a/Config/AccessTransformers.ini
+++ b/Config/AccessTransformers.ini
@@ -15,8 +15,7 @@ Friend=(Class="AFGBuildableSubsystem", FriendClass="USFChainActorService")
 ; Friend access for child hologram lock-state maintenance without calling
 ; LockHologramPosition(), which creates build-gun UI widgets during scaling.
 Friend=(Class="AFGHologram", FriendClass="FSFHologramHelperService")
-; MP Slice 0 chunking: the game instance module hooks UFGBuildGunStateBuild::InternalExecuteDuBuildStepInput
-; (protected) to chunk an oversized client scaled-grid construct before vanilla serializes it, and slices the
-; active hologram's child list (mChildren / mChildrenNameLookupMap) at that seam.
+; MP Slice 0 safety guard: the game instance module hooks the protected
+; UFGBuildGunStateBuild::InternalExecuteDuBuildStepInput (client fire handler) to refuse an oversized client
+; scaled-grid construct before vanilla serializes/sends it.
 Friend=(Class="UFGBuildGunStateBuild", FriendClass="USFGameInstanceModule")
-Friend=(Class="AFGHologram", FriendClass="USFGameInstanceModule")

--- a/Config/AccessTransformers.ini
+++ b/Config/AccessTransformers.ini
@@ -22,3 +22,6 @@ Friend=(Class="UFGBuildGunStateBuild", FriendClass="USFGameInstanceModule")
 ; MP spec-construction hooks (class-agnostic): strip/restore the SF_GridChild children around the
 ; construct-message write and add expanded children pre-construct - mChildren is protected.
 Friend=(Class="AFGHologram", FriendClass="USFGameInstanceModule")
+; MP spec-construction group hook: ConfigureActor (protected) is the pre-BeginPlay window where
+; spec-built buildables join their Smart Dismantle blueprint proxy.
+Friend=(Class="AFGBuildableHologram", FriendClass="USFGameInstanceModule")

--- a/Config/AccessTransformers.ini
+++ b/Config/AccessTransformers.ini
@@ -19,3 +19,6 @@ Friend=(Class="AFGHologram", FriendClass="FSFHologramHelperService")
 ; UFGBuildGunStateBuild::InternalExecuteDuBuildStepInput (client fire handler) to refuse an oversized client
 ; scaled-grid construct before vanilla serializes/sends it.
 Friend=(Class="UFGBuildGunStateBuild", FriendClass="USFGameInstanceModule")
+; MP spec-construction hooks (class-agnostic): strip/restore the SF_GridChild children around the
+; construct-message write and add expanded children pre-construct - mChildren is protected.
+Friend=(Class="AFGHologram", FriendClass="USFGameInstanceModule")

--- a/Config/Alpakit.ini
+++ b/Config/Alpakit.ini
@@ -1,4 +1,4 @@
 [ModTargets]
 Targets=Windows
 Targets=WindowsServer
-
+Targets=LinuxServer

--- a/SmartFoundations.uplugin
+++ b/SmartFoundations.uplugin
@@ -1,8 +1,8 @@
 {
 	"AcceptsAnyRemoteVersion": true,
 	"FileVersion": 3,
-	"Version": 31,
-	"VersionName": "31.1.0",
+	"Version": 32,
+	"VersionName": "32.0.0",
 	"FriendlyName": "Smart!",
 	"Description": "Advanced hologram control for precision building - Rebuilt for Satisfactory 1.2",
 	"Category": "Modding",
@@ -30,7 +30,7 @@
 			"SemVersion": "^3.11.3"
 		}
 	],
-	"SemVersion": "31.1.0",
+	"SemVersion": "32.0.0",
 	"GameVersion": ">=491125",
 	"LocalizationTargets": [
 		{

--- a/Source/SmartFoundations/Private/Features/Arrows/SFArrowModule_StaticMesh.cpp
+++ b/Source/SmartFoundations/Private/Features/Arrows/SFArrowModule_StaticMesh.cpp
@@ -65,6 +65,18 @@ bool FSFArrowModule_StaticMesh::Initialize(UWorld* World, UObject* Outer, USFSub
 		return false;
 	}
 
+	// [CHAIN-FIX] Arrows are client cosmetics; on a dedicated server the readiness checks can
+	// never pass (no render data under the null renderer), so every AttachToHologram deferred,
+	// armed 5s timers, and re-ran a failing /Engine/BasicShapes async load on every aim cycle
+	// (live 2026-06-10: "Asset load completed but validation failed (Head=FAILED Shaft=FAILED)"
+	// spam on the dedi during the heap-corruption investigation). No-op the whole module there.
+	if (World->GetNetMode() == NM_DedicatedServer)
+	{
+		bDisabledOnDedicatedServer = true;
+		UE_LOG(LogSmartArrows, Display, TEXT("FSFArrowModule_StaticMesh: disabled on dedicated server (client cosmetics)."));
+		return true;
+	}
+
 	// Store subsystem reference for bounds calculation (Task #67)
 	SubsystemRef = Subsystem;
 	if (Subsystem)
@@ -152,6 +164,10 @@ bool FSFArrowModule_StaticMesh::Initialize(UWorld* World, UObject* Outer, USFSub
 
 bool FSFArrowModule_StaticMesh::AttachToHologram(USceneComponent* HologramRootComponent)
 {
+	if (bDisabledOnDedicatedServer)
+	{
+		return false; // [CHAIN-FIX] silent no-op on the dedi - see Initialize
+	}
 	if (!bInitialized)
 	{
 		UE_LOG(LogSmartArrows, Warning, TEXT("FSFArrowModule_StaticMesh::AttachToHologram: Not initialized"));
@@ -267,7 +283,12 @@ bool FSFArrowModule_StaticMesh::AttachToHologram(USceneComponent* HologramRootCo
 		SF_LOG_ARROWS(Normal, TEXT("⏳ AttachToHologram: Assets not ready yet, deferring attachment (will complete when assets load)"));
 		
 		PendingAttachTarget = HologramRootComponent;
-		
+
+		// [CHAIN-FIX] Remember the arming world so Cleanup can ALWAYS clear this timer. The old
+		// path resolved the world through ArrowX's outer - the HOLOGRAM - which usually dies
+		// before this module, so an armed timer with a raw-`this` lambda could outlive cleanup.
+		DeferredAttachTimerWorld = World;
+
 		// Set timeout timer (5 seconds)
 		World->GetTimerManager().SetTimer(
 			DeferredAttachTimerHandle,
@@ -354,52 +375,26 @@ void FSFArrowModule_StaticMesh::Cleanup()
 	AssetManager.CancelPendingLoads();
 	PendingAttachTarget.Reset();
 	
-	// Task #67 Cleanup: Clear deferred attachment timer if active
-	// Safe approach: Get world from component owner, not from dangling component pointers
+	// [CHAIN-FIX] Clear the deferred-attach timer UNCONDITIONALLY via the world cached when it
+	// was armed. The old path resolved the world through ArrowX's outer - the HOLOGRAM - which
+	// usually dies before this module, so the clear was silently skipped and only the LOCAL
+	// handle was invalidated ("timer will be cleaned up by engine anyway" was wrong: the armed
+	// raw-`this` lambda still fires; if this module is ever destroyed first, that is a
+	// write-after-free into recycled heap - the 2026-06-10 dedi corruption suspect class).
 	if (DeferredAttachTimerHandle.IsValid())
 	{
-		UE_LOG(LogSmartArrows, Verbose, TEXT("Cleanup: Found active deferred attachment timer"));
-		
-		// Try to get world from ArrowX's owner (subsystem) if component still valid
-		if (ArrowX.IsValid())
+		if (UWorld* TimerWorld = DeferredAttachTimerWorld.Get())
 		{
-			if (UObject* Owner = ArrowX.Get()->GetOuter())
-			{
-				if (UWorld* World = Owner->GetWorld())
-				{
-					if (World->GetTimerManager().IsTimerActive(DeferredAttachTimerHandle))
-					{
-						World->GetTimerManager().ClearTimer(DeferredAttachTimerHandle);
-						UE_LOG(LogSmartArrows, Verbose, TEXT("Cleanup: ✅ Cleared deferred attachment timer"));
-					}
-					else
-					{
-						UE_LOG(LogSmartArrows, Verbose, TEXT("Cleanup: Timer exists but not active"));
-					}
-				}
-				else
-				{
-					UE_LOG(LogSmartArrows, Warning, TEXT("Cleanup: Owner has no world"));
-				}
-			}
-			else
-			{
-				UE_LOG(LogSmartArrows, Warning, TEXT("Cleanup: ArrowX has no valid owner"));
-			}
+			TimerWorld->GetTimerManager().ClearTimer(DeferredAttachTimerHandle);
+			UE_LOG(LogSmartArrows, Verbose, TEXT("Cleanup: ✅ Cleared deferred attachment timer (cached world)"));
 		}
 		else
 		{
-			UE_LOG(LogSmartArrows, Warning, TEXT("Cleanup: ArrowX invalid, force invalidating timer"));
+			UE_LOG(LogSmartArrows, Warning, TEXT("Cleanup: timer was armed but its world is gone (world teardown) - timer died with the world"));
 		}
-		
-		// If we can't get world safely, timer will be cleaned up by engine anyway
 		DeferredAttachTimerHandle.Invalidate();
-		UE_LOG(LogSmartArrows, Verbose, TEXT("Cleanup: Timer handle invalidated"));
 	}
-	else
-	{
-		UE_LOG(LogSmartArrows, Verbose, TEXT("Cleanup: No active deferred attachment timer"));
-	}
+	DeferredAttachTimerWorld.Reset();
 	
 	// Early exit if arrows were never initialized (never attached to a hologram)
 	// This happens during world transitions when no build gun was ever equipped

--- a/Source/SmartFoundations/Private/Features/Extend/SFExtendCloneSpawner.cpp
+++ b/Source/SmartFoundations/Private/Features/Extend/SFExtendCloneSpawner.cpp
@@ -343,7 +343,7 @@ int32 FSFCloneTopology::SpawnChildHolograms(
                 Rotation,
                 SpawnParams
             );
-            
+
             if (BeltChild)
             {
                 BeltChild->SetReplicates(false);
@@ -410,7 +410,7 @@ int32 FSFCloneTopology::SpawnChildHolograms(
                 
                 // Force hologram material (required for spline mesh visibility)
                 BeltChild->ForceApplyHologramMaterial();
-                
+
                 SpawnedHologram = BeltChild;
                 SpawnedCount++;
                 
@@ -1152,7 +1152,7 @@ int32 FSFCloneTopology::SpawnChildHolograms(
                         BeltLane->TriggerMeshGeneration();
                     }
                     BeltLane->ForceApplyHologramMaterial();
-                    
+
                     SpawnedHologram = BeltLane;
                     SpawnedCount++;
                     

--- a/Source/SmartFoundations/Private/Features/Extend/SFExtendRestoreReplayService.cpp
+++ b/Source/SmartFoundations/Private/Features/Extend/SFExtendRestoreReplayService.cpp
@@ -323,6 +323,10 @@ void USFExtendRestoreReplayService::ClearRestoredCloneTopologySession(const TCHA
         ? Owner->RestoredCloneTopologyTemplate->ChildHolograms.Num()
         : 0;
 
+    // [EXTEND-MP] A pre-staged restore commit must never be consumed by a later plain fire
+    // (client-only no-op elsewhere; the plain-fire hook also stages an explicit clear).
+    Owner->StageCommitClearForMP();
+
     ClearRestoredCloneTopologyPreview();
     Owner->RestoredCloneParentHologram.Reset();
     Owner->RestoredCloneTopologyTemplate.Reset();
@@ -519,6 +523,12 @@ void USFExtendRestoreReplayService::TickRestoredCloneTopology(float DeltaTime)
     }
 
     Owner->HologramService->RefreshChildPositions();
+
+    // [EXTEND-MP] Pre-stage the RESTORE commit continuously while the replay session is live
+    // (client-only + 250ms-throttled inside; BuildCommitSpecForMP builds the restore variant when
+    // this session is active). Same rationale as the Extend pre-stage: the commit RPC is much
+    // larger than the construct RPC and loses the cross-channel race when staged only at fire.
+    Owner->MaybeStageCommitForMP(ParentHologram);
 }
 
 void USFExtendRestoreReplayService::OnRestoredCloneTopologyStateChanged()

--- a/Source/SmartFoundations/Private/Features/Extend/SFExtendService.cpp
+++ b/Source/SmartFoundations/Private/Features/Extend/SFExtendService.cpp
@@ -817,19 +817,38 @@ bool USFExtendService::TryExtendFromBuilding(AFGBuildable* HitBuilding, AFGHolog
         // Not yet activated — validate normally before first activation
         if (!IsValid(HitBuilding) || !IsValid(SourceHologram))
         {
-            return false;
+            return false; // no target/hologram (handled/logged upstream)
         }
 
         UClass* HologramBuildClass = SourceHologram->GetBuildClass();
         if (!HologramBuildClass || !HitBuilding->IsA(HologramBuildClass))
         {
+            // [EXTEND-MP] TEMP: class mismatch is a common client failure (proxy class vs hologram build class).
+            static double LastBail1 = 0; const double Now1 = FPlatformTime::Seconds();
+            if (Now1 - LastBail1 > 1.0)
+            {
+                UE_LOG(LogSmartExtend, Display, TEXT("[EXTEND-MP] activation bail: IsA mismatch - building=%s holoBuildClass=%s"),
+                    *HitBuilding->GetClass()->GetName(), HologramBuildClass ? *HologramBuildClass->GetName() : TEXT("NULL"));
+                LastBail1 = Now1;
+            }
             return false;
         }
 
         if (!IsValidExtendTarget(HitBuilding))
         {
+            // [EXTEND-MP] TEMP: target rejected (resource extractor / not a manufacturer / detection-service check).
+            static double LastBail2 = 0; const double Now2 = FPlatformTime::Seconds();
+            if (Now2 - LastBail2 > 1.0)
+            {
+                UE_LOG(LogSmartExtend, Display, TEXT("[EXTEND-MP] activation bail: IsValidExtendTarget=false for %s"),
+                    *HitBuilding->GetClass()->GetName());
+                LastBail2 = Now2;
+            }
             return false;
         }
+
+        // [EXTEND-MP] TEMP: passed activation validation - Extend SHOULD proceed to build the preview.
+        UE_LOG(LogSmartExtend, Display, TEXT("[EXTEND-MP] activation PASSED for %s - proceeding to preview"), *HitBuilding->GetName());
     }
 
     // Issue #274: When Scaled Extend is committed (locked for inspection), suppress re-triggering

--- a/Source/SmartFoundations/Private/Features/Extend/SFExtendService.cpp
+++ b/Source/SmartFoundations/Private/Features/Extend/SFExtendService.cpp
@@ -684,6 +684,14 @@ void USFExtendService::SetStoredCloneTopologyForServerCommit(const FSFCloneTopol
         Clone.ChildHolograms.Num(), *Clone.ParentBuildClass);
 }
 
+void USFExtendService::SetServerCommitSourceBuilding(AFGBuildable* Source)
+{
+    LastBuiltFromBuilding = Source;
+    CurrentExtendTarget = Source;
+    UE_LOG(LogSmartExtend, Display,
+        TEXT("[EXTEND-MP] Server installed commit source building: %s."), *GetNameSafe(Source));
+}
+
 void USFExtendService::ReceiveServerTopology(const FSFExtendTopology& Topology)
 {
     CachedServerTopology = Topology;

--- a/Source/SmartFoundations/Private/Features/Extend/SFExtendService.cpp
+++ b/Source/SmartFoundations/Private/Features/Extend/SFExtendService.cpp
@@ -931,17 +931,19 @@ bool USFExtendService::TryExtendFromBuilding(AFGBuildable* HitBuilding, AFGHolog
     // NOTE: Orphaned pending builds will be cleared at the start of CreateBeltPreviews().
     // No need to clear here - the flow is: WalkTopology → CreateBeltPreviews (clears all → spawns new).
 
-    if (!WalkTopology(HitBuilding))
+    const bool bWalked = WalkTopology(HitBuilding);
     {
-        // Debug: Log topology walk failure
-        static double LastTopoLog = 0;
-        double Now = FPlatformTime::Seconds();
-        if (Now - LastTopoLog > 2.0)
+        // [EXTEND-MP] TEMP: is WalkTopology the bail? (bare building vs client-specific failure)
+        static double LastTopoLog = 0; const double Now = FPlatformTime::Seconds();
+        if (Now - LastTopoLog > 1.0)
         {
-            UE_LOG(LogSmartExtend, VeryVerbose, TEXT("🔄 EXTEND: No valid topology found for %s (no belts/distributors connected?)"),
-                *HitBuilding->GetName());
+            UE_LOG(LogSmartExtend, Display, TEXT("[EXTEND-MP] WalkTopology(%s) = %s"),
+                *HitBuilding->GetName(), bWalked ? TEXT("TRUE - proceeding") : TEXT("FALSE - bail (no belts/distributors connected?)"));
             LastTopoLog = Now;
         }
+    }
+    if (!bWalked)
+    {
         return false;
     }
 

--- a/Source/SmartFoundations/Private/Features/Extend/SFExtendService.cpp
+++ b/Source/SmartFoundations/Private/Features/Extend/SFExtendService.cpp
@@ -26,6 +26,7 @@
 #include "Services/RadarPulse/SFRadarPulseService.h"
 #include "SmartFoundations.h"  // For LogSmartExtend
 #include "Holograms/Core/SFFactoryHologram.h"
+#include "Holograms/Core/SFFoundationHologram.h"
 #include "Holograms/Logistics/SFConveyorAttachmentChildHologram.h"
 #include "Holograms/Logistics/SFConveyorBeltHologram.h"
 #include "Holograms/Logistics/SFPipelineHologram.h"
@@ -1635,7 +1636,7 @@ UFGBuildGunStateBuild* USFExtendService::GetBuildGunBuildState(AFGBuildGun* Buil
     return Cast<UFGBuildGunStateBuild>(BuildGun->GetBuildGunStateFor(EBuildGunState::BGS_BUILD));
 }
 
-ASFFactoryHologram* USFExtendService::SwapToSmartFactoryHologram(AFGHologram* VanillaHologram)
+ASFFactoryHologram* USFExtendService::SwapToSmartFactoryHologram(AFGHologram* VanillaHologram, bool bTrackAsExtendSwap)
 {
     if (!VanillaHologram || !VanillaHologram->IsValidLowLevel())
     {
@@ -1741,12 +1742,95 @@ ASFFactoryHologram* USFExtendService::SwapToSmartFactoryHologram(AFGHologram* Va
     // Destroy the vanilla hologram
     VanillaHologram->Destroy();
 
-    // Track the swap (both locally and in HologramService for future migration)
-    SwappedHologram = CustomHologram;
-    bHasSwappedHologram = true;
+    // Track the swap (both locally and in HologramService for future migration).
+    // The MP scaling spec path reuses this swap but must NOT put Extend into "swapped" state
+    // (no Extend target is active and RestoreOriginalHologram must stay a no-op).
+    if (bTrackAsExtendSwap)
+    {
+        SwappedHologram = CustomHologram;
+        bHasSwappedHologram = true;
+    }
 
     SF_EXTEND_DIAGNOSTIC_LOG(LogSmartExtend, Log, TEXT("🔄 EXTEND SWAP: ✅ Successfully swapped to ASFFactoryHologram"));
 
+    return CustomHologram;
+}
+
+ASFFoundationHologram* USFExtendService::SwapToSmartFoundationHologram(AFGHologram* VanillaHologram)
+{
+    // MP scaling spec path for FOUNDATION grids. Mirrors SwapToSmartFactoryHologram (the proven
+    // mechanism: deferred spawn -> init from vanilla -> repoint BuildState->mHologram -> destroy
+    // vanilla) with ASFFoundationHologram as the target and no Extend swap tracking.
+    if (!VanillaHologram || !VanillaHologram->IsValidLowLevel())
+    {
+        UE_LOG(LogSmartFoundations, Warning, TEXT("[MP-SPEC] FOUNDATION SWAP: Invalid vanilla hologram"));
+        return nullptr;
+    }
+
+    AFGBuildGun* BuildGun = GetPlayerBuildGun();
+    if (!BuildGun)
+    {
+        UE_LOG(LogSmartFoundations, Warning, TEXT("[MP-SPEC] FOUNDATION SWAP: Could not get build gun"));
+        return nullptr;
+    }
+
+    UFGBuildGunStateBuild* BuildState = GetBuildGunBuildState(BuildGun);
+    if (!BuildState)
+    {
+        UE_LOG(LogSmartFoundations, Warning, TEXT("[MP-SPEC] FOUNDATION SWAP: Could not get build state"));
+        return nullptr;
+    }
+
+    UWorld* World = VanillaHologram->GetWorld();
+    if (!World || !VanillaHologram->GetBuildClass())
+    {
+        UE_LOG(LogSmartFoundations, Warning, TEXT("[MP-SPEC] FOUNDATION SWAP: No world or no BuildClass"));
+        return nullptr;
+    }
+
+    ASFFoundationHologram* CustomHologram = World->SpawnActorDeferred<ASFFoundationHologram>(
+        ASFFoundationHologram::StaticClass(),
+        FTransform(VanillaHologram->GetActorRotation(), VanillaHologram->GetActorLocation()),
+        BuildGun,
+        nullptr,
+        ESpawnActorCollisionHandlingMethod::AlwaysSpawn
+    );
+    if (!CustomHologram)
+    {
+        UE_LOG(LogSmartFoundations, Error, TEXT("[MP-SPEC] FOUNDATION SWAP: Failed to spawn deferred custom hologram"));
+        return nullptr;
+    }
+
+    // Initialize from the vanilla hologram BEFORE BeginPlay (copies mBuildClass + mRecipe).
+    CustomHologram->InitializeFromHologram(VanillaHologram);
+
+    // Copy mConstructionInstigator (private) via reflection - needed for build FX
+    if (FProperty* InstigatorProp = AFGHologram::StaticClass()->FindPropertyByName(TEXT("mConstructionInstigator")))
+    {
+        InstigatorProp->CopyCompleteValue(
+            InstigatorProp->ContainerPtrToValuePtr<void>(CustomHologram),
+            InstigatorProp->ContainerPtrToValuePtr<void>(VanillaHologram)
+        );
+    }
+
+    CustomHologram->FinishSpawning(FTransform(VanillaHologram->GetActorRotation(), VanillaHologram->GetActorLocation()));
+
+    // Repoint the build gun's hologram pointer to the custom one (the loop-avoidance key).
+    FProperty* HologramProp = BuildState->GetClass()->FindPropertyByName(TEXT("mHologram"));
+    FObjectProperty* ObjProp = HologramProp ? CastField<FObjectProperty>(HologramProp) : nullptr;
+    void* ValuePtr = ObjProp ? HologramProp->ContainerPtrToValuePtr<void>(BuildState) : nullptr;
+    if (!ValuePtr)
+    {
+        UE_LOG(LogSmartFoundations, Error, TEXT("[MP-SPEC] FOUNDATION SWAP: Could not find mHologram property"));
+        CustomHologram->Destroy();
+        return nullptr;
+    }
+    ObjProp->SetObjectPropertyValue(ValuePtr, CustomHologram);
+
+    VanillaHologram->Destroy();
+
+    UE_LOG(LogSmartFoundations, Display, TEXT("[MP-SPEC] FOUNDATION SWAP: Swapped to ASFFoundationHologram (%s)"),
+        *CustomHologram->GetName());
     return CustomHologram;
 }
 

--- a/Source/SmartFoundations/Private/Features/Extend/SFExtendService.cpp
+++ b/Source/SmartFoundations/Private/Features/Extend/SFExtendService.cpp
@@ -724,17 +724,62 @@ bool USFExtendService::BuildCommitSpecForMP(AFGHologram* ParentHologram, FSFExte
         return false;
     }
 
-    // Re-emit a FRESH clone topology at the hologram's CURRENT position - the preview's stored
-    // topology has stale transforms (children are re-positioned while aiming).
-    const FVector FinalOffset = ParentHologram->GetActorLocation() - Topo.SourceBuilding->GetActorLocation();
-    const FSFSourceTopology Source = FSFSourceTopology::CaptureFromTopology(Topo);
-    OutSpec.Clone = FSFCloneTopology::FromSource(Source, FinalOffset);
+    // PARAMETERS ONLY: the clone topology is derived SERVER-side (ReconstructCommitOnServer).
+    // Capturing it here poisons every segment's connections - CaptureBeltChain/CapturePipeChain
+    // read GetConnection(), null on clients - and the wiring manifest comes out empty (live root
+    // cause 2026-06-10: every MP Extend built unwired).
+    OutSpec.ParentOffset = ParentHologram->GetActorLocation() - Topo.SourceBuilding->GetActorLocation();
     OutSpec.Cost = ParentHologram->GetCost(true); // parent + preview children, exact preview cost
     OutSpec.BuildClass = ParentHologram->GetBuildClass();
     OutSpec.SourceBuilding = Topo.SourceBuilding.Get();
     GetScaledClonePlanForCommit(OutSpec.ScaledClones);
-    OutSpec.bValid = OutSpec.Clone.ChildHolograms.Num() > 0;
-    return OutSpec.bValid;
+    OutSpec.bValid = true;
+    return true;
+}
+
+int32 USFExtendService::ReconstructCommitOnServer(AFGHologram* ParentHologram, const FSFExtendCommitSpec& Spec)
+{
+    if (!ParentHologram || !TopologyService)
+    {
+        return 0;
+    }
+
+    SetStoredCloneTopologyForServerCommit(FSFCloneTopology()); // replaced below; keep state coherent
+    SetServerCommitSourceBuilding(Spec.SourceBuilding);
+
+    AFGBuildable* Source = CurrentExtendTarget.Get();
+    if (!Source)
+    {
+        UE_LOG(LogSmartExtend, Warning,
+            TEXT("[EXTEND-MP] ReconstructCommitOnServer: no source building in the commit - nothing reconstructed."));
+        return 0;
+    }
+
+    // Authoritative graph walk: only the SERVER's GetConnection() values are real.
+    if (!TopologyService->WalkTopology(Source))
+    {
+        UE_LOG(LogSmartExtend, Warning,
+            TEXT("[EXTEND-MP] ReconstructCommitOnServer: server topology walk failed for %s."),
+            *GetNameSafe(Source));
+        return 0;
+    }
+
+    const FSFSourceTopology Src = FSFSourceTopology::CaptureFromTopology(TopologyService->GetCurrentTopology());
+    const FSFCloneTopology Clone = FSFCloneTopology::FromSource(Src, Spec.ParentOffset);
+    SetStoredCloneTopologyForServerCommit(Clone);
+
+    TMap<FString, AFGHologram*> SpawnedClones;
+    const int32 NumSpawned = Clone.SpawnChildHolograms(ParentHologram, this, SpawnedClones);
+    const int32 NumWired = Clone.WireChildHologramConnections(SpawnedClones, ParentHologram);
+    UE_LOG(LogSmartFoundations, Display,
+        TEXT("[EXTEND-MP] Server reconstructed %d/%d clone children (%d pre-wired) for %s; vanilla construct will build them."),
+        NumSpawned, Clone.ChildHolograms.Num(), NumWired, *ParentHologram->GetName());
+
+    // Scaled clone sets ride the same server-derived topology (SpawnScaledExtendPreviews
+    // re-captures from the topology service's CurrentTopology, walked above).
+    ReconstructScaledCommitOnServer(ParentHologram, Spec.ScaledClones);
+
+    return NumSpawned;
 }
 
 void USFExtendService::MaybeStageCommitForMP(AFGHologram* ParentHologram)

--- a/Source/SmartFoundations/Private/Features/Extend/SFExtendService.cpp
+++ b/Source/SmartFoundations/Private/Features/Extend/SFExtendService.cpp
@@ -1085,17 +1085,31 @@ bool USFExtendService::CanAffordExtendCost(AFGHologram* Hologram, UFGInventoryCo
         return true;  // Can't evaluate -> never block.
     }
 
+    // #357: ALWAYS run the parent cost walk every frame, even under No Build Cost. Beyond
+    // computing affordability, GetCost(includeChildren=true) walks the child holograms, and
+    // that per-frame walk is what KEEPS THE EXTEND CHILD BELT PREVIEWS ALIVE. The internal
+    // factory<->distributor belts (role "belt_segment", built via SetSplineDataAndUpdate) are
+    // otherwise regenerated to ZERO spline meshes by vanilla's per-frame spline rebuild; the
+    // between-distributor lanes (AutoRouteSplineWithNormals) survive regardless. Proven by
+    // elimination: affordable-via-materials (walk runs -> belts visible, HMS_OK) and
+    // affordable-via-No-Build-Cost (old early-return skipped the walk -> belts missing, also
+    // HMS_OK) are BOTH HMS_OK, so the material state is NOT the trigger; running GetCost is.
+    // The early-return added in 720e2bc (#324) skipped this walk under free build, which is the
+    // sole behavioral difference between the visible and missing cases (the availability loop
+    // below is pure inventory reads with no hologram side effect).
+    AFGCentralStorageSubsystem* CentralStorage = AFGCentralStorageSubsystem::Get(Hologram->GetWorld());
+    const TArray<FItemAmount> TotalCost = Hologram->GetCost(/*includeChildren=*/true);
+
     // Free building (session No Build Cost cheat OR the per-player rule that Advanced Game
     // Settings / Creative Mode toggles) means materials are never required. GetNoBuildCost()
     // is the same method vanilla uses; without this, Creative Mode players got a material-cost
     // request and an unaffordable block on Extend even though the base game would build for free.
+    // (We still ran GetCost above for its preview-keep-alive side effect.)
     if (Inventory->GetNoBuildCost())
     {
         return true;
     }
 
-    AFGCentralStorageSubsystem* CentralStorage = AFGCentralStorageSubsystem::Get(Hologram->GetWorld());
-    const TArray<FItemAmount> TotalCost = Hologram->GetCost(/*includeChildren=*/true);
     for (const FItemAmount& Item : TotalCost)
     {
         if (!Item.ItemClass || Item.Amount <= 0)

--- a/Source/SmartFoundations/Private/Features/Extend/SFExtendService.cpp
+++ b/Source/SmartFoundations/Private/Features/Extend/SFExtendService.cpp
@@ -692,6 +692,73 @@ void USFExtendService::SetServerCommitSourceBuilding(AFGBuildable* Source)
         TEXT("[EXTEND-MP] Server installed commit source building: %s."), *GetNameSafe(Source));
 }
 
+void USFExtendService::GetScaledClonePlanForCommit(TArray<FSFExtendCommitScaledClone>& OutClones) const
+{
+    OutClones.Reset();
+    for (const FSFScaledExtendClone& Clone : ScaledExtendClones)
+    {
+        FSFExtendCommitScaledClone Entry;
+        Entry.WorldOffset = Clone.WorldOffset;
+        Entry.RotationOffset = Clone.RotationOffset;
+        Entry.GridX = Clone.GridX;
+        Entry.GridY = Clone.GridY;
+        Entry.bIsSeed = Clone.bIsSeed;
+        OutClones.Add(Entry);
+    }
+}
+
+int32 USFExtendService::ReconstructScaledCommitOnServer(AFGHologram* ParentHologram,
+    const TArray<FSFExtendCommitScaledClone>& Clones)
+{
+    if (Clones.Num() == 0 || !ParentHologram || !TopologyService || !ScaledService)
+    {
+        return 0;
+    }
+    AFGBuildable* Source = CurrentExtendTarget.Get();
+    if (!Source)
+    {
+        UE_LOG(LogSmartExtend, Warning,
+            TEXT("[EXTEND-MP] ReconstructScaledCommitOnServer: no source building installed - scaled clone sets skipped."));
+        return 0;
+    }
+
+    // Authoritative graph walk (the server owns mConnectedComponent) - the spawn pipeline below
+    // captures its source topology from TopologyService->GetCurrentTopology().
+    if (!TopologyService->WalkTopology(Source))
+    {
+        UE_LOG(LogSmartExtend, Warning,
+            TEXT("[EXTEND-MP] ReconstructScaledCommitOnServer: server topology walk failed for %s - scaled clone sets skipped."),
+            *GetNameSafe(Source));
+        return 0;
+    }
+
+    // Install the session state SpawnScaledExtendPreviews reads, then run the SAME pipeline the
+    // SP preview uses: per clone it spawns the factory child (JsonCloneId "sc{i}_factory"),
+    // regenerates the infrastructure topology (FromSource + rigid-body rotation + lanes), and
+    // fills ScaledExtendClones[i].SpawnedHolograms / CloneTopology - exactly the state the scaled
+    // post-build wiring consumes after the vanilla child-construct loop builds everything.
+    CurrentExtendHologram = ParentHologram;
+    ScaledExtendClones.Empty();
+    for (const FSFExtendCommitScaledClone& C : Clones)
+    {
+        FSFScaledExtendClone Entry;
+        Entry.GridX = C.GridX;
+        Entry.GridY = C.GridY;
+        Entry.bIsSeed = C.bIsSeed;
+        Entry.WorldOffset = C.WorldOffset;
+        Entry.RotationOffset = C.RotationOffset;
+        ScaledExtendClones.Add(Entry);
+    }
+
+    ScaledService->SpawnCloneSetsForServerCommit();
+
+    UE_LOG(LogSmartExtend, Display,
+        TEXT("[EXTEND-MP] Server reconstructed %d scaled clone set(s) for %s (parent now has %d children)."),
+        ScaledExtendClones.Num(), *GetNameSafe(ParentHologram), ParentHologram->GetHologramChildren().Num());
+
+    return ScaledExtendClones.Num();
+}
+
 void USFExtendService::ReceiveServerTopology(const FSFExtendTopology& Topology)
 {
     CachedServerTopology = Topology;

--- a/Source/SmartFoundations/Private/Features/Extend/SFExtendService.cpp
+++ b/Source/SmartFoundations/Private/Features/Extend/SFExtendService.cpp
@@ -26,7 +26,6 @@
 #include "Services/RadarPulse/SFRadarPulseService.h"
 #include "SmartFoundations.h"  // For LogSmartExtend
 #include "Holograms/Core/SFFactoryHologram.h"
-#include "Holograms/Core/SFFoundationHologram.h"
 #include "Holograms/Logistics/SFConveyorAttachmentChildHologram.h"
 #include "Holograms/Logistics/SFConveyorBeltHologram.h"
 #include "Holograms/Logistics/SFPipelineHologram.h"
@@ -1756,83 +1755,9 @@ ASFFactoryHologram* USFExtendService::SwapToSmartFactoryHologram(AFGHologram* Va
     return CustomHologram;
 }
 
-ASFFoundationHologram* USFExtendService::SwapToSmartFoundationHologram(AFGHologram* VanillaHologram)
-{
-    // MP scaling spec path for FOUNDATION grids. Mirrors SwapToSmartFactoryHologram (the proven
-    // mechanism: deferred spawn -> init from vanilla -> repoint BuildState->mHologram -> destroy
-    // vanilla) with ASFFoundationHologram as the target and no Extend swap tracking.
-    if (!VanillaHologram || !VanillaHologram->IsValidLowLevel())
-    {
-        UE_LOG(LogSmartFoundations, Warning, TEXT("[MP-SPEC] FOUNDATION SWAP: Invalid vanilla hologram"));
-        return nullptr;
-    }
-
-    AFGBuildGun* BuildGun = GetPlayerBuildGun();
-    if (!BuildGun)
-    {
-        UE_LOG(LogSmartFoundations, Warning, TEXT("[MP-SPEC] FOUNDATION SWAP: Could not get build gun"));
-        return nullptr;
-    }
-
-    UFGBuildGunStateBuild* BuildState = GetBuildGunBuildState(BuildGun);
-    if (!BuildState)
-    {
-        UE_LOG(LogSmartFoundations, Warning, TEXT("[MP-SPEC] FOUNDATION SWAP: Could not get build state"));
-        return nullptr;
-    }
-
-    UWorld* World = VanillaHologram->GetWorld();
-    if (!World || !VanillaHologram->GetBuildClass())
-    {
-        UE_LOG(LogSmartFoundations, Warning, TEXT("[MP-SPEC] FOUNDATION SWAP: No world or no BuildClass"));
-        return nullptr;
-    }
-
-    ASFFoundationHologram* CustomHologram = World->SpawnActorDeferred<ASFFoundationHologram>(
-        ASFFoundationHologram::StaticClass(),
-        FTransform(VanillaHologram->GetActorRotation(), VanillaHologram->GetActorLocation()),
-        BuildGun,
-        nullptr,
-        ESpawnActorCollisionHandlingMethod::AlwaysSpawn
-    );
-    if (!CustomHologram)
-    {
-        UE_LOG(LogSmartFoundations, Error, TEXT("[MP-SPEC] FOUNDATION SWAP: Failed to spawn deferred custom hologram"));
-        return nullptr;
-    }
-
-    // Initialize from the vanilla hologram BEFORE BeginPlay (copies mBuildClass + mRecipe).
-    CustomHologram->InitializeFromHologram(VanillaHologram);
-
-    // Copy mConstructionInstigator (private) via reflection - needed for build FX
-    if (FProperty* InstigatorProp = AFGHologram::StaticClass()->FindPropertyByName(TEXT("mConstructionInstigator")))
-    {
-        InstigatorProp->CopyCompleteValue(
-            InstigatorProp->ContainerPtrToValuePtr<void>(CustomHologram),
-            InstigatorProp->ContainerPtrToValuePtr<void>(VanillaHologram)
-        );
-    }
-
-    CustomHologram->FinishSpawning(FTransform(VanillaHologram->GetActorRotation(), VanillaHologram->GetActorLocation()));
-
-    // Repoint the build gun's hologram pointer to the custom one (the loop-avoidance key).
-    FProperty* HologramProp = BuildState->GetClass()->FindPropertyByName(TEXT("mHologram"));
-    FObjectProperty* ObjProp = HologramProp ? CastField<FObjectProperty>(HologramProp) : nullptr;
-    void* ValuePtr = ObjProp ? HologramProp->ContainerPtrToValuePtr<void>(BuildState) : nullptr;
-    if (!ValuePtr)
-    {
-        UE_LOG(LogSmartFoundations, Error, TEXT("[MP-SPEC] FOUNDATION SWAP: Could not find mHologram property"));
-        CustomHologram->Destroy();
-        return nullptr;
-    }
-    ObjProp->SetObjectPropertyValue(ValuePtr, CustomHologram);
-
-    VanillaHologram->Destroy();
-
-    UE_LOG(LogSmartFoundations, Display, TEXT("[MP-SPEC] FOUNDATION SWAP: Swapped to ASFFoundationHologram (%s)"),
-        *CustomHologram->GetName());
-    return CustomHologram;
-}
+// (SwapToSmartFoundationHologram was removed: the MP spec-construction path is now class-agnostic
+// via SML hooks - see USFGameInstanceModule::RegisterSpecConstructionHooks - so no scaling swap of
+// any kind is needed. The factory swap above remains for EXTEND.)
 
 void USFExtendService::RestoreOriginalHologram()
 {

--- a/Source/SmartFoundations/Private/Features/Extend/SFExtendService.cpp
+++ b/Source/SmartFoundations/Private/Features/Extend/SFExtendService.cpp
@@ -127,6 +127,10 @@ void USFExtendService::ClearExtendState()
 {
     if (bHasValidTarget)
     {
+        // [EXTEND-MP] Stage an explicit commit CLEAR (client-only no-op otherwise): a pre-staged
+        // commit must never survive the session it belonged to.
+        StageCommitClearForMP();
+
         // CRITICAL: Unlock the extend hologram BEFORE any cleanup.
         // This is the hologram that was locked at activation — must be unlocked
         // so the build gun can reposition it when the player aims elsewhere.
@@ -704,6 +708,80 @@ void USFExtendService::GetScaledClonePlanForCommit(TArray<FSFExtendCommitScaledC
         Entry.GridY = Clone.GridY;
         Entry.bIsSeed = Clone.bIsSeed;
         OutClones.Add(Entry);
+    }
+}
+
+bool USFExtendService::BuildCommitSpecForMP(AFGHologram* ParentHologram, FSFExtendCommitSpec& OutSpec) const
+{
+    OutSpec = FSFExtendCommitSpec();
+    if (!ParentHologram)
+    {
+        return false;
+    }
+    const FSFExtendTopology& Topo = GetLastExtendTopology();
+    if (!Topo.bIsValid || !Topo.SourceBuilding.IsValid())
+    {
+        return false;
+    }
+
+    // Re-emit a FRESH clone topology at the hologram's CURRENT position - the preview's stored
+    // topology has stale transforms (children are re-positioned while aiming).
+    const FVector FinalOffset = ParentHologram->GetActorLocation() - Topo.SourceBuilding->GetActorLocation();
+    const FSFSourceTopology Source = FSFSourceTopology::CaptureFromTopology(Topo);
+    OutSpec.Clone = FSFCloneTopology::FromSource(Source, FinalOffset);
+    OutSpec.Cost = ParentHologram->GetCost(true); // parent + preview children, exact preview cost
+    OutSpec.BuildClass = ParentHologram->GetBuildClass();
+    OutSpec.SourceBuilding = Topo.SourceBuilding.Get();
+    GetScaledClonePlanForCommit(OutSpec.ScaledClones);
+    OutSpec.bValid = OutSpec.Clone.ChildHolograms.Num() > 0;
+    return OutSpec.bValid;
+}
+
+void USFExtendService::MaybeStageCommitForMP(AFGHologram* ParentHologram)
+{
+    if (!Subsystem.IsValid() || !FSFNetworkHelper::IsClient(Subsystem->GetWorld()))
+    {
+        return;
+    }
+    const double Now = FPlatformTime::Seconds();
+    if (Now - LastCommitStageTime < 0.25)
+    {
+        return;
+    }
+    LastCommitStageTime = Now;
+
+    FSFExtendCommitSpec Spec;
+    if (!BuildCommitSpecForMP(ParentHologram, Spec))
+    {
+        return;
+    }
+    if (UWorld* World = Subsystem->GetWorld())
+    {
+        if (AFGPlayerController* PC = Cast<AFGPlayerController>(World->GetFirstPlayerController()))
+        {
+            if (USFRCO* RCO = PC->GetRemoteCallObjectOfClass<USFRCO>())
+            {
+                RCO->Server_StageExtendCommit(Spec);
+            }
+        }
+    }
+}
+
+void USFExtendService::StageCommitClearForMP()
+{
+    if (!Subsystem.IsValid() || !FSFNetworkHelper::IsClient(Subsystem->GetWorld()))
+    {
+        return;
+    }
+    if (UWorld* World = Subsystem->GetWorld())
+    {
+        if (AFGPlayerController* PC = Cast<AFGPlayerController>(World->GetFirstPlayerController()))
+        {
+            if (USFRCO* RCO = PC->GetRemoteCallObjectOfClass<USFRCO>())
+            {
+                RCO->Server_StageExtendCommit(FSFExtendCommitSpec()); // bValid=false = clear
+            }
+        }
     }
 }
 
@@ -1331,6 +1409,11 @@ void USFExtendService::RefreshExtension(AFGHologram* SourceHologram, bool bForce
     {
         ActiveHologram = SourceHologram;
     }
+
+    // [EXTEND-MP] Pre-stage the commit while the preview is active (throttled, client-only no-op
+    // otherwise): the commit RPC is large and lost the cross-channel race against the tiny
+    // construct RPC when staged only at fire time (live 2026-06-10).
+    MaybeStageCommitForMP(ActiveHologram);
 
     if (!IsValid(ActiveHologram))
     {

--- a/Source/SmartFoundations/Private/Features/Extend/SFExtendService.cpp
+++ b/Source/SmartFoundations/Private/Features/Extend/SFExtendService.cpp
@@ -846,6 +846,25 @@ bool USFExtendService::TryExtendFromBuilding(AFGBuildable* HitBuilding, AFGHolog
         return false;
     }
 
+    // [EXTEND-MP] The DEDICATED SERVER must never run the Extend preview pipeline on its mirror
+    // hologram. Extend previews are client-side cosmetics, and the staged commit
+    // (Server_StageExtendCommit) carries everything the server needs at construct time. Live
+    // crash 2026-06-10: the dedi's mirror activation spawned its OWN recipe-less clone preview
+    // children; the client's construct message then deserialized into that hologram (clobbering
+    // mChildren - the documented hazard) and ValidatePlacementAndCost made a virtual call into a
+    // freed child (EXCEPTION_ACCESS_VIOLATION at 0xffffffff). SP and listen-host are unaffected
+    // (their local player IS the previewing player).
+    if (Subsystem.IsValid())
+    {
+        if (UWorld* World = Subsystem->GetWorld())
+        {
+            if (World->GetNetMode() == NM_DedicatedServer)
+            {
+                return false;
+            }
+        }
+    }
+
     // Debug: Entry log
     static double LastEntryLog = 0;
     double EntryNow = FPlatformTime::Seconds();

--- a/Source/SmartFoundations/Private/Features/Extend/SFExtendService.cpp
+++ b/Source/SmartFoundations/Private/Features/Extend/SFExtendService.cpp
@@ -676,6 +676,14 @@ bool USFExtendService::WalkTopology(AFGBuildable* SourceBuilding)
     return false;
 }
 
+void USFExtendService::SetStoredCloneTopologyForServerCommit(const FSFCloneTopology& Clone)
+{
+    StoredCloneTopology = MakeShared<FSFCloneTopology>(Clone);
+    UE_LOG(LogSmartExtend, Display,
+        TEXT("[EXTEND-MP] Server installed staged clone topology: %d children (parent class %s)."),
+        Clone.ChildHolograms.Num(), *Clone.ParentBuildClass);
+}
+
 void USFExtendService::ReceiveServerTopology(const FSFExtendTopology& Topology)
 {
     CachedServerTopology = Topology;

--- a/Source/SmartFoundations/Private/Features/Extend/SFExtendService.cpp
+++ b/Source/SmartFoundations/Private/Features/Extend/SFExtendService.cpp
@@ -852,6 +852,28 @@ int32 USFExtendService::ReconstructCommitOnServer(AFGHologram* ParentHologram, c
         TEXT("[EXTEND-MP] Server reconstructed %d/%d clone children (%d pre-wired) for %s; vanilla construct will build them."),
         NumSpawned, Clone.ChildHolograms.Num(), NumWired, *ParentHologram->GetName());
 
+    // [EXTEND-MP] Push the authoritative clone topology to the BUILDING CLIENT so a later
+    // Import-from-Last-Extend saves a preset with REAL segment connections - the client's own
+    // capture has them all empty (GetConnection() null on clients) and such a preset restores
+    // into unconnected belt segments (live finding 2026-06-10). Value-only struct, one reliable
+    // RPC, bounded by the parent clone set's child count.
+    if (APawn* InstigatorPawn = ParentHologram->GetConstructionInstigator())
+    {
+        if (AFGPlayerController* InstigatorPC = Cast<AFGPlayerController>(InstigatorPawn->GetController()))
+        {
+            if (!InstigatorPC->IsLocalController())
+            {
+                if (USFRCO* RCO = InstigatorPC->GetRemoteCallObjectOfClass<USFRCO>())
+                {
+                    RCO->Client_ReceiveServerCloneTopology(Clone);
+                    UE_LOG(LogSmartExtend, Display,
+                        TEXT("[EXTEND-MP] Pushed server-derived clone topology (%d children) to %s for preset capture."),
+                        Clone.ChildHolograms.Num(), *GetNameSafe(InstigatorPC));
+                }
+            }
+        }
+    }
+
     // Scaled clone sets ride the same server-derived topology (SpawnScaledExtendPreviews
     // re-captures from the topology service's CurrentTopology, walked above).
     ReconstructScaledCommitOnServer(ParentHologram, Spec.ScaledClones);
@@ -959,6 +981,14 @@ int32 USFExtendService::ReconstructScaledCommitOnServer(AFGHologram* ParentHolog
     return ScaledExtendClones.Num();
 }
 
+void USFExtendService::ReceiveServerCloneTopology(const FSFCloneTopology& Topology)
+{
+    ServerDerivedCloneTopology = MakeShared<FSFCloneTopology>(Topology);
+    UE_LOG(LogSmartExtend, Display,
+        TEXT("[EXTEND-MP] Client received server-derived clone topology: %d children (preset-grade, full connections)."),
+        Topology.ChildHolograms.Num());
+}
+
 void USFExtendService::ReceiveServerTopology(const FSFExtendTopology& Topology)
 {
     CachedServerTopology = Topology;
@@ -1003,6 +1033,19 @@ TSharedPtr<FSFCloneTopology> USFExtendService::GetLastCloneTopology() const
             TEXT("[SmartRestore][Extend] GetLastCloneTopology: returning restored template topology children=%d"),
             RestoredCloneTopologyTemplate->ChildHolograms.Num());
         return MakeShared<FSFCloneTopology>(*RestoredCloneTopologyTemplate);
+    }
+
+    // [EXTEND-MP] On a client, prefer the SERVER-derived copy (pushed after every commit
+    // reconstruction): the client-captured topologies below have empty segment connections
+    // (GetConnection() is null on clients) and poison any preset saved from them - restored
+    // builds then place belts that never wire (live finding 2026-06-10).
+    if (ServerDerivedCloneTopology.IsValid()
+        && Subsystem.IsValid() && FSFNetworkHelper::IsClient(Subsystem->GetWorld()))
+    {
+        SF_EXTEND_DIAGNOSTIC_LOG(LogSmartExtend, Log,
+            TEXT("[SmartRestore][Extend] GetLastCloneTopology: returning SERVER-derived topology children=%d"),
+            ServerDerivedCloneTopology->ChildHolograms.Num());
+        return MakeShared<FSFCloneTopology>(*ServerDerivedCloneTopology);
     }
 
     if (StoredCloneTopology.IsValid())

--- a/Source/SmartFoundations/Private/Features/Extend/SFExtendService.cpp
+++ b/Source/SmartFoundations/Private/Features/Extend/SFExtendService.cpp
@@ -22,6 +22,9 @@
 #include "Services/SFRecipeManagementService.h"
 #include "Subsystem/SFSubsystem.h"
 #include "Subsystem/SFHologramDataService.h"
+#include "Core/Helpers/SFNetworkHelper.h"   // [EXTEND-MP] IsClient (server-walk topology branch)
+#include "SFRCO.h"                          // [EXTEND-MP] Server_RequestExtendTopology
+#include "FGPlayerController.h"
 // NOTE: SFRecipeCostInjector.h removed - child holograms automatically aggregate costs via GetCost()
 #include "Services/RadarPulse/SFRadarPulseService.h"
 #include "SmartFoundations.h"  // For LogSmartExtend
@@ -607,6 +610,58 @@ TArray<ESFExtendDirection> USFExtendService::GetValidDirections() const
 
 bool USFExtendService::WalkTopology(AFGBuildable* SourceBuilding)
 {
+    // [EXTEND-MP] A network client cannot walk the graph locally: mConnectedComponent is
+    // UPROPERTY(SaveGame) - server-only, NOT replicated - so GetConnection() is null on clients
+    // by design (live-diagnosed 2026-06-08: "2 factory connectors, 0 with resolved
+    // GetConnection()"). Ask the SERVER to walk via the USFRCO topology request and consume the
+    // cached reply here: activation calls WalkTopology every tick while aiming, so returning
+    // false until the reply lands makes the flow async with zero restructuring. The reply's
+    // actor/component references are replicated objects, so they resolve against local proxies.
+    if (Subsystem.IsValid() && FSFNetworkHelper::IsClient(Subsystem->GetWorld()))
+    {
+        const double Now = FPlatformTime::Seconds();
+
+        // Cached reply for THIS building, still fresh?
+        if (CachedServerTopologyBuilding.Get() == SourceBuilding
+            && Now - CachedServerTopologyTime < 3.0)
+        {
+            if (!CachedServerTopology.bIsValid)
+            {
+                return false; // negative result cached: nothing to extend here
+            }
+            if (TopologyService)
+            {
+                TopologyService->InjectTopology(CachedServerTopology);
+            }
+            LastExtendTopology = CachedServerTopology;
+            return true;
+        }
+
+        // Not cached (or stale): fire a throttled server request and bail for this tick.
+        if (PendingTopologyRequestBuilding.Get() != SourceBuilding
+            || Now - LastTopologyRequestTime > 1.0)
+        {
+            bool bRequested = false;
+            if (UWorld* World = Subsystem->GetWorld())
+            {
+                if (AFGPlayerController* PC = Cast<AFGPlayerController>(World->GetFirstPlayerController()))
+                {
+                    if (USFRCO* RCO = PC->GetRemoteCallObjectOfClass<USFRCO>())
+                    {
+                        RCO->Server_RequestExtendTopology(SourceBuilding);
+                        bRequested = true;
+                    }
+                }
+            }
+            PendingTopologyRequestBuilding = SourceBuilding;
+            LastTopologyRequestTime = Now;
+            UE_LOG(LogSmartExtend, Display,
+                TEXT("[EXTEND-MP] Client requested server topology walk for %s (%s)."),
+                *GetNameSafe(SourceBuilding), bRequested ? TEXT("sent") : TEXT("RCO unavailable"));
+        }
+        return false;
+    }
+
     if (TopologyService)
     {
         const bool bWalked = TopologyService->WalkTopology(SourceBuilding);
@@ -619,6 +674,19 @@ bool USFExtendService::WalkTopology(AFGBuildable* SourceBuilding)
 
     UE_LOG(LogSmartExtend, Verbose, TEXT("Smart!: WalkTopology called but TopologyService not initialized"));
     return false;
+}
+
+void USFExtendService::ReceiveServerTopology(const FSFExtendTopology& Topology)
+{
+    CachedServerTopology = Topology;
+    CachedServerTopologyBuilding = Topology.SourceBuilding;
+    CachedServerTopologyTime = FPlatformTime::Seconds();
+
+    UE_LOG(LogSmartExtend, Display,
+        TEXT("[EXTEND-MP] Client received server topology for %s: valid=%d (beltIn=%d beltOut=%d pipeIn=%d pipeOut=%d power=%d)"),
+        *GetNameSafe(Topology.SourceBuilding.Get()), Topology.bIsValid ? 1 : 0,
+        Topology.InputChains.Num(), Topology.OutputChains.Num(),
+        Topology.PipeInputChains.Num(), Topology.PipeOutputChains.Num(), Topology.PowerPoles.Num());
 }
 
 const FSFExtendTopology& USFExtendService::GetCurrentTopology() const

--- a/Source/SmartFoundations/Private/Features/Extend/SFExtendService.cpp
+++ b/Source/SmartFoundations/Private/Features/Extend/SFExtendService.cpp
@@ -718,6 +718,51 @@ bool USFExtendService::BuildCommitSpecForMP(AFGHologram* ParentHologram, FSFExte
     {
         return false;
     }
+
+    // [EXTEND-MP] RESTORE commit: an active Smart Restore replay session owns the preview, so the
+    // commit must be the restore one - there is no source building to walk (the topology comes
+    // from the saved preset template, value-only and wire-safe). Ship the compact TEMPLATE plus
+    // the panel state + production recipe the server-side replay pipeline reads; the server
+    // re-expands at the validated parent's final position (fresher than any client re-emission).
+    if (bRestoredCloneTopologyActive && RestoredCloneTopologyTemplate.IsValid())
+    {
+        const FSFCloneTopology& Template = *RestoredCloneTopologyTemplate;
+
+        // Reliable-RPC ceiling guard (same rationale as the conduit-plan guard): a preset
+        // template is normally one clone's infrastructure, but refuse anything that could
+        // overflow the staging RPC before the previews are destroyed.
+        int32 BytesEstimate = 0;
+        for (const FSFCloneHologram& Holo : Template.ChildHolograms)
+        {
+            BytesEstimate += 400 + Holo.SplineData.Points.Num() * 80;
+        }
+        if (BytesEstimate > 45000)
+        {
+            UE_LOG(LogSmartExtend, Warning,
+                TEXT("[EXTEND-MP] Restore commit refused: preset template too large to stage reliably (%d children, ~%d bytes)."),
+                Template.ChildHolograms.Num(), BytesEstimate);
+            return false;
+        }
+
+        OutSpec.bIsRestore = true;
+        OutSpec.RestoreTemplate = Template;
+        OutSpec.Cost = ParentHologram->GetCost(true); // parent + restored preview children, exact
+        OutSpec.BuildClass = ParentHologram->GetBuildClass();
+        if (Subsystem.IsValid())
+        {
+            OutSpec.RestoreCounterState = Subsystem->GetCounterState();
+            if (USFRecipeManagementService* RecipeSvc = Subsystem->GetRecipeManagementService())
+            {
+                if (RecipeSvc->HasStoredProductionRecipe())
+                {
+                    OutSpec.RestoreProductionRecipe = RecipeSvc->GetStoredProductionRecipe();
+                }
+            }
+        }
+        OutSpec.bValid = true;
+        return true;
+    }
+
     const FSFExtendTopology& Topo = GetLastExtendTopology();
     if (!Topo.bIsValid || !Topo.SourceBuilding.IsValid())
     {
@@ -742,6 +787,38 @@ int32 USFExtendService::ReconstructCommitOnServer(AFGHologram* ParentHologram, c
     if (!ParentHologram || !TopologyService)
     {
         return 0;
+    }
+
+    // [EXTEND-MP] RESTORE commit: no source building exists to walk - the preset TEMPLATE arrived
+    // with the commit. Install the client's panel state + production recipe (the replay pipeline
+    // and the restored-factory placement/wiring math read them from the subsystem), then run the
+    // SAME replay pipeline the SP preview uses: expansion at this validated parent's position,
+    // rr_X_Y factory spawn, infra spawn, pre-wiring, and the session state
+    // (StoredCloneTopology / JsonSpawnedHolograms / RestoredScaledFactoryPreviewLocations) the
+    // post-construct wiring pass consumes. Mirrors how the scaled commit reuses
+    // SpawnScaledExtendPreviews via SpawnCloneSetsForServerCommit.
+    if (Spec.bIsRestore)
+    {
+        if (Subsystem.IsValid())
+        {
+            Subsystem->UpdateCounterState(Spec.RestoreCounterState);
+            if (Spec.RestoreProductionRecipe)
+            {
+                if (USFRecipeManagementService* RecipeSvc = Subsystem->GetRecipeManagementService())
+                {
+                    RecipeSvc->StoreProductionRecipeClass(Spec.RestoreProductionRecipe);
+                }
+            }
+        }
+
+        const bool bReplayed = ReplayRestoreCloneTopology(ParentHologram, Spec.RestoreTemplate);
+        const int32 NumChildren = ParentHologram->GetHologramChildren().Num();
+        UE_LOG(LogSmartFoundations, Display,
+            TEXT("[EXTEND-MP] Server reconstructed RESTORE commit for %s: replayed=%d, parent now has %d children (template %d, grid %dx%d)."),
+            *ParentHologram->GetName(), bReplayed ? 1 : 0, NumChildren,
+            Spec.RestoreTemplate.ChildHolograms.Num(),
+            Spec.RestoreCounterState.GridCounters.X, Spec.RestoreCounterState.GridCounters.Y);
+        return bReplayed ? NumChildren : 0;
     }
 
     SetStoredCloneTopologyForServerCommit(FSFCloneTopology()); // replaced below; keep state coherent

--- a/Source/SmartFoundations/Private/Features/Extend/SFExtendService.cpp
+++ b/Source/SmartFoundations/Private/Features/Extend/SFExtendService.cpp
@@ -659,7 +659,7 @@ bool USFExtendService::WalkTopology(AFGBuildable* SourceBuilding)
             }
             PendingTopologyRequestBuilding = SourceBuilding;
             LastTopologyRequestTime = Now;
-            UE_LOG(LogSmartExtend, Display,
+            UE_LOG(LogSmartExtend, Verbose,
                 TEXT("[EXTEND-MP] Client requested server topology walk for %s (%s)."),
                 *GetNameSafe(SourceBuilding), bRequested ? TEXT("sent") : TEXT("RCO unavailable"));
         }
@@ -683,7 +683,7 @@ bool USFExtendService::WalkTopology(AFGBuildable* SourceBuilding)
 void USFExtendService::SetStoredCloneTopologyForServerCommit(const FSFCloneTopology& Clone)
 {
     StoredCloneTopology = MakeShared<FSFCloneTopology>(Clone);
-    UE_LOG(LogSmartExtend, Display,
+    UE_LOG(LogSmartExtend, Verbose,
         TEXT("[EXTEND-MP] Server installed staged clone topology: %d children (parent class %s)."),
         Clone.ChildHolograms.Num(), *Clone.ParentBuildClass);
 }
@@ -692,7 +692,7 @@ void USFExtendService::SetServerCommitSourceBuilding(AFGBuildable* Source)
 {
     LastBuiltFromBuilding = Source;
     CurrentExtendTarget = Source;
-    UE_LOG(LogSmartExtend, Display,
+    UE_LOG(LogSmartExtend, Verbose,
         TEXT("[EXTEND-MP] Server installed commit source building: %s."), *GetNameSafe(Source));
 }
 
@@ -813,7 +813,7 @@ int32 USFExtendService::ReconstructCommitOnServer(AFGHologram* ParentHologram, c
 
         const bool bReplayed = ReplayRestoreCloneTopology(ParentHologram, Spec.RestoreTemplate);
         const int32 NumChildren = ParentHologram->GetHologramChildren().Num();
-        UE_LOG(LogSmartFoundations, Display,
+        UE_LOG(LogSmartFoundations, Verbose,
             TEXT("[EXTEND-MP] Server reconstructed RESTORE commit for %s: replayed=%d, parent now has %d children (template %d, grid %dx%d)."),
             *ParentHologram->GetName(), bReplayed ? 1 : 0, NumChildren,
             Spec.RestoreTemplate.ChildHolograms.Num(),
@@ -848,7 +848,7 @@ int32 USFExtendService::ReconstructCommitOnServer(AFGHologram* ParentHologram, c
     TMap<FString, AFGHologram*> SpawnedClones;
     const int32 NumSpawned = Clone.SpawnChildHolograms(ParentHologram, this, SpawnedClones);
     const int32 NumWired = Clone.WireChildHologramConnections(SpawnedClones, ParentHologram);
-    UE_LOG(LogSmartFoundations, Display,
+    UE_LOG(LogSmartFoundations, Verbose,
         TEXT("[EXTEND-MP] Server reconstructed %d/%d clone children (%d pre-wired) for %s; vanilla construct will build them."),
         NumSpawned, Clone.ChildHolograms.Num(), NumWired, *ParentHologram->GetName());
 
@@ -866,7 +866,7 @@ int32 USFExtendService::ReconstructCommitOnServer(AFGHologram* ParentHologram, c
                 if (USFRCO* RCO = InstigatorPC->GetRemoteCallObjectOfClass<USFRCO>())
                 {
                     RCO->Client_ReceiveServerCloneTopology(Clone);
-                    UE_LOG(LogSmartExtend, Display,
+                    UE_LOG(LogSmartExtend, Verbose,
                         TEXT("[EXTEND-MP] Pushed server-derived clone topology (%d children) to %s for preset capture."),
                         Clone.ChildHolograms.Num(), *GetNameSafe(InstigatorPC));
                 }
@@ -974,7 +974,7 @@ int32 USFExtendService::ReconstructScaledCommitOnServer(AFGHologram* ParentHolog
 
     ScaledService->SpawnCloneSetsForServerCommit();
 
-    UE_LOG(LogSmartExtend, Display,
+    UE_LOG(LogSmartExtend, Verbose,
         TEXT("[EXTEND-MP] Server reconstructed %d scaled clone set(s) for %s (parent now has %d children)."),
         ScaledExtendClones.Num(), *GetNameSafe(ParentHologram), ParentHologram->GetHologramChildren().Num());
 
@@ -984,7 +984,7 @@ int32 USFExtendService::ReconstructScaledCommitOnServer(AFGHologram* ParentHolog
 void USFExtendService::ReceiveServerCloneTopology(const FSFCloneTopology& Topology)
 {
     ServerDerivedCloneTopology = MakeShared<FSFCloneTopology>(Topology);
-    UE_LOG(LogSmartExtend, Display,
+    UE_LOG(LogSmartExtend, Verbose,
         TEXT("[EXTEND-MP] Client received server-derived clone topology: %d children (preset-grade, full connections)."),
         Topology.ChildHolograms.Num());
 }
@@ -995,7 +995,7 @@ void USFExtendService::ReceiveServerTopology(const FSFExtendTopology& Topology)
     CachedServerTopologyBuilding = Topology.SourceBuilding;
     CachedServerTopologyTime = FPlatformTime::Seconds();
 
-    UE_LOG(LogSmartExtend, Display,
+    UE_LOG(LogSmartExtend, Verbose,
         TEXT("[EXTEND-MP] Client received server topology for %s: valid=%d (beltIn=%d beltOut=%d pipeIn=%d pipeOut=%d power=%d)"),
         *GetNameSafe(Topology.SourceBuilding.Get()), Topology.bIsValid ? 1 : 0,
         Topology.InputChains.Num(), Topology.OutputChains.Num(),
@@ -1240,7 +1240,7 @@ bool USFExtendService::TryExtendFromBuilding(AFGBuildable* HitBuilding, AFGHolog
             static double LastBail1 = 0; const double Now1 = FPlatformTime::Seconds();
             if (Now1 - LastBail1 > 1.0)
             {
-                UE_LOG(LogSmartExtend, Display, TEXT("[EXTEND-MP] activation bail: IsA mismatch - building=%s holoBuildClass=%s"),
+                UE_LOG(LogSmartExtend, Verbose, TEXT("[EXTEND-MP] activation bail: IsA mismatch - building=%s holoBuildClass=%s"),
                     *HitBuilding->GetClass()->GetName(), HologramBuildClass ? *HologramBuildClass->GetName() : TEXT("NULL"));
                 LastBail1 = Now1;
             }
@@ -1253,7 +1253,7 @@ bool USFExtendService::TryExtendFromBuilding(AFGBuildable* HitBuilding, AFGHolog
             static double LastBail2 = 0; const double Now2 = FPlatformTime::Seconds();
             if (Now2 - LastBail2 > 1.0)
             {
-                UE_LOG(LogSmartExtend, Display, TEXT("[EXTEND-MP] activation bail: IsValidExtendTarget=false for %s"),
+                UE_LOG(LogSmartExtend, Verbose, TEXT("[EXTEND-MP] activation bail: IsValidExtendTarget=false for %s"),
                     *HitBuilding->GetClass()->GetName());
                 LastBail2 = Now2;
             }
@@ -1261,7 +1261,7 @@ bool USFExtendService::TryExtendFromBuilding(AFGBuildable* HitBuilding, AFGHolog
         }
 
         // [EXTEND-MP] TEMP: passed activation validation - Extend SHOULD proceed to build the preview.
-        UE_LOG(LogSmartExtend, Display, TEXT("[EXTEND-MP] activation PASSED for %s - proceeding to preview"), *HitBuilding->GetName());
+        UE_LOG(LogSmartExtend, Verbose, TEXT("[EXTEND-MP] activation PASSED for %s - proceeding to preview"), *HitBuilding->GetName());
     }
 
     // Issue #274: When Scaled Extend is committed (locked for inspection), suppress re-triggering
@@ -1350,7 +1350,7 @@ bool USFExtendService::TryExtendFromBuilding(AFGBuildable* HitBuilding, AFGHolog
         static double LastTopoLog = 0; const double Now = FPlatformTime::Seconds();
         if (Now - LastTopoLog > 1.0)
         {
-            UE_LOG(LogSmartExtend, Display, TEXT("[EXTEND-MP] WalkTopology(%s) = %s"),
+            UE_LOG(LogSmartExtend, Verbose, TEXT("[EXTEND-MP] WalkTopology(%s) = %s"),
                 *HitBuilding->GetName(), bWalked ? TEXT("TRUE - proceeding") : TEXT("FALSE - bail (no belts/distributors connected?)"));
             LastTopoLog = Now;
         }

--- a/Source/SmartFoundations/Private/Features/Extend/SFExtendTopologyService.cpp
+++ b/Source/SmartFoundations/Private/Features/Extend/SFExtendTopologyService.cpp
@@ -76,6 +76,24 @@ bool USFExtendTopologyService::WalkTopology(AFGBuildable* SourceBuilding)
     SF_EXTEND_DIAGNOSTIC_LOG(LogSmartExtend, Log, TEXT("Smart!: Walking topology for %s with %d connections"),
         *SourceBuilding->GetName(), Connections.Num());
 
+    // [EXTEND-MP] TEMP: does the factory connection graph resolve on a client? Topology bails if every
+    // connector's GetConnection() is null. Log connector count vs resolved count once/sec.
+    {
+        static double LastConnLog = 0; const double NowC = FPlatformTime::Seconds();
+        if (NowC - LastConnLog > 1.0)
+        {
+            int32 NumConnected = 0;
+            for (UFGFactoryConnectionComponent* C : Connections)
+            {
+                if (IsValid(C) && IsValid(C->GetConnection())) { ++NumConnected; }
+            }
+            UE_LOG(LogSmartExtend, Display, TEXT("[EXTEND-MP] %s: %d factory connectors, %d with resolved GetConnection() -> %s"),
+                *SourceBuilding->GetName(), Connections.Num(), NumConnected,
+                (Connections.Num() > 0 && NumConnected == 0) ? TEXT("connection links NOT resolved on client (topology fails)") : TEXT("connections resolve"));
+            LastConnLog = NowC;
+        }
+    }
+
     for (UFGFactoryConnectionComponent* Connector : Connections)
     {
         if (!IsValid(Connector))

--- a/Source/SmartFoundations/Private/Features/Extend/SFExtendTopologyService.cpp
+++ b/Source/SmartFoundations/Private/Features/Extend/SFExtendTopologyService.cpp
@@ -87,7 +87,7 @@ bool USFExtendTopologyService::WalkTopology(AFGBuildable* SourceBuilding)
             {
                 if (IsValid(C) && IsValid(C->GetConnection())) { ++NumConnected; }
             }
-            UE_LOG(LogSmartExtend, Display, TEXT("[EXTEND-MP] %s: %d factory connectors, %d with resolved GetConnection() -> %s"),
+            UE_LOG(LogSmartExtend, Verbose, TEXT("[EXTEND-MP] %s: %d factory connectors, %d with resolved GetConnection() -> %s"),
                 *SourceBuilding->GetName(), Connections.Num(), NumConnected,
                 (Connections.Num() > 0 && NumConnected == 0) ? TEXT("connection links NOT resolved on client (topology fails)") : TEXT("connections resolve"));
             LastConnLog = NowC;

--- a/Source/SmartFoundations/Private/Features/Extend/SFExtendWiringService_Json.cpp
+++ b/Source/SmartFoundations/Private/Features/Extend/SFExtendWiringService_Json.cpp
@@ -1284,42 +1284,37 @@ int32 USFExtendWiringService::GenerateAndExecuteWiring(AFGBuildableFactory* NewF
             continue;
         }
 
-        // Build clone_id -> buildable mapping for ExtendService clone set
+        // Per-clone actor map with PREFIXED keys (scopes chain/network rebuilds to this clone).
         TMap<FString, AActor*> CloneBuiltActors;
-        CloneBuiltActors.Add(TEXT("parent"), CloneFactory);
-
-        // Find all built actors with ExtendService clone's prefix
         FString ClonePrefix = FString::Printf(TEXT("sc%d_"), CloneIdx);
         for (const auto& Pair : ExtendService->JsonBuiltActors)
         {
             if (Pair.Key.StartsWith(ClonePrefix) && IsValid(Pair.Value))
             {
-                // Strip prefix for topology matching
-                FString OriginalId = Pair.Key.Mid(ClonePrefix.Len());
-                CloneBuiltActors.Add(OriginalId, Pair.Value);
+                CloneBuiltActors.Add(Pair.Key, Pair.Value);
             }
         }
+        CloneBuiltActors.Add(FString::Printf(TEXT("sc%d_factory"), CloneIdx), CloneFactory);
 
         SF_EXTEND_DIAGNOSTIC_LOG(LogSmartExtend, Log, TEXT("⚡ SCALED EXTEND Wire: Clone[%d] - %d built actors mapped (factory=%s)"),
             CloneIdx, CloneBuiltActors.Num(), *CloneFactory->GetName());
 
-        // Generate and execute wiring for ExtendService clone
-        // Use the clone's topology but with stripped IDs (matching original topology structure)
-        FSFCloneTopology StrippedTopology = *Clone.CloneTopology;
-        for (FSFCloneHologram& Holo : StrippedTopology.ChildHolograms)
+        // Generate the clone's manifest from its PREFIXED topology against the GLOBAL id map.
+        // The spawn-time prefix pass rewrites every connection TARGET into the prefixed
+        // namespace ("parent" -> "sc{i}_factory", internal refs -> "sc{i}_X", lane source-sides
+        // -> "sc{i-1}_X" or the parent set's UNPREFIXED ids). The old code stripped prefixes
+        // from the map keys and hologram ids but NEVER from the targets, so every lookup missed
+        // and the per-clone manifests came out empty (live 2026-06-10: manifestBelts=0 for every
+        // clone, with clone-0's lanes mis-resolving into its own namespace). The global map
+        // resolves all of it: parent-set ids, every prefixed clone id, and the parent factory.
+        TMap<FString, AActor*> CloneGenMap = CloneIdToBuildable;
+        for (const auto& Pair : CloneBuiltActors)
         {
-            if (Holo.HologramId.StartsWith(ClonePrefix))
-            {
-                Holo.HologramId = Holo.HologramId.Mid(ClonePrefix.Len());
-            }
-            if (Holo.ConnectedPowerPoleHologramId.StartsWith(ClonePrefix))
-            {
-                Holo.ConnectedPowerPoleHologramId = Holo.ConnectedPowerPoleHologramId.Mid(ClonePrefix.Len());
-            }
+            CloneGenMap.Add(Pair.Key, Pair.Value);
         }
 
         FSFWiringManifest CloneManifest = FSFWiringManifest::Generate(
-            StrippedTopology, CloneBuiltActors, CloneFactory);
+            *Clone.CloneTopology, CloneGenMap, CloneFactory);
 
         int32 CloneWired = CloneManifest.ExecuteWiring(GetWorld());
         int32 CloneChains = CloneManifest.CreateChainActors(GetWorld(), CloneBuiltActors);
@@ -1485,7 +1480,8 @@ int32 USFExtendWiringService::GenerateAndExecuteWiring(AFGBuildableFactory* NewF
             }
         }
 
-        for (const FSFCloneHologram& Holo : StrippedTopology.ChildHolograms)
+        // (Prefixed topology + prefixed CloneBuiltActors keys: ids and pole references line up.)
+        for (const FSFCloneHologram& Holo : Clone.CloneTopology->ChildHolograms)
         {
             if (Holo.Role != TEXT("pipe_attachment")) continue;
             if (Holo.ConnectedPowerPoleHologramId.IsEmpty()) continue;

--- a/Source/SmartFoundations/Private/Features/Extend/SFExtendWiringService_Json.cpp
+++ b/Source/SmartFoundations/Private/Features/Extend/SFExtendWiringService_Json.cpp
@@ -1223,11 +1223,19 @@ int32 USFExtendWiringService::GenerateAndExecuteWiring(AFGBuildableFactory* NewF
     // ==================== Scaled Extend: Additional Clone Wiring (Issue #265) ====================
     // Process wiring for each additional clone set beyond clone 1
     int32 ScaledExtendWiredCount = 0;
+    // [EXTEND-MP] Display level while MP Extend validates (Verbose is stripped on the dedi).
+    UE_LOG(LogSmartFoundations, Display,
+        TEXT("[EXTEND-MP] Scaled clone wiring: %d clone set(s), jsonBuilt=%d, sourceTarget=%s."),
+        ExtendService->ScaledExtendClones.Num(), ExtendService->JsonBuiltActors.Num(),
+        *GetNameSafe(ExtendService->CurrentExtendTarget.Get()));
     for (int32 CloneIdx = 0; CloneIdx < ExtendService->ScaledExtendClones.Num(); CloneIdx++)
     {
         FSFScaledExtendClone& Clone = ExtendService->ScaledExtendClones[CloneIdx];
         if (!Clone.CloneTopology.IsValid() || Clone.CloneTopology->ChildHolograms.Num() == 0)
         {
+            UE_LOG(LogSmartFoundations, Display,
+                TEXT("[EXTEND-MP] Scaled clone wiring: Clone[%d] SKIPPED - topology %s."),
+                CloneIdx, Clone.CloneTopology.IsValid() ? TEXT("empty") : TEXT("null"));
             continue;
         }
 
@@ -1270,7 +1278,9 @@ int32 USFExtendWiringService::GenerateAndExecuteWiring(AFGBuildableFactory* NewF
 
         if (!CloneFactory)
         {
-            SF_EXTEND_DIAGNOSTIC_LOG(LogSmartExtend, Warning, TEXT("⚡ SCALED EXTEND Wire: Could not find built factory for Clone[%d] at expected position"), CloneIdx);
+            UE_LOG(LogSmartFoundations, Display,
+                TEXT("[EXTEND-MP] Scaled clone wiring: Clone[%d] SKIPPED - no built factory within 5m of expected position %s."),
+                CloneIdx, *ExpectedPos.ToCompactString());
             continue;
         }
 
@@ -1314,6 +1324,12 @@ int32 USFExtendWiringService::GenerateAndExecuteWiring(AFGBuildableFactory* NewF
         int32 CloneWired = CloneManifest.ExecuteWiring(GetWorld());
         int32 CloneChains = CloneManifest.CreateChainActors(GetWorld(), CloneBuiltActors);
         int32 ClonePipes = CloneManifest.RebuildPipeNetworks(GetWorld(), CloneBuiltActors);
+
+        // [EXTEND-MP] Display level while MP Extend validates.
+        UE_LOG(LogSmartFoundations, Display,
+            TEXT("[EXTEND-MP] Scaled clone wiring: Clone[%d] factory=%s mapped=%d manifestBelts=%d manifestPipes=%d wired=%d chains=%d."),
+            CloneIdx, *CloneFactory->GetName(), CloneBuiltActors.Num(),
+            CloneManifest.BeltConnections.Num(), CloneManifest.PipeConnections.Num(), CloneWired, CloneChains);
 
         // Lift ↔ Passthrough linking for scaled clone (Issue #260) — world search approach
         {

--- a/Source/SmartFoundations/Private/Features/Extend/SFExtendWiringService_Json.cpp
+++ b/Source/SmartFoundations/Private/Features/Extend/SFExtendWiringService_Json.cpp
@@ -1224,7 +1224,7 @@ int32 USFExtendWiringService::GenerateAndExecuteWiring(AFGBuildableFactory* NewF
     // Process wiring for each additional clone set beyond clone 1
     int32 ScaledExtendWiredCount = 0;
     // [EXTEND-MP] Display level while MP Extend validates (Verbose is stripped on the dedi).
-    UE_LOG(LogSmartFoundations, Display,
+    UE_LOG(LogSmartFoundations, Verbose,
         TEXT("[EXTEND-MP] Scaled clone wiring: %d clone set(s), jsonBuilt=%d, sourceTarget=%s."),
         ExtendService->ScaledExtendClones.Num(), ExtendService->JsonBuiltActors.Num(),
         *GetNameSafe(ExtendService->CurrentExtendTarget.Get()));
@@ -1233,7 +1233,7 @@ int32 USFExtendWiringService::GenerateAndExecuteWiring(AFGBuildableFactory* NewF
         FSFScaledExtendClone& Clone = ExtendService->ScaledExtendClones[CloneIdx];
         if (!Clone.CloneTopology.IsValid() || Clone.CloneTopology->ChildHolograms.Num() == 0)
         {
-            UE_LOG(LogSmartFoundations, Display,
+            UE_LOG(LogSmartFoundations, Verbose,
                 TEXT("[EXTEND-MP] Scaled clone wiring: Clone[%d] SKIPPED - topology %s."),
                 CloneIdx, Clone.CloneTopology.IsValid() ? TEXT("empty") : TEXT("null"));
             continue;
@@ -1278,7 +1278,7 @@ int32 USFExtendWiringService::GenerateAndExecuteWiring(AFGBuildableFactory* NewF
 
         if (!CloneFactory)
         {
-            UE_LOG(LogSmartFoundations, Display,
+            UE_LOG(LogSmartFoundations, Verbose,
                 TEXT("[EXTEND-MP] Scaled clone wiring: Clone[%d] SKIPPED - no built factory within 5m of expected position %s."),
                 CloneIdx, *ExpectedPos.ToCompactString());
             continue;
@@ -1321,7 +1321,7 @@ int32 USFExtendWiringService::GenerateAndExecuteWiring(AFGBuildableFactory* NewF
         int32 ClonePipes = CloneManifest.RebuildPipeNetworks(GetWorld(), CloneBuiltActors);
 
         // [EXTEND-MP] Display level while MP Extend validates.
-        UE_LOG(LogSmartFoundations, Display,
+        UE_LOG(LogSmartFoundations, Verbose,
             TEXT("[EXTEND-MP] Scaled clone wiring: Clone[%d] factory=%s mapped=%d manifestBelts=%d manifestPipes=%d wired=%d chains=%d."),
             CloneIdx, *CloneFactory->GetName(), CloneBuiltActors.Num(),
             CloneManifest.BeltConnections.Num(), CloneManifest.PipeConnections.Num(), CloneWired, CloneChains);

--- a/Source/SmartFoundations/Private/Features/Extend/SFWiringManifest.cpp
+++ b/Source/SmartFoundations/Private/Features/Extend/SFWiringManifest.cpp
@@ -825,15 +825,18 @@ int32 FSFWiringManifest::CreateChainActors(UWorld* World, const TMap<FString, AA
         }
     }
 
-    // From AdditionalActors (lane_segment, belt_segment, lift_segment from JSON build)
+    // From AdditionalActors — collect by TYPE, like RebuildPipeNetworks does.
+    // Per-clone scaled-extend maps carry sc{i}_-prefixed keys, which a
+    // StartsWith("lane_segment"...) role filter never matches: clone belts then
+    // skip chain registration entirely (chains=0) while ConfigureComponents has
+    // already deferred AddConveyor to this pass. Connected-but-unchained belts
+    // are the THESIS factory-tick hazard class (live dedi AV in
+    // AFGBuildableSubsystem::TickFactoryActors, 2026-06-10).
     for (const auto& Pair : AdditionalActors)
     {
-        if (Pair.Key.StartsWith(TEXT("lane_segment")) || Pair.Key.StartsWith(TEXT("belt_segment")) || Pair.Key.StartsWith(TEXT("lift_segment")))
+        if (AFGBuildableConveyorBase* Conveyor = Cast<AFGBuildableConveyorBase>(Pair.Value))
         {
-            if (AFGBuildableConveyorBase* Conveyor = Cast<AFGBuildableConveyorBase>(Pair.Value))
-            {
-                AllConveyors.AddUnique(Conveyor);
-            }
+            AllConveyors.AddUnique(Conveyor);
         }
     }
 

--- a/Source/SmartFoundations/Private/Features/Extend/SFWiringManifest.cpp
+++ b/Source/SmartFoundations/Private/Features/Extend/SFWiringManifest.cpp
@@ -879,6 +879,24 @@ int32 FSFWiringManifest::CreateChainActors(UWorld* World, const TMap<FString, AA
     SF_EXTEND_DIAGNOSTIC_LOG(LogSmartExtend, Log, TEXT("⛓️ CHAIN REBUILD: %d conveyors, %d affected chains to rebuild"),
         AllConveyors.Num(), AffectedChains.Num());
 
+    // [CHAIN-DIAG] Shipping-visible summary of what this pass is about to touch (the Verbose
+    // line above is invisible on a shipping dedi — that blindness cost the 2026-06-10 save-poison
+    // investigation a full repro cycle).
+    {
+        FString ChainNames;
+        int32 Listed = 0;
+        for (AFGConveyorChainActor* Chain : AffectedChains)
+        {
+            if (!IsValid(Chain)) continue;
+            if (Listed++ == 8) { ChainNames += TEXT(",..."); break; }
+            if (Listed > 1) ChainNames += TEXT(",");
+            ChainNames += FString::Printf(TEXT("%s(segs=%d)"), *Chain->GetName(), Chain->GetNumChainSegments());
+        }
+        UE_LOG(LogSmartExtend, Display,
+            TEXT("[CHAIN-DIAG] CreateChainActors: %d conveyor(s), %d affected chain(s): %s"),
+            AllConveyors.Num(), AffectedChains.Num(), Listed == 0 ? TEXT("<none>") : *ChainNames);
+    }
+
     USFSubsystem* Subsystem = USFSubsystem::Get(World);
     USFChainActorService* ChainService = Subsystem ? Subsystem->GetChainActorService() : nullptr;
     if (!ChainService)

--- a/Source/SmartFoundations/Private/Features/Extend/SFWiringManifest.cpp
+++ b/Source/SmartFoundations/Private/Features/Extend/SFWiringManifest.cpp
@@ -892,7 +892,7 @@ int32 FSFWiringManifest::CreateChainActors(UWorld* World, const TMap<FString, AA
             if (Listed > 1) ChainNames += TEXT(",");
             ChainNames += FString::Printf(TEXT("%s(segs=%d)"), *Chain->GetName(), Chain->GetNumChainSegments());
         }
-        UE_LOG(LogSmartExtend, Display,
+        UE_LOG(LogSmartExtend, Verbose,
             TEXT("[CHAIN-DIAG] CreateChainActors: %d conveyor(s), %d affected chain(s): %s"),
             AllConveyors.Num(), AffectedChains.Num(), Listed == 0 ? TEXT("<none>") : *ChainNames);
     }

--- a/Source/SmartFoundations/Private/Features/PowerAutoConnect/SFPowerAutoConnectManager.cpp
+++ b/Source/SmartFoundations/Private/Features/PowerAutoConnect/SFPowerAutoConnectManager.cpp
@@ -12,6 +12,7 @@
 #include "FGCircuitConnectionComponent.h"
 #include "SmartFoundations.h"  // For LogSmartFoundations
 #include "Constants/SFAssetPaths.h"
+#include "Core/Helpers/SFNetworkHelper.h"  // [#334] authority gate
 #include "FGPlayerController.h"
 #include "FGCharacterPlayer.h"
 #include "FGInventoryComponent.h"
@@ -1031,6 +1032,15 @@ void FSFPowerAutoConnectManager::OnPowerPoleBuilt(AFGBuildablePowerPole* BuiltPo
 	if (!BuiltPole || !Subsystem)
 	{
 		UE_LOG(LogSmartAutoConnect, Warning, TEXT("⚡ OnPowerPoleBuilt: Invalid parameters"));
+		return;
+	}
+
+	// [MP / #334] Authority gate: this function direct-spawns AFGBuildableWire actors. On a
+	// network client it would create client-only ghost wires for replicated server-built poles -
+	// the original #334 bug. Authority sides (SP standalone / listen host / dedicated server)
+	// are unchanged. Defense-in-depth: the OnActorSpawned caller is gated too.
+	if (FSFNetworkHelper::IsClient(BuiltPole->GetWorld()))
+	{
 		return;
 	}
 

--- a/Source/SmartFoundations/Private/Features/Upgrade/SFUpgradeAuditService.cpp
+++ b/Source/SmartFoundations/Private/Features/Upgrade/SFUpgradeAuditService.cpp
@@ -549,22 +549,20 @@ void USFUpgradeAuditService::FinalizeAudit()
 	{
 		if (AFGPlayerController* PC = CurrentParams.RequestingPlayer.Get())
 		{
-			// Find our RCO instance for this player
-			// In SML, RCOs are spawned per player controller
-			TArray<AActor*> RCOActors;
-			UGameplayStatics::GetAllActorsOfClass(World, USFRCO::StaticClass(), RCOActors);
-			
-			for (AActor* Actor : RCOActors)
+			// RCOs are UObjects outered to the player controller, NOT actors — the old
+			// GetAllActorsOfClass scan here could never find one, so audit results were never
+			// delivered to clients (live finding 2026-06-10; the panel-side request lookup had
+			// the same bug, masking this one).
+			if (USFRCO* RCO = PC->GetRemoteCallObjectOfClass<USFRCO>())
 			{
-				if (USFRCO* RCO = Cast<USFRCO>(Actor))
-				{
-					if (RCO->GetOuter() == PC)
-					{
-						RCO->Client_ReceiveAuditResult(LastResult);
-						UE_LOG(LogSmartUpgrade, Verbose, TEXT("USFUpgradeAuditService: Sent audit result to client via RCO"));
-						break;
-					}
-				}
+				RCO->Client_ReceiveAuditResult(LastResult);
+				UE_LOG(LogSmartUpgrade, Verbose, TEXT("USFUpgradeAuditService: Sent audit result to client via RCO"));
+			}
+			else
+			{
+				UE_LOG(LogSmartUpgrade, Warning,
+					TEXT("USFUpgradeAuditService: Could not resolve USFRCO for %s - audit result not delivered."),
+					*GetNameSafe(PC));
 			}
 		}
 	}

--- a/Source/SmartFoundations/Private/Features/Upgrade/SFUpgradeExecutionService.cpp
+++ b/Source/SmartFoundations/Private/Features/Upgrade/SFUpgradeExecutionService.cpp
@@ -666,8 +666,13 @@ int32 USFUpgradeExecutionService::ProcessSingleUpgrade(AFGBuildable* Buildable, 
 	// Get buildable subsystem
 	AFGBuildableSubsystem* BuildableSubsystem = AFGBuildableSubsystem::Get(World);
 
-	// Get player controller and build gun for hologram spawning
-	AFGPlayerController* PC = Cast<AFGPlayerController>(World->GetFirstPlayerController());
+	// Get player controller and build gun for hologram spawning. [UPGRADE-MP] Use the REQUESTING
+	// player's controller: on a dedicated server GetFirstPlayerController is whichever client
+	// happened to connect first (the known wrong-player build-path hazard) - and the requester's
+	// build gun/pawn exist server-side. Fall back to first PC for legacy callers without one.
+	AFGPlayerController* PC = CurrentParams.PlayerController
+		? CurrentParams.PlayerController.Get()
+		: Cast<AFGPlayerController>(World->GetFirstPlayerController());
 	if (!PC)
 	{
 		UE_LOG(LogSmartUpgrade, Warning, TEXT("UpgradeExecutionService: No player controller"));
@@ -1701,6 +1706,40 @@ void USFUpgradeExecutionService::CompleteUpgrade()
 	OnUpgradeExecutionCompleted.Broadcast(LastResult);
 	UE_LOG(LogSmartUpgrade, Verbose, TEXT("UpgradeExecutionService: Upgrade complete - Success=%d Fail=%d Skip=%d"),
 		LastResult.SuccessCount, LastResult.FailCount, LastResult.SkipCount);
+
+	// [UPGRADE-MP] When the request came from a REMOTE client (RCO-routed), echo the result back
+	// to that player's RCO so their local service broadcasts to their panel - the same delivery
+	// the audit service uses.
+	if (CurrentParams.PlayerController && !CurrentParams.PlayerController->IsLocalController() && World)
+	{
+		TArray<AActor*> RCOActors;
+		UGameplayStatics::GetAllActorsOfClass(World, USFRCO::StaticClass(), RCOActors);
+		for (AActor* Actor : RCOActors)
+		{
+			if (USFRCO* RCO = Cast<USFRCO>(Actor))
+			{
+				if (RCO->GetOuter() == CurrentParams.PlayerController)
+				{
+					RCO->Client_ReceiveUpgradeResult(LastResult);
+					UE_LOG(LogSmartUpgrade, Display,
+						TEXT("[UPGRADE-MP] Sent upgrade result to client %s via RCO (Success=%d Fail=%d Skip=%d)."),
+						*GetNameSafe(CurrentParams.PlayerController), LastResult.SuccessCount,
+						LastResult.FailCount, LastResult.SkipCount);
+					break;
+				}
+			}
+		}
+	}
+}
+
+void USFUpgradeExecutionService::InjectUpgradeResult(const FSFUpgradeExecutionResult& Result)
+{
+	LastResult = Result;
+	bUpgradeInProgress = false;
+	OnUpgradeExecutionCompleted.Broadcast(LastResult);
+	UE_LOG(LogSmartUpgrade, Verbose,
+		TEXT("[UPGRADE-MP] Injected server upgrade result - Success=%d Fail=%d Skip=%d"),
+		Result.SuccessCount, Result.FailCount, Result.SkipCount);
 }
 
 TSubclassOf<UFGRecipe> USFUpgradeExecutionService::GetUpgradeRecipe(ESFUpgradeFamily Family, int32 TargetTier) const

--- a/Source/SmartFoundations/Private/Features/Upgrade/SFUpgradeExecutionService.cpp
+++ b/Source/SmartFoundations/Private/Features/Upgrade/SFUpgradeExecutionService.cpp
@@ -1717,7 +1717,7 @@ void USFUpgradeExecutionService::CompleteUpgrade()
 		if (USFRCO* RCO = CurrentParams.PlayerController->GetRemoteCallObjectOfClass<USFRCO>())
 		{
 			RCO->Client_ReceiveUpgradeResult(LastResult);
-			UE_LOG(LogSmartUpgrade, Display,
+			UE_LOG(LogSmartUpgrade, Verbose,
 				TEXT("[UPGRADE-MP] Sent upgrade result to client %s via RCO (Success=%d Fail=%d Skip=%d)."),
 				*GetNameSafe(CurrentParams.PlayerController), LastResult.SuccessCount,
 				LastResult.FailCount, LastResult.SkipCount);

--- a/Source/SmartFoundations/Private/Features/Upgrade/SFUpgradeExecutionService.cpp
+++ b/Source/SmartFoundations/Private/Features/Upgrade/SFUpgradeExecutionService.cpp
@@ -1712,22 +1712,21 @@ void USFUpgradeExecutionService::CompleteUpgrade()
 	// the audit service uses.
 	if (CurrentParams.PlayerController && !CurrentParams.PlayerController->IsLocalController() && World)
 	{
-		TArray<AActor*> RCOActors;
-		UGameplayStatics::GetAllActorsOfClass(World, USFRCO::StaticClass(), RCOActors);
-		for (AActor* Actor : RCOActors)
+		// RCOs are not actors — resolve via the owning PC, never GetAllActorsOfClass
+		// (the audit service's identical actor scan never found one; live finding 2026-06-10).
+		if (USFRCO* RCO = CurrentParams.PlayerController->GetRemoteCallObjectOfClass<USFRCO>())
 		{
-			if (USFRCO* RCO = Cast<USFRCO>(Actor))
-			{
-				if (RCO->GetOuter() == CurrentParams.PlayerController)
-				{
-					RCO->Client_ReceiveUpgradeResult(LastResult);
-					UE_LOG(LogSmartUpgrade, Display,
-						TEXT("[UPGRADE-MP] Sent upgrade result to client %s via RCO (Success=%d Fail=%d Skip=%d)."),
-						*GetNameSafe(CurrentParams.PlayerController), LastResult.SuccessCount,
-						LastResult.FailCount, LastResult.SkipCount);
-					break;
-				}
-			}
+			RCO->Client_ReceiveUpgradeResult(LastResult);
+			UE_LOG(LogSmartUpgrade, Display,
+				TEXT("[UPGRADE-MP] Sent upgrade result to client %s via RCO (Success=%d Fail=%d Skip=%d)."),
+				*GetNameSafe(CurrentParams.PlayerController), LastResult.SuccessCount,
+				LastResult.FailCount, LastResult.SkipCount);
+		}
+		else
+		{
+			UE_LOG(LogSmartUpgrade, Warning,
+				TEXT("[UPGRADE-MP] Could not resolve USFRCO for %s - upgrade result not delivered to the client."),
+				*GetNameSafe(CurrentParams.PlayerController));
 		}
 	}
 }

--- a/Source/SmartFoundations/Private/Features/Upgrade/SFUpgradeExecutionServiceImpl.h
+++ b/Source/SmartFoundations/Private/Features/Upgrade/SFUpgradeExecutionServiceImpl.h
@@ -48,3 +48,5 @@
 #include "Features/Extend/SFExtendService.h"
 #include "FGItemPickup_Spawnable.h"
 #include "FGCrate.h"
+#include "SFRCO.h"                     // [UPGRADE-MP] result echo to the requesting client's RCO
+#include "Kismet/GameplayStatics.h"    // [UPGRADE-MP] RCO lookup (GetAllActorsOfClass)

--- a/Source/SmartFoundations/Private/Features/Upgrade/SFUpgradeTraversalService.cpp
+++ b/Source/SmartFoundations/Private/Features/Upgrade/SFUpgradeTraversalService.cpp
@@ -23,6 +23,25 @@
 #include "FGPowerCircuit.h"
 #include "Buildables/FGBuildableWire.h"
 
+// [UPGRADE-MP] Client-side delivery of server-walked traversal results (see header).
+FSFOnTraversalResultReceived USFUpgradeTraversalService::OnClientTraversalResultReceived;
+
+void USFUpgradeTraversalService::InjectTraversalResult(FSFTraversalResult Result)
+{
+	// A TMap UPROPERTY does not reliably serialize across an RPC - rebuild the tier counts from
+	// the entries, which are plain reflected fields.
+	Result.CountByTier.Reset();
+	for (const FSFUpgradeAuditEntry& Entry : Result.Entries)
+	{
+		Result.CountByTier.FindOrAdd(Entry.CurrentTier)++;
+	}
+
+	UE_LOG(LogSmartUpgrade, Verbose,
+		TEXT("[UPGRADE-MP] Injected server traversal result: family=%d entries=%d upgradeable=%d"),
+		static_cast<int32>(Result.Family), Result.Entries.Num(), Result.UpgradeableCount);
+	OnClientTraversalResultReceived.Broadcast(Result);
+}
+
 FSFTraversalResult USFUpgradeTraversalService::TraverseNetwork(
 	AFGBuildable* AnchorBuildable,
 	const FSFTraversalConfig& Config,

--- a/Source/SmartFoundations/Private/Holograms/Core/SFBuildableChildHologram.cpp
+++ b/Source/SmartFoundations/Private/Holograms/Core/SFBuildableChildHologram.cpp
@@ -38,6 +38,17 @@ AActor* ASFBuildableChildHologram::Construct(TArray<AActor*>& out_children, FNet
 	UE_LOG(LogSmartHologram, Log, TEXT("SFBuildableChildHologram::Construct: Building %s from %s"),
 		mBuildClass ? *mBuildClass->GetName() : TEXT("NULL"), *GetName());
 
+	// [MP-SLICE0] TEMP multiplayer instrumentation — remove before release.
+	// Server-side per-child signal: if this fires with HasAuthority=1 on a CLIENT-initiated
+	// build, the previewed child round-tripped to the server. NetMode: 0=Standalone
+	// 1=DedicatedServer 2=ListenServer 3=Client.
+	{
+		const int32 NetMode = GetWorld() ? (int32)GetWorld()->GetNetMode() : -1;
+		UE_LOG(LogSmartHologram, Display,
+			TEXT("[MP-SLICE0] BuildableChild::Construct: %s build=%s NetMode=%d HasAuthority=%d"),
+			*GetName(), mBuildClass ? *mBuildClass->GetName() : TEXT("NULL"), NetMode, HasAuthority() ? 1 : 0);
+	}
+
 	AActor* BuiltActor = Super::Construct(out_children, constructionID);
 
 	if (BuiltActor)

--- a/Source/SmartFoundations/Private/Holograms/Core/SFBuildableChildHologram.cpp
+++ b/Source/SmartFoundations/Private/Holograms/Core/SFBuildableChildHologram.cpp
@@ -44,7 +44,7 @@ AActor* ASFBuildableChildHologram::Construct(TArray<AActor*>& out_children, FNet
 	// 1=DedicatedServer 2=ListenServer 3=Client.
 	{
 		const int32 NetMode = GetWorld() ? (int32)GetWorld()->GetNetMode() : -1;
-		UE_LOG(LogSmartHologram, Display,
+		UE_LOG(LogSmartHologram, Verbose,
 			TEXT("[MP-SLICE0] BuildableChild::Construct: %s build=%s NetMode=%d HasAuthority=%d"),
 			*GetName(), mBuildClass ? *mBuildClass->GetName() : TEXT("NULL"), NetMode, HasAuthority() ? 1 : 0);
 	}

--- a/Source/SmartFoundations/Private/Holograms/Core/SFFactoryHologram.cpp
+++ b/Source/SmartFoundations/Private/Holograms/Core/SFFactoryHologram.cpp
@@ -12,20 +12,8 @@
 #include "Holograms/Logistics/SFConveyorBeltHologram.h"
 #include "Holograms/Logistics/SFConveyorLiftHologram.h"
 #include "Holograms/Logistics/SFPipelineHologram.h"
-#include "Subsystem/SFPositionCalculator.h"
-#include "Data/SFBuildableSizeRegistry.h"
-#include "HAL/IConsoleManager.h"
+#include "Holograms/Core/SFScalingSpecExpansion.h"
 #include "Logging/SFLogMacros.h"
-
-// MP spec-based construction toggle. Off by default: the existing path (and the oversized-grid
-// safety guard) remain authoritative until this is validated in a live multiplayer session.
-// Set `sf.MP.SpecConstruction 1` on the CLIENT to ship the compact grid spec instead of N children.
-static TAutoConsoleVariable<int32> CVarSFMPSpecConstruction(
-    TEXT("sf.MP.SpecConstruction"),
-    0,
-    TEXT("Smart!: when 1, scaling grids commit via a compact server-expanded spec (MP) instead of ")
-    TEXT("serializing N child holograms. Experimental; default 0 (legacy path + oversized guard)."),
-    ECVF_Default);
 
 ASFFactoryHologram::ASFFactoryHologram()
 {
@@ -46,27 +34,9 @@ void ASFFactoryHologram::PreConstructMessageSerialization()
     // wire O(1)). The server regenerates them from mScalingSpec in PostConstructMessageDeserialization.
     // Guarded so legacy behaviour (and SP / listen-host, which construct directly without a message)
     // is completely unaffected.
-    if (CVarSFMPSpecConstruction.GetValueOnAnyThread() == 0) return;
+    if (!SFScalingSpecExpansion::IsSpecConstructionEnabled()) return;
     if (mChildren.Num() == 0) return;
-
-    // Capture the grid into a compact spec from the authoritative counter state + size registry.
-    // (Self-contained on the hologram: the client knows its own grid via the subsystem.)
-    USFSubsystem* SS = USFSubsystem::Get(GetWorld());
-    if (!SS) return;
-
-    const FSFCounterState Counters = SS->GetCounterState();
-    const int32 NX = FMath::Max(1, FMath::Abs(Counters.GridCounters.X));
-    const int32 NY = FMath::Max(1, FMath::Abs(Counters.GridCounters.Y));
-    const int32 NZ = FMath::Max(1, FMath::Abs(Counters.GridCounters.Z));
-    if (NX * NY * NZ <= 1) return; // trivial grid: nothing to expand server-side
-
-    USFBuildableSizeRegistry::Initialize();
-    const FSFBuildableSizeProfile Profile = USFBuildableSizeRegistry::GetProfile(GetBuildClass());
-
-    mScalingSpec.Counters = Counters;
-    mScalingSpec.ItemSize = Profile.DefaultSize;
-    mScalingSpec.AnchorOffset = Profile.AnchorOffset;
-    mScalingSpec.bValid = true;
+    if (!SFScalingSpecExpansion::CaptureScalingSpec(this, mScalingSpec)) return;
 
     // Detach the grid children from the serialized child list so they are NOT sent. The preview
     // actors still exist and are owned/cleaned up by the Smart grid-spawner's own tracking list,
@@ -79,8 +49,8 @@ void ASFFactoryHologram::PreConstructMessageSerialization()
     mChildren.Reset();
 
     UE_LOG(LogSmartFoundations, Display,
-        TEXT("[MP-SPEC] PreConstructMessageSerialization: captured spec (%d cells), stripped %d grid ")
-        TEXT("children from the wire. Construct message is now O(1)."),
+        TEXT("[MP-SPEC] PreConstructMessageSerialization(factory): captured spec (%d cells), stripped ")
+        TEXT("%d grid children from the wire. Construct message is now O(1)."),
         mScalingSpec.CellCount(), mStashedSpecChildren.Num());
 }
 
@@ -95,81 +65,7 @@ void ASFFactoryHologram::PostConstructMessageDeserialization()
     if (!HasAuthority()) return;
     if (mChildren.Num() > 0) return; // already populated (shouldn't happen on the spec path)
 
-    ExpandScalingSpecIntoChildren();
-}
-
-void ASFFactoryHologram::ExpandScalingSpecIntoChildren()
-{
-    UWorld* World = GetWorld();
-    if (!World || !mScalingSpec.bValid) return;
-    if (!mRecipe)
-    {
-        UE_LOG(LogSmartFoundations, Warning,
-            TEXT("[MP-SPEC] ExpandScalingSpecIntoChildren: no recipe on parent hologram %s; cannot expand."),
-            *GetName());
-        return;
-    }
-
-    const FSFCounterState& C = mScalingSpec.Counters;
-    const FVector ParentLoc = GetActorLocation();
-    const FRotator ParentRot = GetActorRotation();
-
-    const int32 NX = FMath::Max(1, FMath::Abs(C.GridCounters.X));
-    const int32 NY = FMath::Max(1, FMath::Abs(C.GridCounters.Y));
-    const int32 NZ = FMath::Max(1, FMath::Abs(C.GridCounters.Z));
-    const int32 SgnX = (C.GridCounters.X < 0) ? -1 : 1;
-    const int32 SgnY = (C.GridCounters.Y < 0) ? -1 : 1;
-    const int32 SgnZ = (C.GridCounters.Z < 0) ? -1 : 1;
-
-    FSFPositionCalculator Calc;
-    AActor* HoloOwner = GetOwner();
-    int32 SpawnedChildren = 0;
-    int32 LinearIndex = 0;
-
-    for (int32 ZI = 0; ZI < NZ; ++ZI)
-    {
-        for (int32 YI = 0; YI < NY; ++YI)
-        {
-            for (int32 XI = 0; XI < NX; ++XI)
-            {
-                // (0,0,0) is the parent buildable itself (built by Super::Construct), not a child.
-                if (XI == 0 && YI == 0 && ZI == 0) continue;
-
-                const int32 GX = XI * SgnX;
-                const int32 GY = YI * SgnY;
-                const int32 GZ = ZI * SgnZ;
-
-                const FVector CellLoc = Calc.CalculateChildPosition(
-                    GX, GY, GZ, ParentLoc, ParentRot,
-                    mScalingSpec.ItemSize, C, LinearIndex, mScalingSpec.AnchorOffset);
-                ++LinearIndex;
-
-                const FName ChildName(*FString::Printf(TEXT("SFSpecCell_%d_%d_%d"), GX, GY, GZ));
-
-                AFGHologram* Child = AFGHologram::SpawnChildHologramFromRecipe(
-                    this, ChildName, mRecipe, HoloOwner, CellLoc,
-                    [ParentRot](AFGHologram* NewChild)
-                    {
-                        if (NewChild)
-                        {
-                            NewChild->SetActorRotation(ParentRot);
-                            NewChild->Tags.AddUnique(FName(TEXT("SF_GridChild")));
-                        }
-                    });
-
-                if (Child)
-                {
-                    ++SpawnedChildren;
-                }
-            }
-        }
-    }
-
-    UE_LOG(LogSmartFoundations, Display,
-        TEXT("[MP-SPEC] ExpandScalingSpecIntoChildren: regenerated %d/%d grid children server-side ")
-        TEXT("for %s (recipe=%s). Vanilla cost + Construct will now build the full grid."),
-        SpawnedChildren, mScalingSpec.CellCount() - 1, *GetName(),
-        mRecipe ? *mRecipe->GetName() : TEXT("null"));
+    SFScalingSpecExpansion::ExpandScalingSpecIntoChildren(this, mScalingSpec, mRecipe);
 }
 
 void ASFFactoryHologram::BeginPlay()

--- a/Source/SmartFoundations/Private/Holograms/Core/SFFactoryHologram.cpp
+++ b/Source/SmartFoundations/Private/Holograms/Core/SFFactoryHologram.cpp
@@ -12,90 +12,11 @@
 #include "Holograms/Logistics/SFConveyorBeltHologram.h"
 #include "Holograms/Logistics/SFConveyorLiftHologram.h"
 #include "Holograms/Logistics/SFPipelineHologram.h"
-#include "Holograms/Core/SFScalingSpecExpansion.h"
 #include "Logging/SFLogMacros.h"
 
 ASFFactoryHologram::ASFFactoryHologram()
 {
     // Initialize factory-specific defaults
-}
-
-// ────────────────────────────────────────────────────────────────────────────────────────────
-// MP spec-based construction (Option A: ride the natural build-gun fire with an O(1) spec)
-// See docs/Features/Multiplayer/PLAN_MP_ScalingConstruction_Impl.md
-// ────────────────────────────────────────────────────────────────────────────────────────────
-
-void ASFFactoryHologram::PreConstructMessageSerialization()
-{
-    Super::PreConstructMessageSerialization();
-
-    // Client-side, at fire time: if the spec path is enabled and we have a populated grid spec,
-    // detach the grid children so they are NOT serialized into the construct message (keeps the
-    // wire O(1)). The server regenerates them from mScalingSpec in PostConstructMessageDeserialization.
-    // Guarded so legacy behaviour (and SP / listen-host, which construct directly without a message)
-    // is completely unaffected.
-    if (!SFScalingSpecExpansion::IsSpecConstructionEnabled()) return;
-    if (mChildren.Num() == 0) return;
-    if (!SFScalingSpecExpansion::CaptureScalingSpec(this, mScalingSpec)) return;
-
-    // Detach the grid children from the serialized child list so they are NOT sent. The preview
-    // actors still exist and are owned/cleaned up by the Smart grid-spawner's own tracking list,
-    // not by mChildren. The server regenerates them from mScalingSpec.
-    mStashedSpecChildren.Reset();
-    for (AFGHologram* Child : mChildren)
-    {
-        mStashedSpecChildren.Add(Child);
-    }
-    mChildren.Reset();
-
-    UE_LOG(LogSmartFoundations, Display,
-        TEXT("[MP-SPEC] PreConstructMessageSerialization(factory): captured spec (%d cells), stripped ")
-        TEXT("%d grid children from the wire. Construct message is now O(1)."),
-        mScalingSpec.CellCount(), mStashedSpecChildren.Num());
-}
-
-void ASFFactoryHologram::SerializeConstructMessage(FArchive& ar, FNetConstructionID id)
-{
-    Super::SerializeConstructMessage(ar, id);
-
-    // Client/saving: the message bytes were just written from the STRIPPED child list. Restore the
-    // stash into mChildren immediately so the hologram is whole again - the build gun's post-fire
-    // teardown then destroys the preview children normally. Without this, the stripped previews
-    // leak as orphans and the grid-spawner tracking desyncs (live-test finding, 2026-06-09).
-    if (ar.IsSaving() && mStashedSpecChildren.Num() > 0)
-    {
-        for (const TObjectPtr<AFGHologram>& Child : mStashedSpecChildren)
-        {
-            if (Child)
-            {
-                mChildren.Add(Child);
-            }
-        }
-        UE_LOG(LogSmartFoundations, Display,
-            TEXT("[MP-SPEC] SerializeConstructMessage(factory): restored %d stripped children post-write."),
-            mStashedSpecChildren.Num());
-        mStashedSpecChildren.Reset();
-    }
-}
-
-TArray<FItemAmount> ASFFactoryHologram::GetCost(bool includeChildren) const
-{
-    TArray<FItemAmount> Cost = Super::GetCost(includeChildren);
-
-    // Spec path, server side: cost is validated/charged BEFORE Construct, but the grid children are
-    // expanded INSIDE Construct (after validation - fresh holograms cannot pass vanilla placement
-    // validation, live-test finding 2026-06-09). The grid is uniform, so the correct total is the
-    // parent's per-cell cost scaled by the cell count. Client side never scales: its children are
-    // real (mChildren populated), so vanilla aggregation already yields the full amount.
-    if (includeChildren && mScalingSpec.bValid && HasAuthority() && mChildren.Num() == 0)
-    {
-        const int32 Cells = mScalingSpec.CellCount();
-        for (FItemAmount& Item : Cost)
-        {
-            Item.Amount *= Cells;
-        }
-    }
-    return Cost;
 }
 
 void ASFFactoryHologram::BeginPlay()
@@ -129,16 +50,6 @@ void ASFFactoryHologram::BeginPlay()
 
 AActor* ASFFactoryHologram::Construct(TArray<AActor*>& out_children, FNetConstructionID constructionID)
 {
-    // [MP-SPEC] Server-side spec expansion. Runs HERE - after Server_ConstructHologram validation
-    // has passed on the (childless) parent - because fresh holograms cannot pass vanilla placement
-    // validation (FGCDInitializing/InvalidFloor/InvalidAimLocation; live-test finding 2026-06-09).
-    // Cost was already charged correctly via the GetCost cell-count scaling. The children added
-    // here are constructed by Super::Construct's normal child loop, never validated.
-    if (HasAuthority() && mScalingSpec.bValid && mChildren.Num() == 0)
-    {
-        SFScalingSpecExpansion::ExpandScalingSpecIntoChildren(this, mScalingSpec, mRecipe);
-    }
-
     // [MP-SLICE0] TEMP multiplayer instrumentation — remove before release.
     // Parent-commit signal: does the scaled-factory Construct run with authority for a
     // CLIENT-initiated build, and how many children does it carry into the build?

--- a/Source/SmartFoundations/Private/Holograms/Core/SFFactoryHologram.cpp
+++ b/Source/SmartFoundations/Private/Holograms/Core/SFFactoryHologram.cpp
@@ -12,11 +12,144 @@
 #include "Holograms/Logistics/SFConveyorBeltHologram.h"
 #include "Holograms/Logistics/SFConveyorLiftHologram.h"
 #include "Holograms/Logistics/SFPipelineHologram.h"
+#include "Subsystem/SFPositionCalculator.h"
+#include "HAL/IConsoleManager.h"
 #include "Logging/SFLogMacros.h"
+
+// MP spec-based construction toggle. Off by default: the existing path (and the oversized-grid
+// safety guard) remain authoritative until this is validated in a live multiplayer session.
+// Set `sf.MP.SpecConstruction 1` on the CLIENT to ship the compact grid spec instead of N children.
+static TAutoConsoleVariable<int32> CVarSFMPSpecConstruction(
+    TEXT("sf.MP.SpecConstruction"),
+    0,
+    TEXT("Smart!: when 1, scaling grids commit via a compact server-expanded spec (MP) instead of ")
+    TEXT("serializing N child holograms. Experimental; default 0 (legacy path + oversized guard)."),
+    ECVF_Default);
 
 ASFFactoryHologram::ASFFactoryHologram()
 {
     // Initialize factory-specific defaults
+}
+
+// ────────────────────────────────────────────────────────────────────────────────────────────
+// MP spec-based construction (Option A: ride the natural build-gun fire with an O(1) spec)
+// See docs/Features/Multiplayer/PLAN_MP_ScalingConstruction_Impl.md
+// ────────────────────────────────────────────────────────────────────────────────────────────
+
+void ASFFactoryHologram::PreConstructMessageSerialization()
+{
+    Super::PreConstructMessageSerialization();
+
+    // Client-side, at fire time: if the spec path is enabled and we have a populated grid spec,
+    // detach the grid children so they are NOT serialized into the construct message (keeps the
+    // wire O(1)). The server regenerates them from mScalingSpec in PostConstructMessageDeserialization.
+    // Guarded so legacy behaviour (and SP / listen-host, which construct directly without a message)
+    // is completely unaffected.
+    if (CVarSFMPSpecConstruction.GetValueOnAnyThread() == 0) return;
+    if (!mScalingSpec.bValid) return;
+    if (mChildren.Num() == 0) return;
+
+    mStashedSpecChildren.Reset();
+    for (AFGHologram* Child : mChildren)
+    {
+        mStashedSpecChildren.Add(Child);
+    }
+    // Detach from the serialized child list. The preview actors still exist and are owned/cleaned up
+    // by the Smart grid-spawner's own tracking list, not by mChildren.
+    mChildren.Reset();
+
+    UE_LOG(LogSmartFoundations, Display,
+        TEXT("[MP-SPEC] PreConstructMessageSerialization: stripped %d grid children from the wire; ")
+        TEXT("spec describes %d cells. Construct message is now O(1)."),
+        mStashedSpecChildren.Num(), mScalingSpec.CellCount());
+}
+
+void ASFFactoryHologram::PostConstructMessageDeserialization()
+{
+    Super::PostConstructMessageDeserialization();
+
+    // Server-side, after the spec has been read off the wire and before vanilla cost-aggregation +
+    // Construct run: regenerate the grid children from the compact spec. With the children present
+    // again, vanilla GetCost(includeChildren) charges the full grid and Super::Construct builds it.
+    if (!mScalingSpec.bValid) return;
+    if (!HasAuthority()) return;
+    if (mChildren.Num() > 0) return; // already populated (shouldn't happen on the spec path)
+
+    ExpandScalingSpecIntoChildren();
+}
+
+void ASFFactoryHologram::ExpandScalingSpecIntoChildren()
+{
+    UWorld* World = GetWorld();
+    if (!World || !mScalingSpec.bValid) return;
+    if (!mRecipe)
+    {
+        UE_LOG(LogSmartFoundations, Warning,
+            TEXT("[MP-SPEC] ExpandScalingSpecIntoChildren: no recipe on parent hologram %s; cannot expand."),
+            *GetName());
+        return;
+    }
+
+    const FSFCounterState& C = mScalingSpec.Counters;
+    const FVector ParentLoc = GetActorLocation();
+    const FRotator ParentRot = GetActorRotation();
+
+    const int32 NX = FMath::Max(1, FMath::Abs(C.GridCounters.X));
+    const int32 NY = FMath::Max(1, FMath::Abs(C.GridCounters.Y));
+    const int32 NZ = FMath::Max(1, FMath::Abs(C.GridCounters.Z));
+    const int32 SgnX = (C.GridCounters.X < 0) ? -1 : 1;
+    const int32 SgnY = (C.GridCounters.Y < 0) ? -1 : 1;
+    const int32 SgnZ = (C.GridCounters.Z < 0) ? -1 : 1;
+
+    FSFPositionCalculator Calc;
+    AActor* HoloOwner = GetOwner();
+    int32 SpawnedChildren = 0;
+    int32 LinearIndex = 0;
+
+    for (int32 ZI = 0; ZI < NZ; ++ZI)
+    {
+        for (int32 YI = 0; YI < NY; ++YI)
+        {
+            for (int32 XI = 0; XI < NX; ++XI)
+            {
+                // (0,0,0) is the parent buildable itself (built by Super::Construct), not a child.
+                if (XI == 0 && YI == 0 && ZI == 0) continue;
+
+                const int32 GX = XI * SgnX;
+                const int32 GY = YI * SgnY;
+                const int32 GZ = ZI * SgnZ;
+
+                const FVector CellLoc = Calc.CalculateChildPosition(
+                    GX, GY, GZ, ParentLoc, ParentRot,
+                    mScalingSpec.ItemSize, C, LinearIndex, mScalingSpec.AnchorOffset);
+                ++LinearIndex;
+
+                const FName ChildName(*FString::Printf(TEXT("SFSpecCell_%d_%d_%d"), GX, GY, GZ));
+
+                AFGHologram* Child = AFGHologram::SpawnChildHologramFromRecipe(
+                    this, ChildName, mRecipe, HoloOwner, CellLoc,
+                    [ParentRot](AFGHologram* NewChild)
+                    {
+                        if (NewChild)
+                        {
+                            NewChild->SetActorRotation(ParentRot);
+                            NewChild->Tags.AddUnique(FName(TEXT("SF_GridChild")));
+                        }
+                    });
+
+                if (Child)
+                {
+                    ++SpawnedChildren;
+                }
+            }
+        }
+    }
+
+    UE_LOG(LogSmartFoundations, Display,
+        TEXT("[MP-SPEC] ExpandScalingSpecIntoChildren: regenerated %d/%d grid children server-side ")
+        TEXT("for %s (recipe=%s). Vanilla cost + Construct will now build the full grid."),
+        SpawnedChildren, mScalingSpec.CellCount() - 1, *GetName(),
+        mRecipe ? *mRecipe->GetName() : TEXT("null"));
 }
 
 void ASFFactoryHologram::BeginPlay()

--- a/Source/SmartFoundations/Private/Holograms/Core/SFFactoryHologram.cpp
+++ b/Source/SmartFoundations/Private/Holograms/Core/SFFactoryHologram.cpp
@@ -13,6 +13,7 @@
 #include "Holograms/Logistics/SFConveyorLiftHologram.h"
 #include "Holograms/Logistics/SFPipelineHologram.h"
 #include "Subsystem/SFPositionCalculator.h"
+#include "Data/SFBuildableSizeRegistry.h"
 #include "HAL/IConsoleManager.h"
 #include "Logging/SFLogMacros.h"
 
@@ -46,22 +47,41 @@ void ASFFactoryHologram::PreConstructMessageSerialization()
     // Guarded so legacy behaviour (and SP / listen-host, which construct directly without a message)
     // is completely unaffected.
     if (CVarSFMPSpecConstruction.GetValueOnAnyThread() == 0) return;
-    if (!mScalingSpec.bValid) return;
     if (mChildren.Num() == 0) return;
 
+    // Capture the grid into a compact spec from the authoritative counter state + size registry.
+    // (Self-contained on the hologram: the client knows its own grid via the subsystem.)
+    USFSubsystem* SS = USFSubsystem::Get(GetWorld());
+    if (!SS) return;
+
+    const FSFCounterState Counters = SS->GetCounterState();
+    const int32 NX = FMath::Max(1, FMath::Abs(Counters.GridCounters.X));
+    const int32 NY = FMath::Max(1, FMath::Abs(Counters.GridCounters.Y));
+    const int32 NZ = FMath::Max(1, FMath::Abs(Counters.GridCounters.Z));
+    if (NX * NY * NZ <= 1) return; // trivial grid: nothing to expand server-side
+
+    USFBuildableSizeRegistry::Initialize();
+    const FSFBuildableSizeProfile Profile = USFBuildableSizeRegistry::GetProfile(GetBuildClass());
+
+    mScalingSpec.Counters = Counters;
+    mScalingSpec.ItemSize = Profile.DefaultSize;
+    mScalingSpec.AnchorOffset = Profile.AnchorOffset;
+    mScalingSpec.bValid = true;
+
+    // Detach the grid children from the serialized child list so they are NOT sent. The preview
+    // actors still exist and are owned/cleaned up by the Smart grid-spawner's own tracking list,
+    // not by mChildren. The server regenerates them from mScalingSpec.
     mStashedSpecChildren.Reset();
     for (AFGHologram* Child : mChildren)
     {
         mStashedSpecChildren.Add(Child);
     }
-    // Detach from the serialized child list. The preview actors still exist and are owned/cleaned up
-    // by the Smart grid-spawner's own tracking list, not by mChildren.
     mChildren.Reset();
 
     UE_LOG(LogSmartFoundations, Display,
-        TEXT("[MP-SPEC] PreConstructMessageSerialization: stripped %d grid children from the wire; ")
-        TEXT("spec describes %d cells. Construct message is now O(1)."),
-        mStashedSpecChildren.Num(), mScalingSpec.CellCount());
+        TEXT("[MP-SPEC] PreConstructMessageSerialization: captured spec (%d cells), stripped %d grid ")
+        TEXT("children from the wire. Construct message is now O(1)."),
+        mScalingSpec.CellCount(), mStashedSpecChildren.Num());
 }
 
 void ASFFactoryHologram::PostConstructMessageDeserialization()

--- a/Source/SmartFoundations/Private/Holograms/Core/SFFactoryHologram.cpp
+++ b/Source/SmartFoundations/Private/Holograms/Core/SFFactoryHologram.cpp
@@ -78,18 +78,24 @@ void ASFFactoryHologram::SerializeConstructMessage(FArchive& ar, FNetConstructio
     }
 }
 
-void ASFFactoryHologram::PostConstructMessageDeserialization()
+TArray<FItemAmount> ASFFactoryHologram::GetCost(bool includeChildren) const
 {
-    Super::PostConstructMessageDeserialization();
+    TArray<FItemAmount> Cost = Super::GetCost(includeChildren);
 
-    // Server-side, after the spec has been read off the wire and before vanilla cost-aggregation +
-    // Construct run: regenerate the grid children from the compact spec. With the children present
-    // again, vanilla GetCost(includeChildren) charges the full grid and Super::Construct builds it.
-    if (!mScalingSpec.bValid) return;
-    if (!HasAuthority()) return;
-    if (mChildren.Num() > 0) return; // already populated (shouldn't happen on the spec path)
-
-    SFScalingSpecExpansion::ExpandScalingSpecIntoChildren(this, mScalingSpec, mRecipe);
+    // Spec path, server side: cost is validated/charged BEFORE Construct, but the grid children are
+    // expanded INSIDE Construct (after validation - fresh holograms cannot pass vanilla placement
+    // validation, live-test finding 2026-06-09). The grid is uniform, so the correct total is the
+    // parent's per-cell cost scaled by the cell count. Client side never scales: its children are
+    // real (mChildren populated), so vanilla aggregation already yields the full amount.
+    if (includeChildren && mScalingSpec.bValid && HasAuthority() && mChildren.Num() == 0)
+    {
+        const int32 Cells = mScalingSpec.CellCount();
+        for (FItemAmount& Item : Cost)
+        {
+            Item.Amount *= Cells;
+        }
+    }
+    return Cost;
 }
 
 void ASFFactoryHologram::BeginPlay()
@@ -123,6 +129,16 @@ void ASFFactoryHologram::BeginPlay()
 
 AActor* ASFFactoryHologram::Construct(TArray<AActor*>& out_children, FNetConstructionID constructionID)
 {
+    // [MP-SPEC] Server-side spec expansion. Runs HERE - after Server_ConstructHologram validation
+    // has passed on the (childless) parent - because fresh holograms cannot pass vanilla placement
+    // validation (FGCDInitializing/InvalidFloor/InvalidAimLocation; live-test finding 2026-06-09).
+    // Cost was already charged correctly via the GetCost cell-count scaling. The children added
+    // here are constructed by Super::Construct's normal child loop, never validated.
+    if (HasAuthority() && mScalingSpec.bValid && mChildren.Num() == 0)
+    {
+        SFScalingSpecExpansion::ExpandScalingSpecIntoChildren(this, mScalingSpec, mRecipe);
+    }
+
     // [MP-SLICE0] TEMP multiplayer instrumentation — remove before release.
     // Parent-commit signal: does the scaled-factory Construct run with authority for a
     // CLIENT-initiated build, and how many children does it carry into the build?

--- a/Source/SmartFoundations/Private/Holograms/Core/SFFactoryHologram.cpp
+++ b/Source/SmartFoundations/Private/Holograms/Core/SFFactoryHologram.cpp
@@ -50,8 +50,24 @@ void ASFFactoryHologram::BeginPlay()
 
 AActor* ASFFactoryHologram::Construct(TArray<AActor*>& out_children, FNetConstructionID constructionID)
 {
+    // [MP-SLICE0] TEMP multiplayer instrumentation — remove before release.
+    // Parent-commit signal: does the scaled-factory Construct run with authority for a
+    // CLIENT-initiated build, and how many children does it carry into the build?
+    // NetMode: 0=Standalone 1=DedicatedServer 2=ListenServer 3=Client.
+    {
+        const int32 NetMode = GetWorld() ? (int32)GetWorld()->GetNetMode() : -1;
+        UE_LOG(LogSmartFoundations, Display,
+            TEXT("[MP-SLICE0] FactoryHologram::Construct ENTER: %s NetMode=%d HasAuthority=%d mChildren=%d"),
+            *GetName(), NetMode, HasAuthority() ? 1 : 0, mChildren.Num());
+    }
+
     AActor* BuiltActor = Super::Construct(out_children, constructionID);
-    
+
+    // [MP-SLICE0] TEMP — out_children = built child actors produced server-side this Construct.
+    UE_LOG(LogSmartFoundations, Display,
+        TEXT("[MP-SLICE0] FactoryHologram::Construct EXIT: %s BuiltActor=%s out_children=%d mChildren=%d"),
+        *GetName(), BuiltActor ? *BuiltActor->GetName() : TEXT("null"), out_children.Num(), mChildren.Num());
+
     if (BuiltActor)
     {
         USFSubsystem* SmartSubsystem = USFSubsystem::Get(GetWorld());

--- a/Source/SmartFoundations/Private/Holograms/Core/SFFactoryHologram.cpp
+++ b/Source/SmartFoundations/Private/Holograms/Core/SFFactoryHologram.cpp
@@ -56,7 +56,7 @@ AActor* ASFFactoryHologram::Construct(TArray<AActor*>& out_children, FNetConstru
     // NetMode: 0=Standalone 1=DedicatedServer 2=ListenServer 3=Client.
     {
         const int32 NetMode = GetWorld() ? (int32)GetWorld()->GetNetMode() : -1;
-        UE_LOG(LogSmartFoundations, Display,
+        UE_LOG(LogSmartFoundations, Verbose,
             TEXT("[MP-SLICE0] FactoryHologram::Construct ENTER: %s NetMode=%d HasAuthority=%d mChildren=%d"),
             *GetName(), NetMode, HasAuthority() ? 1 : 0, mChildren.Num());
     }
@@ -64,7 +64,7 @@ AActor* ASFFactoryHologram::Construct(TArray<AActor*>& out_children, FNetConstru
     AActor* BuiltActor = Super::Construct(out_children, constructionID);
 
     // [MP-SLICE0] TEMP — out_children = built child actors produced server-side this Construct.
-    UE_LOG(LogSmartFoundations, Display,
+    UE_LOG(LogSmartFoundations, Verbose,
         TEXT("[MP-SLICE0] FactoryHologram::Construct EXIT: %s BuiltActor=%s out_children=%d mChildren=%d"),
         *GetName(), BuiltActor ? *BuiltActor->GetName() : TEXT("null"), out_children.Num(), mChildren.Num());
 

--- a/Source/SmartFoundations/Private/Holograms/Core/SFFactoryHologram.cpp
+++ b/Source/SmartFoundations/Private/Holograms/Core/SFFactoryHologram.cpp
@@ -54,6 +54,30 @@ void ASFFactoryHologram::PreConstructMessageSerialization()
         mScalingSpec.CellCount(), mStashedSpecChildren.Num());
 }
 
+void ASFFactoryHologram::SerializeConstructMessage(FArchive& ar, FNetConstructionID id)
+{
+    Super::SerializeConstructMessage(ar, id);
+
+    // Client/saving: the message bytes were just written from the STRIPPED child list. Restore the
+    // stash into mChildren immediately so the hologram is whole again - the build gun's post-fire
+    // teardown then destroys the preview children normally. Without this, the stripped previews
+    // leak as orphans and the grid-spawner tracking desyncs (live-test finding, 2026-06-09).
+    if (ar.IsSaving() && mStashedSpecChildren.Num() > 0)
+    {
+        for (const TObjectPtr<AFGHologram>& Child : mStashedSpecChildren)
+        {
+            if (Child)
+            {
+                mChildren.Add(Child);
+            }
+        }
+        UE_LOG(LogSmartFoundations, Display,
+            TEXT("[MP-SPEC] SerializeConstructMessage(factory): restored %d stripped children post-write."),
+            mStashedSpecChildren.Num());
+        mStashedSpecChildren.Reset();
+    }
+}
+
 void ASFFactoryHologram::PostConstructMessageDeserialization()
 {
     Super::PostConstructMessageDeserialization();

--- a/Source/SmartFoundations/Private/Holograms/Core/SFFoundationHologram.cpp
+++ b/Source/SmartFoundations/Private/Holograms/Core/SFFoundationHologram.cpp
@@ -1,111 +1,11 @@
 // Copyright (c) 2025-present Finalomega. All rights reserved. See LICENSE.md.
 
 #include "Holograms/Core/SFFoundationHologram.h"
-#include "Holograms/Core/SFScalingSpecExpansion.h"
-#include "SmartFoundations.h"
-#include "FGRecipe.h"
 #include "Logging/SFLogMacros.h"
 
 ASFFoundationHologram::ASFFoundationHologram()
 {
     // Initialize foundation-specific defaults
-}
-
-void ASFFoundationHologram::InitializeFromHologram(AFGHologram* SourceHologram)
-{
-    if (!SourceHologram)
-    {
-        UE_LOG(LogSmartFoundations, Error, TEXT("SFFoundationHologram::InitializeFromHologram: SourceHologram is null"));
-        return;
-    }
-
-    // Copy the build class + recipe from the source hologram (protected members; we inherit access).
-    mBuildClass = SourceHologram->GetBuildClass();
-    if (TSubclassOf<UFGRecipe> SourceRecipe = SourceHologram->GetRecipe())
-    {
-        mRecipe = SourceRecipe;
-    }
-
-    UE_LOG(LogSmartFoundations, Log, TEXT("SFFoundationHologram::InitializeFromHologram: Set mBuildClass=%s, mRecipe=%s"),
-        mBuildClass ? *mBuildClass->GetName() : TEXT("null"),
-        mRecipe ? *mRecipe->GetName() : TEXT("null"));
-}
-
-// ── Multiplayer spec-based construction (mirrors ASFFactoryHologram; shared logic in
-//    SFScalingSpecExpansion; see PLAN_MP_ScalingConstruction_Impl.md) ─────────────────────────────
-
-void ASFFoundationHologram::PreConstructMessageSerialization()
-{
-    Super::PreConstructMessageSerialization();
-
-    if (!SFScalingSpecExpansion::IsSpecConstructionEnabled()) return;
-    if (mChildren.Num() == 0) return;
-    if (!SFScalingSpecExpansion::CaptureScalingSpec(this, mScalingSpec)) return;
-
-    // Detach the grid children from the serialized child list so they are NOT sent. The preview
-    // actors still exist and are owned/cleaned up by the Smart grid-spawner's own tracking list,
-    // not by mChildren. The server regenerates them from mScalingSpec.
-    mStashedSpecChildren.Reset();
-    for (AFGHologram* Child : mChildren)
-    {
-        mStashedSpecChildren.Add(Child);
-    }
-    mChildren.Reset();
-
-    UE_LOG(LogSmartFoundations, Display,
-        TEXT("[MP-SPEC] PreConstructMessageSerialization(foundation): captured spec (%d cells), stripped ")
-        TEXT("%d grid children from the wire. Construct message is now O(1)."),
-        mScalingSpec.CellCount(), mStashedSpecChildren.Num());
-}
-
-void ASFFoundationHologram::SerializeConstructMessage(FArchive& ar, FNetConstructionID id)
-{
-    Super::SerializeConstructMessage(ar, id);
-
-    // Client/saving: restore the stripped children post-write so the post-fire teardown destroys
-    // the previews normally (see ASFFactoryHologram::SerializeConstructMessage).
-    if (ar.IsSaving() && mStashedSpecChildren.Num() > 0)
-    {
-        for (const TObjectPtr<AFGHologram>& Child : mStashedSpecChildren)
-        {
-            if (Child)
-            {
-                mChildren.Add(Child);
-            }
-        }
-        UE_LOG(LogSmartFoundations, Display,
-            TEXT("[MP-SPEC] SerializeConstructMessage(foundation): restored %d stripped children post-write."),
-            mStashedSpecChildren.Num());
-        mStashedSpecChildren.Reset();
-    }
-}
-
-TArray<FItemAmount> ASFFoundationHologram::GetCost(bool includeChildren) const
-{
-    TArray<FItemAmount> Cost = Super::GetCost(includeChildren);
-
-    // Spec path, server side: children are expanded inside Construct (after validation), so scale
-    // the uniform per-cell cost by the cell count (see ASFFactoryHologram::GetCost).
-    if (includeChildren && mScalingSpec.bValid && HasAuthority() && mChildren.Num() == 0)
-    {
-        const int32 Cells = mScalingSpec.CellCount();
-        for (FItemAmount& Item : Cost)
-        {
-            Item.Amount *= Cells;
-        }
-    }
-    return Cost;
-}
-
-AActor* ASFFoundationHologram::Construct(TArray<AActor*>& out_children, FNetConstructionID constructionID)
-{
-    // [MP-SPEC] Server-side spec expansion, post-validation (see ASFFactoryHologram::Construct).
-    if (HasAuthority() && mScalingSpec.bValid && mChildren.Num() == 0)
-    {
-        SFScalingSpecExpansion::ExpandScalingSpecIntoChildren(this, mScalingSpec, mRecipe);
-    }
-
-    return Super::Construct(out_children, constructionID);
 }
 
 void ASFFoundationHologram::BeginPlay()

--- a/Source/SmartFoundations/Private/Holograms/Core/SFFoundationHologram.cpp
+++ b/Source/SmartFoundations/Private/Holograms/Core/SFFoundationHologram.cpp
@@ -80,15 +80,32 @@ void ASFFoundationHologram::SerializeConstructMessage(FArchive& ar, FNetConstruc
     }
 }
 
-void ASFFoundationHologram::PostConstructMessageDeserialization()
+TArray<FItemAmount> ASFFoundationHologram::GetCost(bool includeChildren) const
 {
-    Super::PostConstructMessageDeserialization();
+    TArray<FItemAmount> Cost = Super::GetCost(includeChildren);
 
-    if (!mScalingSpec.bValid) return;
-    if (!HasAuthority()) return;
-    if (mChildren.Num() > 0) return; // already populated (shouldn't happen on the spec path)
+    // Spec path, server side: children are expanded inside Construct (after validation), so scale
+    // the uniform per-cell cost by the cell count (see ASFFactoryHologram::GetCost).
+    if (includeChildren && mScalingSpec.bValid && HasAuthority() && mChildren.Num() == 0)
+    {
+        const int32 Cells = mScalingSpec.CellCount();
+        for (FItemAmount& Item : Cost)
+        {
+            Item.Amount *= Cells;
+        }
+    }
+    return Cost;
+}
 
-    SFScalingSpecExpansion::ExpandScalingSpecIntoChildren(this, mScalingSpec, mRecipe);
+AActor* ASFFoundationHologram::Construct(TArray<AActor*>& out_children, FNetConstructionID constructionID)
+{
+    // [MP-SPEC] Server-side spec expansion, post-validation (see ASFFactoryHologram::Construct).
+    if (HasAuthority() && mScalingSpec.bValid && mChildren.Num() == 0)
+    {
+        SFScalingSpecExpansion::ExpandScalingSpecIntoChildren(this, mScalingSpec, mRecipe);
+    }
+
+    return Super::Construct(out_children, constructionID);
 }
 
 void ASFFoundationHologram::BeginPlay()

--- a/Source/SmartFoundations/Private/Holograms/Core/SFFoundationHologram.cpp
+++ b/Source/SmartFoundations/Private/Holograms/Core/SFFoundationHologram.cpp
@@ -1,11 +1,72 @@
 // Copyright (c) 2025-present Finalomega. All rights reserved. See LICENSE.md.
 
 #include "Holograms/Core/SFFoundationHologram.h"
+#include "Holograms/Core/SFScalingSpecExpansion.h"
+#include "SmartFoundations.h"
+#include "FGRecipe.h"
 #include "Logging/SFLogMacros.h"
 
 ASFFoundationHologram::ASFFoundationHologram()
 {
     // Initialize foundation-specific defaults
+}
+
+void ASFFoundationHologram::InitializeFromHologram(AFGHologram* SourceHologram)
+{
+    if (!SourceHologram)
+    {
+        UE_LOG(LogSmartFoundations, Error, TEXT("SFFoundationHologram::InitializeFromHologram: SourceHologram is null"));
+        return;
+    }
+
+    // Copy the build class + recipe from the source hologram (protected members; we inherit access).
+    mBuildClass = SourceHologram->GetBuildClass();
+    if (TSubclassOf<UFGRecipe> SourceRecipe = SourceHologram->GetRecipe())
+    {
+        mRecipe = SourceRecipe;
+    }
+
+    UE_LOG(LogSmartFoundations, Log, TEXT("SFFoundationHologram::InitializeFromHologram: Set mBuildClass=%s, mRecipe=%s"),
+        mBuildClass ? *mBuildClass->GetName() : TEXT("null"),
+        mRecipe ? *mRecipe->GetName() : TEXT("null"));
+}
+
+// ── Multiplayer spec-based construction (mirrors ASFFactoryHologram; shared logic in
+//    SFScalingSpecExpansion; see PLAN_MP_ScalingConstruction_Impl.md) ─────────────────────────────
+
+void ASFFoundationHologram::PreConstructMessageSerialization()
+{
+    Super::PreConstructMessageSerialization();
+
+    if (!SFScalingSpecExpansion::IsSpecConstructionEnabled()) return;
+    if (mChildren.Num() == 0) return;
+    if (!SFScalingSpecExpansion::CaptureScalingSpec(this, mScalingSpec)) return;
+
+    // Detach the grid children from the serialized child list so they are NOT sent. The preview
+    // actors still exist and are owned/cleaned up by the Smart grid-spawner's own tracking list,
+    // not by mChildren. The server regenerates them from mScalingSpec.
+    mStashedSpecChildren.Reset();
+    for (AFGHologram* Child : mChildren)
+    {
+        mStashedSpecChildren.Add(Child);
+    }
+    mChildren.Reset();
+
+    UE_LOG(LogSmartFoundations, Display,
+        TEXT("[MP-SPEC] PreConstructMessageSerialization(foundation): captured spec (%d cells), stripped ")
+        TEXT("%d grid children from the wire. Construct message is now O(1)."),
+        mScalingSpec.CellCount(), mStashedSpecChildren.Num());
+}
+
+void ASFFoundationHologram::PostConstructMessageDeserialization()
+{
+    Super::PostConstructMessageDeserialization();
+
+    if (!mScalingSpec.bValid) return;
+    if (!HasAuthority()) return;
+    if (mChildren.Num() > 0) return; // already populated (shouldn't happen on the spec path)
+
+    SFScalingSpecExpansion::ExpandScalingSpecIntoChildren(this, mScalingSpec, mRecipe);
 }
 
 void ASFFoundationHologram::BeginPlay()

--- a/Source/SmartFoundations/Private/Holograms/Core/SFFoundationHologram.cpp
+++ b/Source/SmartFoundations/Private/Holograms/Core/SFFoundationHologram.cpp
@@ -58,6 +58,28 @@ void ASFFoundationHologram::PreConstructMessageSerialization()
         mScalingSpec.CellCount(), mStashedSpecChildren.Num());
 }
 
+void ASFFoundationHologram::SerializeConstructMessage(FArchive& ar, FNetConstructionID id)
+{
+    Super::SerializeConstructMessage(ar, id);
+
+    // Client/saving: restore the stripped children post-write so the post-fire teardown destroys
+    // the previews normally (see ASFFactoryHologram::SerializeConstructMessage).
+    if (ar.IsSaving() && mStashedSpecChildren.Num() > 0)
+    {
+        for (const TObjectPtr<AFGHologram>& Child : mStashedSpecChildren)
+        {
+            if (Child)
+            {
+                mChildren.Add(Child);
+            }
+        }
+        UE_LOG(LogSmartFoundations, Display,
+            TEXT("[MP-SPEC] SerializeConstructMessage(foundation): restored %d stripped children post-write."),
+            mStashedSpecChildren.Num());
+        mStashedSpecChildren.Reset();
+    }
+}
+
 void ASFFoundationHologram::PostConstructMessageDeserialization()
 {
     Super::PostConstructMessageDeserialization();

--- a/Source/SmartFoundations/Private/Holograms/Core/SFScalingSpecExpansion.cpp
+++ b/Source/SmartFoundations/Private/Holograms/Core/SFScalingSpecExpansion.cpp
@@ -13,6 +13,8 @@
 #include "Holograms/Power/SFWireHologram.h"
 #include "FGPowerConnectionComponent.h"
 #include "Buildables/FGBuildable.h"
+#include "Buildables/FGBuildableWire.h"
+#include "FGBlueprintProxy.h"
 #include "Engine/World.h"
 #include "EngineUtils.h"
 #include "HAL/IConsoleManager.h"
@@ -204,22 +206,36 @@ void CaptureConduitPlan(AFGHologram* Hologram, FSFScalingSpec& InOutSpec)
 		return;
 	}
 
-	// All Smart auto-connect previews - distributor belts (incl. manifold lanes of grid-child
-	// distributors), junction/floor-hole pipes, stackable-run belts/pipes, and power wires - are
-	// attached as TAGGED CHILDREN of the active parent hologram (proven: the fire-hook strip of
-	// parent mChildren removes every one of them). One uniform walk captures every family.
+	// All Smart auto-connect previews are TAGGED holograms somewhere in the parent's DESCENDANT
+	// tree: distributor belts attach to the top parent, but grid-child junctions/poles attach
+	// their pipe/wire previews to THEMSELVES (live finding 2026-06-10: a 5-cell junction grid
+	// captured only the parent's 1 pipe with a direct-children-only walk). Walk recursively.
 	static const FName BeltTag(TEXT("SF_BeltAutoConnectChild"));
 	static const FName PipeTag(TEXT("SF_PipeAutoConnectChild"));
 	static const FName PowerTag(TEXT("SF_PowerAutoConnectChild"));
 	static const FName StackableTag(TEXT("SF_StackableChild"));
 
-	int32 PerKind[5] = {0, 0, 0, 0, 0};
-	for (AFGHologram* Child : Hologram->GetHologramChildren())
+	TArray<AFGHologram*> Descendants;
 	{
-		if (!Child)
+		TArray<AFGHologram*> Stack;
+		Stack.Add(Hologram);
+		while (Stack.Num() > 0)
 		{
-			continue;
+			AFGHologram* Current = Stack.Pop();
+			for (AFGHologram* Child : Current->GetHologramChildren())
+			{
+				if (Child)
+				{
+					Descendants.Add(Child);
+					Stack.Add(Child);
+				}
+			}
 		}
+	}
+
+	int32 PerKind[5] = {0, 0, 0, 0, 0};
+	for (AFGHologram* Child : Descendants)
+	{
 
 		FSFConduitPlanEntry Entry;
 		if (ASFConveyorBeltHologram* BeltHolo = Cast<ASFConveyorBeltHologram>(Child))
@@ -321,14 +337,14 @@ void CaptureConduitPlan(AFGHologram* Hologram, FSFScalingSpec& InOutSpec)
 	}
 }
 
-// Resolve the power connection component nearest to a captured wire-endpoint location, searching
-// the PRE-CONSTRUCT hologram set first (parent + grid children - vanilla remaps hologram
-// connections to the built poles during construct, the SP mechanism), then already-built world
-// actors (a wire endpoint may target an existing pole/machine outside the grid).
-static UFGPowerConnectionComponent* SF_ResolvePowerConnectionAt(
-	AFGHologram* Parent, const FVector& Location, float Tolerance)
+// Resolve the circuit connection component nearest to a captured wire-endpoint location among
+// the BUILT actors of this construct (parent + out_children), falling back to the world (a wire
+// endpoint may target an existing pole/machine outside the grid).
+static UFGCircuitConnectionComponent* SF_ResolveCircuitConnectionAt(
+	UWorld* World, AActor* BuiltParent, const TArray<AActor*>& OutChildren,
+	const FVector& Location, float Tolerance)
 {
-	UFGPowerConnectionComponent* Best = nullptr;
+	UFGCircuitConnectionComponent* Best = nullptr;
 	float BestDistSq = FMath::Square(Tolerance);
 
 	auto Consider = [&](AActor* Actor)
@@ -337,9 +353,9 @@ static UFGPowerConnectionComponent* SF_ResolvePowerConnectionAt(
 		{
 			return;
 		}
-		TArray<UFGPowerConnectionComponent*> Connections;
-		Actor->GetComponents<UFGPowerConnectionComponent>(Connections);
-		for (UFGPowerConnectionComponent* Conn : Connections)
+		TArray<UFGCircuitConnectionComponent*> Connections;
+		Actor->GetComponents<UFGCircuitConnectionComponent>(Connections);
+		for (UFGCircuitConnectionComponent* Conn : Connections)
 		{
 			if (!Conn)
 			{
@@ -354,14 +370,14 @@ static UFGPowerConnectionComponent* SF_ResolvePowerConnectionAt(
 		}
 	};
 
-	Consider(Parent);
-	for (AFGHologram* Child : Parent->GetHologramChildren())
+	Consider(BuiltParent);
+	for (AActor* Child : OutChildren)
 	{
 		Consider(Child);
 	}
-	if (!Best)
+	if (!Best && World)
 	{
-		for (TActorIterator<AFGBuildable> It(Parent->GetWorld()); It; ++It)
+		for (TActorIterator<AFGBuildable> It(World); It; ++It)
 		{
 			Consider(*It);
 		}
@@ -481,22 +497,6 @@ int32 SpawnConduitPlanChildren(AFGHologram* Parent, const FSFScalingSpec& Spec)
 				if (Data)
 				{
 					Data->bIsPipeAutoConnectChild = true;
-					// PipeAutoConnectConn0 is ONLY a branch discriminator at the construct seam:
-					// null = floor-hole branch (passthrough snap registration by proximity),
-					// non-null = junction branch (deferred geometric wiring). The component is
-					// never dereferenced there, so any non-null connection works server-side.
-					if (!Entry.bFloorHolePipe)
-					{
-						TArray<UFGPipeConnectionComponentBase*> PipeConns;
-						Pipe->GetComponents<UFGPipeConnectionComponentBase>(PipeConns);
-						Data->PipeAutoConnectConn0 = PipeConns.Num() > 0 ? PipeConns[0] : nullptr;
-						if (PipeConns.Num() == 0)
-						{
-							UE_LOG(LogSmartFoundations, Warning,
-								TEXT("[MP-334] SpawnConduitPlanChildren: pipe entry %d has no connection component for the junction-branch discriminator; it will take the floor-hole branch."),
-								EntryIndex);
-						}
-					}
 				}
 			}
 			else
@@ -511,6 +511,24 @@ int32 SpawnConduitPlanChildren(AFGHologram* Parent, const FSFScalingSpec& Spec)
 
 			Pipe->FinishSpawning(FTransform(Entry.Rotation, Entry.Location));
 			Pipe->SetActorEnableCollision(false);
+
+			// PipeAutoConnectConn0 is ONLY a branch discriminator at the construct seam: null =
+			// floor-hole branch (passthrough snap registration by proximity), non-null = junction
+			// branch (deferred geometric wiring). The component is never dereferenced there, so
+			// any non-null connection works server-side. MUST be resolved AFTER FinishSpawning -
+			// the deferred-spawned hologram has no components before it (live finding 2026-06-10).
+			if (Entry.Kind == ESFConduitPlanKind::Pipe && Data && !Entry.bFloorHolePipe)
+			{
+				TArray<UFGPipeConnectionComponentBase*> PipeConns;
+				Pipe->GetComponents<UFGPipeConnectionComponentBase>(PipeConns);
+				Data->PipeAutoConnectConn0 = PipeConns.Num() > 0 ? PipeConns[0] : nullptr;
+				if (PipeConns.Num() == 0)
+				{
+					UE_LOG(LogSmartFoundations, Warning,
+						TEXT("[MP-334] SpawnConduitPlanChildren: pipe entry %d has no connection component for the junction-branch discriminator; it will take the floor-hole branch."),
+						EntryIndex);
+				}
+			}
 			Pipe->SetSplineDataAndUpdate(Entry.SplinePoints);
 			Parent->AddChild(Pipe, Pipe->GetFName());
 			Pipe->SetSplineDataAndUpdate(Entry.SplinePoints);
@@ -519,37 +537,11 @@ int32 SpawnConduitPlanChildren(AFGHologram* Parent, const FSFScalingSpec& Spec)
 		}
 
 		case ESFConduitPlanKind::Wire:
-		{
-			UFGPowerConnectionComponent* C0 = SF_ResolvePowerConnectionAt(Parent, Entry.WireStart, 100.0f);
-			UFGPowerConnectionComponent* C1 = SF_ResolvePowerConnectionAt(Parent, Entry.WireEnd, 100.0f);
-			if (!C0 || !C1 || C0 == C1)
-			{
-				UE_LOG(LogSmartFoundations, Warning,
-					TEXT("[MP-334] SpawnConduitPlanChildren: wire entry %d endpoints unresolved (C0=%s, C1=%s) - skipped."),
-					EntryIndex, *GetNameSafe(C0), *GetNameSafe(C1));
-				break;
-			}
-
-			ASFWireHologram* Wire = World->SpawnActor<ASFWireHologram>(
-				ASFWireHologram::StaticClass(), Entry.WireStart, FRotator::ZeroRotator, SpawnParams);
-			if (!Wire)
-			{
-				break;
-			}
-			Wire->SetReplicates(false);
-			Wire->SetReplicateMovement(false);
-			Wire->SetBuildClass(Entry.BuildClass);
-			Wire->SetRecipe(Entry.Recipe);
-			Wire->Tags.AddUnique(FName(TEXT("SF_PowerAutoConnectChild")));
-			USFHologramDataService::DisableValidation(Wire);
-			Wire->FinishSpawning(FTransform(FRotator::ZeroRotator, Entry.WireStart));
-			// Sets mConnections[0/1]; vanilla AFGWireHologram::Construct builds the AFGBuildableWire
-			// between them, remapping hologram-owned connections to the built poles (SP mechanism).
-			Wire->SetupWirePreview(C0, C1);
-			Parent->AddChild(Wire, Wire->GetFName());
-			Conduit = Wire;
-			break;
-		}
+			// Wires are NOT built from holograms - even in SP the wire child holograms exist only
+			// for cost, and the persistent wire is direct-spawned post-build (unconnected wires
+			// self-destruct; live finding 2026-06-10: hologram-replayed wires built as unconnected
+			// zombies). Handled by SpawnWirePlanPostConstruct AFTER the grid constructs.
+			continue;
 
 		default:
 			break;
@@ -567,11 +559,121 @@ int32 SpawnConduitPlanChildren(AFGHologram* Parent, const FSFScalingSpec& Spec)
 		}
 	}
 
+	int32 WireEntries = 0;
+	for (const FSFConduitPlanEntry& Entry : Spec.ConduitPlan)
+	{
+		if (Entry.Kind == ESFConduitPlanKind::Wire)
+		{
+			++WireEntries;
+		}
+	}
 	UE_LOG(LogSmartFoundations, Display,
-		TEXT("[MP-334] SpawnConduitPlanChildren: %d/%d staged conduit(s) attached to %s; vanilla construct will build + wire them."),
-		Spawned, Spec.ConduitPlan.Num(), *Parent->GetName());
+		TEXT("[MP-334] SpawnConduitPlanChildren: %d/%d staged conduit(s) attached to %s (%d wire(s) deferred to post-construct); vanilla construct will build + wire them."),
+		Spawned, Spec.ConduitPlan.Num() - WireEntries, *Parent->GetName(), WireEntries);
 
 	return Spawned;
+}
+
+int32 SpawnWirePlanPostConstruct(AActor* BuiltParent, const TArray<AActor*>& OutChildren,
+	const FSFScalingSpec& Spec, AFGBlueprintProxy* GroupProxy)
+{
+	UWorld* World = BuiltParent ? BuiltParent->GetWorld() : nullptr;
+	if (!World)
+	{
+		return 0;
+	}
+
+	int32 Built = 0;
+	int32 WireEntries = 0;
+	int32 EntryIndex = 0;
+	for (const FSFConduitPlanEntry& Entry : Spec.ConduitPlan)
+	{
+		++EntryIndex;
+		if (Entry.Kind != ESFConduitPlanKind::Wire)
+		{
+			continue;
+		}
+		++WireEntries;
+
+		if (!Entry.BuildClass || !Entry.BuildClass->IsChildOf(AFGBuildableWire::StaticClass()))
+		{
+			UE_LOG(LogSmartFoundations, Warning,
+				TEXT("[MP-334] SpawnWirePlanPostConstruct: wire entry %d has invalid wire class %s - skipped."),
+				EntryIndex, *GetNameSafe(*Entry.BuildClass));
+			continue;
+		}
+
+		UFGCircuitConnectionComponent* C0 = SF_ResolveCircuitConnectionAt(
+			World, BuiltParent, OutChildren, Entry.WireStart, 100.0f);
+		UFGCircuitConnectionComponent* C1 = SF_ResolveCircuitConnectionAt(
+			World, BuiltParent, OutChildren, Entry.WireEnd, 100.0f);
+		if (!C0 || !C1 || C0 == C1)
+		{
+			UE_LOG(LogSmartFoundations, Warning,
+				TEXT("[MP-334] SpawnWirePlanPostConstruct: wire entry %d endpoints unresolved (C0=%s, C1=%s) - skipped."),
+				EntryIndex, *GetNameSafe(C0), *GetNameSafe(C1));
+			continue;
+		}
+
+		// Dedupe: the power manager's OnPowerPoleBuilt also runs server-side during this construct
+		// and may already have wired this pair (e.g. pole-to-existing-factory connections).
+		bool bAlreadyConnected = false;
+		TArray<AFGBuildableWire*> ExistingWires;
+		C0->GetWires(ExistingWires);
+		for (AFGBuildableWire* Wire : ExistingWires)
+		{
+			if (Wire && (Wire->GetConnection(0) == C1 || Wire->GetConnection(1) == C1))
+			{
+				bAlreadyConnected = true;
+				break;
+			}
+		}
+		if (bAlreadyConnected)
+		{
+			continue;
+		}
+
+		// The proven OnPowerPoleBuilt primitive: direct-spawn the wire and Connect the two built
+		// connection components. Unconnected wires self-destruct, so Connect failure -> Destroy.
+		FActorSpawnParameters SpawnParams;
+		SpawnParams.SpawnCollisionHandlingOverride = ESpawnActorCollisionHandlingMethod::AlwaysSpawn;
+		AFGBuildableWire* NewWire = World->SpawnActor<AFGBuildableWire>(
+			*Entry.BuildClass, Entry.WireStart, FRotator::ZeroRotator, SpawnParams);
+		if (!NewWire)
+		{
+			UE_LOG(LogSmartFoundations, Warning,
+				TEXT("[MP-334] SpawnWirePlanPostConstruct: wire entry %d failed to spawn."), EntryIndex);
+			continue;
+		}
+		if (!NewWire->Connect(C0, C1))
+		{
+			UE_LOG(LogSmartFoundations, Warning,
+				TEXT("[MP-334] SpawnWirePlanPostConstruct: wire entry %d Connect() failed (%s <-> %s) - destroyed."),
+				EntryIndex, *GetNameSafe(C0->GetOwner()), *GetNameSafe(C1->GetOwner()));
+			NewWire->Destroy();
+			continue;
+		}
+
+		// Wires built here are not in out_children, so the module's proxy sweep misses them -
+		// register into the Smart Dismantle group directly (wires are real actors, never
+		// lightweight, so post-construct registration is safe).
+		if (GroupProxy && !NewWire->GetBlueprintProxy())
+		{
+			NewWire->SetBlueprintProxy(GroupProxy);
+			GroupProxy->RegisterBuildable(NewWire);
+		}
+
+		++Built;
+	}
+
+	if (WireEntries > 0)
+	{
+		UE_LOG(LogSmartFoundations, Display,
+			TEXT("[MP-334] SpawnWirePlanPostConstruct: built %d/%d staged wire(s) for %s."),
+			Built, WireEntries, *GetNameSafe(BuiltParent));
+	}
+
+	return Built;
 }
 
 } // namespace SFScalingSpecExpansion

--- a/Source/SmartFoundations/Private/Holograms/Core/SFScalingSpecExpansion.cpp
+++ b/Source/SmartFoundations/Private/Holograms/Core/SFScalingSpecExpansion.cpp
@@ -9,7 +9,12 @@
 #include "Data/SFBuildableSizeRegistry.h"
 #include "Features/AutoConnect/SFAutoConnectService.h"
 #include "Holograms/Logistics/SFConveyorBeltHologram.h"
+#include "Holograms/Logistics/SFPipelineHologram.h"
+#include "Holograms/Power/SFWireHologram.h"
+#include "FGPowerConnectionComponent.h"
+#include "Buildables/FGBuildable.h"
 #include "Engine/World.h"
+#include "EngineUtils.h"
 #include "HAL/IConsoleManager.h"
 
 // MP spec-based construction. ON by default - the mod must be self-contained (no launch options /
@@ -170,155 +175,401 @@ int32 ExpandScalingSpecIntoChildren(AFGHologram* Parent, const FSFScalingSpec& S
 	return SpawnedChildren;
 }
 
-void CaptureBeltPlan(AFGHologram* Hologram, FSFScalingSpec& InOutSpec)
+// Merge one preview's cost items into the plan's aggregated cost (per item class).
+static void SF_MergePlanCost(FSFScalingSpec& Spec, const TArray<FItemAmount>& Items)
+{
+	for (const FItemAmount& Item : Items)
+	{
+		bool bMerged = false;
+		for (FItemAmount& Existing : Spec.ConduitPlanCost)
+		{
+			if (Existing.ItemClass == Item.ItemClass)
+			{
+				Existing.Amount += Item.Amount;
+				bMerged = true;
+				break;
+			}
+		}
+		if (!bMerged)
+		{
+			Spec.ConduitPlanCost.Add(Item);
+		}
+	}
+}
+
+void CaptureConduitPlan(AFGHologram* Hologram, FSFScalingSpec& InOutSpec)
 {
 	if (!Hologram)
 	{
 		return;
 	}
-	USFSubsystem* SS = USFSubsystem::Get(Hologram->GetWorld());
-	USFAutoConnectService* AutoConnect = SS ? SS->GetAutoConnectService() : nullptr;
-	if (!AutoConnect)
-	{
-		return;
-	}
 
-	// The service stores previews keyed per distributor hologram: the parent itself and/or any of
-	// its grid children (manifold lanes are stored on their SOURCE distributor, so walking each
-	// distributor once visits every belt exactly once).
-	TArray<AFGHologram*> Sources;
-	Sources.Add(Hologram);
+	// All Smart auto-connect previews - distributor belts (incl. manifold lanes of grid-child
+	// distributors), junction/floor-hole pipes, stackable-run belts/pipes, and power wires - are
+	// attached as TAGGED CHILDREN of the active parent hologram (proven: the fire-hook strip of
+	// parent mChildren removes every one of them). One uniform walk captures every family.
+	static const FName BeltTag(TEXT("SF_BeltAutoConnectChild"));
+	static const FName PipeTag(TEXT("SF_PipeAutoConnectChild"));
+	static const FName PowerTag(TEXT("SF_PowerAutoConnectChild"));
+	static const FName StackableTag(TEXT("SF_StackableChild"));
+
+	int32 PerKind[5] = {0, 0, 0, 0, 0};
 	for (AFGHologram* Child : Hologram->GetHologramChildren())
 	{
-		if (Child)
-		{
-			Sources.Add(Child);
-		}
-	}
-
-	for (AFGHologram* Source : Sources)
-	{
-		const TArray<TSharedPtr<FBeltPreviewHelper>>* Previews = AutoConnect->GetBeltPreviews(Source);
-		if (!Previews)
+		if (!Child)
 		{
 			continue;
 		}
-		for (const TSharedPtr<FBeltPreviewHelper>& Helper : *Previews)
+
+		FSFConduitPlanEntry Entry;
+		if (ASFConveyorBeltHologram* BeltHolo = Cast<ASFConveyorBeltHologram>(Child))
 		{
-			if (!Helper.IsValid())
+			if (Child->Tags.Contains(BeltTag))
+			{
+				Entry.Kind = ESFConduitPlanKind::Belt;
+			}
+			else if (Child->Tags.Contains(StackableTag))
+			{
+				Entry.Kind = ESFConduitPlanKind::StackableBelt;
+			}
+			else
 			{
 				continue;
 			}
-			ASFConveyorBeltHologram* BeltHolo = Helper->GetTypedHologram();
-			if (!IsValid(BeltHolo) || BeltHolo->GetSplineData().Num() < 2)
+			if (BeltHolo->GetSplineData().Num() < 2)
 			{
 				continue;
 			}
-
-			FSFBeltPlanEntry Entry;
-			Entry.BeltClass = BeltHolo->GetBuildClass();
-			Entry.Recipe = BeltHolo->GetRecipe();
-			Entry.Location = BeltHolo->GetActorLocation();
-			Entry.Rotation = BeltHolo->GetActorRotation();
 			Entry.SplinePoints = BeltHolo->GetSplineData();
-			InOutSpec.BeltPlan.Add(MoveTemp(Entry));
-
-			// Exact vanilla length-based cost of this preview, merged per item class. Charged by
-			// the server's GetCost hook alongside the cell-scaled grid cost.
-			for (const FItemAmount& Item : BeltHolo->GetCost(false))
+		}
+		else if (ASFPipelineHologram* PipeHolo = Cast<ASFPipelineHologram>(Child))
+		{
+			if (Child->Tags.Contains(PipeTag))
 			{
-				bool bMerged = false;
-				for (FItemAmount& Existing : InOutSpec.BeltPlanCost)
-				{
-					if (Existing.ItemClass == Item.ItemClass)
-					{
-						Existing.Amount += Item.Amount;
-						bMerged = true;
-						break;
-					}
-				}
-				if (!bMerged)
-				{
-					InOutSpec.BeltPlanCost.Add(Item);
-				}
+				Entry.Kind = ESFConduitPlanKind::Pipe;
+			}
+			else if (Child->Tags.Contains(StackableTag))
+			{
+				Entry.Kind = ESFConduitPlanKind::StackablePipe;
+			}
+			else
+			{
+				continue;
+			}
+			if (PipeHolo->GetSplineData().Num() < 2)
+			{
+				continue;
+			}
+			Entry.SplinePoints = PipeHolo->GetSplineData();
+		}
+		else if (ASFWireHologram* WireHolo = Cast<ASFWireHologram>(Child))
+		{
+			if (!Child->Tags.Contains(PowerTag))
+			{
+				continue;
+			}
+			UFGCircuitConnectionComponent* C0 = WireHolo->GetConnection(0);
+			UFGCircuitConnectionComponent* C1 = WireHolo->GetConnection(1);
+			if (!C0 || !C1)
+			{
+				continue;
+			}
+			Entry.Kind = ESFConduitPlanKind::Wire;
+			Entry.WireStart = C0->GetComponentLocation();
+			Entry.WireEnd = C1->GetComponentLocation();
+		}
+		else
+		{
+			continue;
+		}
+
+		// Family-specific registry facts that must survive the wire (the registry is client-local).
+		if (FSFHologramData* Data = USFHologramDataRegistry::GetData(Child))
+		{
+			if (Entry.Kind == ESFConduitPlanKind::Pipe)
+			{
+				Entry.bFloorHolePipe = (Data->PipeAutoConnectConn0 == nullptr);
+			}
+			else if (Entry.Kind == ESFConduitPlanKind::StackableBelt)
+			{
+				Entry.StackIndex = Data->StackableBeltIndex;
+			}
+			else if (Entry.Kind == ESFConduitPlanKind::StackablePipe)
+			{
+				Entry.StackIndex = Data->StackablePipeIndex;
 			}
 		}
+
+		Entry.BuildClass = Child->GetBuildClass();
+		Entry.Recipe = Child->GetRecipe();
+		Entry.Location = Child->GetActorLocation();
+		Entry.Rotation = Child->GetActorRotation();
+
+		// Exact vanilla preview cost, merged per item class. Charged by the server's GetCost hook
+		// alongside the cell-scaled grid cost.
+		SF_MergePlanCost(InOutSpec, Child->GetCost(false));
+
+		++PerKind[(int32)Entry.Kind];
+		InOutSpec.ConduitPlan.Add(MoveTemp(Entry));
 	}
 
-	if (InOutSpec.BeltPlan.Num() > 0)
+	if (InOutSpec.ConduitPlan.Num() > 0)
 	{
 		UE_LOG(LogSmartFoundations, Display,
-			TEXT("[MP-334] Client fire: captured belt plan with %d belt(s) (%d cost item type(s)) from live previews."),
-			InOutSpec.BeltPlan.Num(), InOutSpec.BeltPlanCost.Num());
+			TEXT("[MP-334] Client fire: captured conduit plan - %d belt(s), %d pipe(s), %d stackable belt(s), %d stackable pipe(s), %d wire(s) (%d cost item type(s))."),
+			PerKind[0], PerKind[1], PerKind[2], PerKind[3], PerKind[4], InOutSpec.ConduitPlanCost.Num());
 	}
 }
 
-int32 SpawnBeltPlanChildren(AFGHologram* Parent, const FSFScalingSpec& Spec)
+// Resolve the power connection component nearest to a captured wire-endpoint location, searching
+// the PRE-CONSTRUCT hologram set first (parent + grid children - vanilla remaps hologram
+// connections to the built poles during construct, the SP mechanism), then already-built world
+// actors (a wire endpoint may target an existing pole/machine outside the grid).
+static UFGPowerConnectionComponent* SF_ResolvePowerConnectionAt(
+	AFGHologram* Parent, const FVector& Location, float Tolerance)
+{
+	UFGPowerConnectionComponent* Best = nullptr;
+	float BestDistSq = FMath::Square(Tolerance);
+
+	auto Consider = [&](AActor* Actor)
+	{
+		if (!Actor)
+		{
+			return;
+		}
+		TArray<UFGPowerConnectionComponent*> Connections;
+		Actor->GetComponents<UFGPowerConnectionComponent>(Connections);
+		for (UFGPowerConnectionComponent* Conn : Connections)
+		{
+			if (!Conn)
+			{
+				continue;
+			}
+			const float DistSq = FVector::DistSquared(Conn->GetComponentLocation(), Location);
+			if (DistSq < BestDistSq)
+			{
+				BestDistSq = DistSq;
+				Best = Conn;
+			}
+		}
+	};
+
+	Consider(Parent);
+	for (AFGHologram* Child : Parent->GetHologramChildren())
+	{
+		Consider(Child);
+	}
+	if (!Best)
+	{
+		for (TActorIterator<AFGBuildable> It(Parent->GetWorld()); It; ++It)
+		{
+			Consider(*It);
+		}
+	}
+	return Best;
+}
+
+int32 SpawnConduitPlanChildren(AFGHologram* Parent, const FSFScalingSpec& Spec)
 {
 	UWorld* World = Parent ? Parent->GetWorld() : nullptr;
-	if (!World || Spec.BeltPlan.Num() == 0)
+	if (!World || Spec.ConduitPlan.Num() == 0)
 	{
 		return 0;
 	}
 
+	// One synthetic stack-chain id per construct: the stack-chain Construct path only gates on
+	// id/index >= 0 (wiring is geometric coincidence, not index pairing), but use a high offset
+	// away from client/Extend id ranges anyway.
+	static int32 GSFMPStackChainSeq = 1500000000;
+	const int32 StackChainId = GSFMPStackChainSeq++;
+
 	int32 Spawned = 0;
-	int32 BeltIndex = 0;
-	for (const FSFBeltPlanEntry& Entry : Spec.BeltPlan)
+	int32 EntryIndex = 0;
+	for (const FSFConduitPlanEntry& Entry : Spec.ConduitPlan)
 	{
-		++BeltIndex;
-		if (!Entry.BeltClass || Entry.SplinePoints.Num() < 2)
+		++EntryIndex;
+		const bool bIsWire = (Entry.Kind == ESFConduitPlanKind::Wire);
+		if (!Entry.BuildClass || (!bIsWire && Entry.SplinePoints.Num() < 2))
 		{
 			UE_LOG(LogSmartFoundations, Warning,
-				TEXT("[MP-334] SpawnBeltPlanChildren: plan entry %d invalid (class=%s, points=%d) - skipped."),
-				BeltIndex, *GetNameSafe(*Entry.BeltClass), Entry.SplinePoints.Num());
+				TEXT("[MP-334] SpawnConduitPlanChildren: entry %d invalid (kind=%d, class=%s, points=%d) - skipped."),
+				EntryIndex, (int32)Entry.Kind, *GetNameSafe(*Entry.BuildClass), Entry.SplinePoints.Num());
 			continue;
 		}
 
-		// Mirror the proven Extend clone-spawner recipe (SFExtendCloneSpawner belt_segment path),
-		// minus the client-only visual finalization (the server doesn't render previews).
+		// Mirror the proven client spawn recipes (belt/pipe/stackable spawners + the Extend clone
+		// spawner), minus the client-only visual finalization (the server doesn't render previews).
 		FActorSpawnParameters SpawnParams;
 		SpawnParams.Owner = Parent->GetOwner();
 		SpawnParams.SpawnCollisionHandlingOverride = ESpawnActorCollisionHandlingMethod::AlwaysSpawn;
 		SpawnParams.bDeferConstruction = true;
 
-		ASFConveyorBeltHologram* Belt = World->SpawnActor<ASFConveyorBeltHologram>(
-			ASFConveyorBeltHologram::StaticClass(), Entry.Location, Entry.Rotation, SpawnParams);
-		if (!Belt)
+		AFGHologram* Conduit = nullptr;
+		switch (Entry.Kind)
 		{
-			UE_LOG(LogSmartFoundations, Warning,
-				TEXT("[MP-334] SpawnBeltPlanChildren: belt %d failed to spawn."), BeltIndex);
-			continue;
+		case ESFConduitPlanKind::Belt:
+		case ESFConduitPlanKind::StackableBelt:
+		{
+			ASFConveyorBeltHologram* Belt = World->SpawnActor<ASFConveyorBeltHologram>(
+				ASFConveyorBeltHologram::StaticClass(), Entry.Location, Entry.Rotation, SpawnParams);
+			if (!Belt)
+			{
+				break;
+			}
+			Belt->SetReplicates(false);
+			Belt->SetReplicateMovement(false);
+			Belt->SetBuildClass(Entry.BuildClass);
+			Belt->SetRecipe(Entry.Recipe);
+			USFHologramDataService::DisableValidation(Belt);
+
+			if (Entry.Kind == ESFConduitPlanKind::Belt)
+			{
+				// SF_BeltAutoConnectChild routes Construct through the auto-connect path:
+				// Super::Construct builds the belt, then it self-wires each free end to the
+				// nearest free, direction-compatible connector within 50cm among BUILT actors
+				// only - by then the parent buildable and all grid-cell distributors exist
+				// (conduits are appended LAST in mChildren). Same mechanism SP uses.
+				Belt->Tags.AddUnique(FName(TEXT("SF_BeltAutoConnectChild")));
+			}
+			else
+			{
+				// SF_StackableChild + chain identity routes Construct through the stack-chain
+				// path: build fresh, then wire by geometric coincidence against the other built
+				// stacked belts and register for the #341 in-frame chain unification (which runs
+				// in the belt-support parent's Construct hook, also live server-side).
+				Belt->Tags.AddUnique(FName(TEXT("SF_StackableChild")));
+				if (FSFHologramData* Data = USFHologramDataService::GetOrCreateData(Belt))
+				{
+					Data->bIsStackableBelt = true;
+					Data->StackableBeltIndex = FMath::Max(0, Entry.StackIndex);
+					Data->StackChainId = StackChainId;
+					Data->StackChainIndex = FMath::Max(0, Entry.StackIndex);
+				}
+			}
+
+			Belt->FinishSpawning(FTransform(Entry.Rotation, Entry.Location));
+			Belt->SetActorEnableCollision(false);
+			Belt->SetSplineDataAndUpdate(Entry.SplinePoints);
+			Parent->AddChild(Belt, Belt->GetFName());
+			// Defensive re-apply AFTER AddChild (Extend-proven: vanilla can reset spline data on
+			// child registration; empty mSplineData crashes OnRep_SplineData/UpdateSplineComponent).
+			Belt->SetSplineDataAndUpdate(Entry.SplinePoints);
+			Conduit = Belt;
+			break;
 		}
 
-		Belt->SetReplicates(false);
-		Belt->SetReplicateMovement(false);
-		Belt->SetBuildClass(Entry.BeltClass);
-		Belt->SetRecipe(Entry.Recipe);
+		case ESFConduitPlanKind::Pipe:
+		case ESFConduitPlanKind::StackablePipe:
+		{
+			ASFPipelineHologram* Pipe = World->SpawnActor<ASFPipelineHologram>(
+				ASFPipelineHologram::StaticClass(), Entry.Location, Entry.Rotation, SpawnParams);
+			if (!Pipe)
+			{
+				break;
+			}
+			Pipe->SetReplicates(false);
+			Pipe->SetReplicateMovement(false);
+			Pipe->SetBuildClass(Entry.BuildClass);
+			Pipe->SetRecipe(Entry.Recipe);
+			USFHologramDataService::DisableValidation(Pipe);
+			USFHologramDataService::MarkAsChild(Pipe, Parent, ESFChildHologramType::AutoConnect);
 
-		// The SF_BeltAutoConnectChild tag routes this hologram's Construct through the auto-connect
-		// path: Super::Construct builds the belt, then it self-wires each free end to the nearest
-		// free, direction-compatible connector within 50cm among BUILT actors only - by then the
-		// parent buildable and all grid-cell distributors exist (belts are appended LAST in
-		// mChildren), and pre-existing world targets always did. Same mechanism SP uses.
-		Belt->Tags.AddUnique(FName(TEXT("SF_BeltAutoConnectChild")));
-		USFHologramDataService::DisableValidation(Belt);
+			FSFHologramData* Data = USFHologramDataService::GetOrCreateData(Pipe);
+			if (Entry.Kind == ESFConduitPlanKind::Pipe)
+			{
+				Pipe->Tags.AddUnique(FName(TEXT("SF_PipeAutoConnectChild")));
+				if (Data)
+				{
+					Data->bIsPipeAutoConnectChild = true;
+					// PipeAutoConnectConn0 is ONLY a branch discriminator at the construct seam:
+					// null = floor-hole branch (passthrough snap registration by proximity),
+					// non-null = junction branch (deferred geometric wiring). The component is
+					// never dereferenced there, so any non-null connection works server-side.
+					if (!Entry.bFloorHolePipe)
+					{
+						TArray<UFGPipeConnectionComponentBase*> PipeConns;
+						Pipe->GetComponents<UFGPipeConnectionComponentBase>(PipeConns);
+						Data->PipeAutoConnectConn0 = PipeConns.Num() > 0 ? PipeConns[0] : nullptr;
+						if (PipeConns.Num() == 0)
+						{
+							UE_LOG(LogSmartFoundations, Warning,
+								TEXT("[MP-334] SpawnConduitPlanChildren: pipe entry %d has no connection component for the junction-branch discriminator; it will take the floor-hole branch."),
+								EntryIndex);
+						}
+					}
+				}
+			}
+			else
+			{
+				Pipe->Tags.AddUnique(FName(TEXT("SF_StackableChild")));
+				if (Data)
+				{
+					Data->bIsStackablePipe = true;
+					Data->StackablePipeIndex = FMath::Max(0, Entry.StackIndex);
+				}
+			}
 
-		Belt->FinishSpawning(FTransform(Entry.Rotation, Entry.Location));
-		Belt->SetActorEnableCollision(false);
-		Belt->SetSplineDataAndUpdate(Entry.SplinePoints);
+			Pipe->FinishSpawning(FTransform(Entry.Rotation, Entry.Location));
+			Pipe->SetActorEnableCollision(false);
+			Pipe->SetSplineDataAndUpdate(Entry.SplinePoints);
+			Parent->AddChild(Pipe, Pipe->GetFName());
+			Pipe->SetSplineDataAndUpdate(Entry.SplinePoints);
+			Conduit = Pipe;
+			break;
+		}
 
-		Parent->AddChild(Belt, Belt->GetFName());
+		case ESFConduitPlanKind::Wire:
+		{
+			UFGPowerConnectionComponent* C0 = SF_ResolvePowerConnectionAt(Parent, Entry.WireStart, 100.0f);
+			UFGPowerConnectionComponent* C1 = SF_ResolvePowerConnectionAt(Parent, Entry.WireEnd, 100.0f);
+			if (!C0 || !C1 || C0 == C1)
+			{
+				UE_LOG(LogSmartFoundations, Warning,
+					TEXT("[MP-334] SpawnConduitPlanChildren: wire entry %d endpoints unresolved (C0=%s, C1=%s) - skipped."),
+					EntryIndex, *GetNameSafe(C0), *GetNameSafe(C1));
+				break;
+			}
 
-		// Defensive re-apply AFTER AddChild (Extend-proven: vanilla can reset spline data on
-		// child registration; an empty mSplineData crashes OnRep_SplineData/UpdateSplineComponent).
-		Belt->SetSplineDataAndUpdate(Entry.SplinePoints);
+			ASFWireHologram* Wire = World->SpawnActor<ASFWireHologram>(
+				ASFWireHologram::StaticClass(), Entry.WireStart, FRotator::ZeroRotator, SpawnParams);
+			if (!Wire)
+			{
+				break;
+			}
+			Wire->SetReplicates(false);
+			Wire->SetReplicateMovement(false);
+			Wire->SetBuildClass(Entry.BuildClass);
+			Wire->SetRecipe(Entry.Recipe);
+			Wire->Tags.AddUnique(FName(TEXT("SF_PowerAutoConnectChild")));
+			USFHologramDataService::DisableValidation(Wire);
+			Wire->FinishSpawning(FTransform(FRotator::ZeroRotator, Entry.WireStart));
+			// Sets mConnections[0/1]; vanilla AFGWireHologram::Construct builds the AFGBuildableWire
+			// between them, remapping hologram-owned connections to the built poles (SP mechanism).
+			Wire->SetupWirePreview(C0, C1);
+			Parent->AddChild(Wire, Wire->GetFName());
+			Conduit = Wire;
+			break;
+		}
 
-		++Spawned;
+		default:
+			break;
+		}
+
+		if (Conduit)
+		{
+			++Spawned;
+		}
+		else
+		{
+			UE_LOG(LogSmartFoundations, Warning,
+				TEXT("[MP-334] SpawnConduitPlanChildren: entry %d (kind=%d) failed to spawn."),
+				EntryIndex, (int32)Entry.Kind);
+		}
 	}
 
 	UE_LOG(LogSmartFoundations, Display,
-		TEXT("[MP-334] SpawnBeltPlanChildren: %d/%d staged belt(s) attached to %s; vanilla construct will build + wire them."),
-		Spawned, Spec.BeltPlan.Num(), *Parent->GetName());
+		TEXT("[MP-334] SpawnConduitPlanChildren: %d/%d staged conduit(s) attached to %s; vanilla construct will build + wire them."),
+		Spawned, Spec.ConduitPlan.Num(), *Parent->GetName());
 
 	return Spawned;
 }

--- a/Source/SmartFoundations/Private/Holograms/Core/SFScalingSpecExpansion.cpp
+++ b/Source/SmartFoundations/Private/Holograms/Core/SFScalingSpecExpansion.cpp
@@ -70,6 +70,7 @@ bool CaptureScalingSpec(AFGHologram* Hologram, FSFScalingSpec& OutSpec)
 	OutSpec.Counters = Counters;
 	OutSpec.ItemSize = Profile.DefaultSize;
 	OutSpec.AnchorOffset = Profile.AnchorOffset;
+	OutSpec.BuildClass = Hologram->GetBuildClass();
 	OutSpec.bValid = true;
 	return true;
 }

--- a/Source/SmartFoundations/Private/Holograms/Core/SFScalingSpecExpansion.cpp
+++ b/Source/SmartFoundations/Private/Holograms/Core/SFScalingSpecExpansion.cpp
@@ -435,7 +435,13 @@ int32 SpawnConduitPlanChildren(AFGHologram* Parent, const FSFScalingSpec& Spec)
 			Belt->SetReplicates(false);
 			Belt->SetReplicateMovement(false);
 			Belt->SetBuildClass(Entry.BuildClass);
-			Belt->SetRecipe(Entry.Recipe);
+			// Stackable belt previews carry NO recipe on the client (their spawner sets only the
+			// build class), and vanilla SetRecipe check()s non-null - SetRecipe(null) was a live
+			// server crash 2026-06-10. Mirror the client: only set when captured.
+			if (Entry.Recipe)
+			{
+				Belt->SetRecipe(Entry.Recipe);
+			}
 			USFHologramDataService::DisableValidation(Belt);
 
 			if (Entry.Kind == ESFConduitPlanKind::Belt)
@@ -486,7 +492,12 @@ int32 SpawnConduitPlanChildren(AFGHologram* Parent, const FSFScalingSpec& Spec)
 			Pipe->SetReplicates(false);
 			Pipe->SetReplicateMovement(false);
 			Pipe->SetBuildClass(Entry.BuildClass);
-			Pipe->SetRecipe(Entry.Recipe);
+			// Same null guard as belts: stackable pipe previews may carry no recipe, and vanilla
+			// SetRecipe check()s non-null.
+			if (Entry.Recipe)
+			{
+				Pipe->SetRecipe(Entry.Recipe);
+			}
 			USFHologramDataService::DisableValidation(Pipe);
 			USFHologramDataService::MarkAsChild(Pipe, Parent, ESFChildHologramType::AutoConnect);
 

--- a/Source/SmartFoundations/Private/Holograms/Core/SFScalingSpecExpansion.cpp
+++ b/Source/SmartFoundations/Private/Holograms/Core/SFScalingSpecExpansion.cpp
@@ -141,6 +141,17 @@ int32 ExpandScalingSpecIntoChildren(AFGHologram* Parent, const FSFScalingSpec& S
 
 				if (Child)
 				{
+					// Clear the never-aimed state. Freshly spawned holograms carry FGCDInitializing /
+					// FGCDInvalidAimLocation until they receive a placement pass, and server-side
+					// validation rejects the whole construct on them (live-test finding, 2026-06-09).
+					// Run one placement pass with a synthetic hit at the cell, then restore the exact
+					// grid transform (same pattern as the Extend lift spawner).
+					FHitResult CellHit;
+					CellHit.Location = CellLoc;
+					CellHit.ImpactPoint = CellLoc;
+					CellHit.ImpactNormal = FVector::UpVector;
+					Child->SetHologramLocationAndRotation(CellHit);
+					Child->SetActorLocationAndRotation(CellLoc, ParentRot);
 					++SpawnedChildren;
 				}
 			}

--- a/Source/SmartFoundations/Private/Holograms/Core/SFScalingSpecExpansion.cpp
+++ b/Source/SmartFoundations/Private/Holograms/Core/SFScalingSpecExpansion.cpp
@@ -141,16 +141,12 @@ int32 ExpandScalingSpecIntoChildren(AFGHologram* Parent, const FSFScalingSpec& S
 
 				if (Child)
 				{
-					// Clear the never-aimed state. Freshly spawned holograms carry FGCDInitializing /
-					// FGCDInvalidAimLocation until they receive a placement pass, and server-side
-					// validation rejects the whole construct on them (live-test finding, 2026-06-09).
-					// Run one placement pass with a synthetic hit at the cell, then restore the exact
-					// grid transform (same pattern as the Extend lift spawner).
-					FHitResult CellHit;
-					CellHit.Location = CellLoc;
-					CellHit.ImpactPoint = CellLoc;
-					CellHit.ImpactNormal = FVector::UpVector;
-					Child->SetHologramLocationAndRotation(CellHit);
+					// Exact grid transform. No placement/validation pass is needed: expansion runs
+					// inside Construct, AFTER server validation has already passed on the parent -
+					// fresh children are constructed directly and never validated. (Live-test finding
+					// 2026-06-09: expanding BEFORE validation is unworkable - freshly spawned vanilla
+					// holograms carry FGCDInitializing/FGCDInvalidFloor/FGCDInvalidAimLocation that
+					// programmatic spawns cannot clear, and the whole construct gets rejected.)
 					Child->SetActorLocationAndRotation(CellLoc, ParentRot);
 					++SpawnedChildren;
 				}

--- a/Source/SmartFoundations/Private/Holograms/Core/SFScalingSpecExpansion.cpp
+++ b/Source/SmartFoundations/Private/Holograms/Core/SFScalingSpecExpansion.cpp
@@ -122,9 +122,15 @@ int32 ExpandScalingSpecIntoChildren(AFGHologram* Parent, const FSFScalingSpec& S
 				const int32 GY = YI * SgnY;
 				const int32 GZ = ZI * SgnZ;
 
+				// AnchorOffset deliberately NOT passed (ZeroVector): like the legacy grid spawner
+				// (SFGridSpawnerService.cpp "CRITICAL FIX: DO NOT pass AnchorOffset"), we place via
+				// direct actor transform, which expects the FINAL world position. Passing the
+				// registry anchor pre-lowers attachment types (splitters/mergers/pipe junctions,
+				// AnchorOffset.Z ~ -100cm) by their compensation - live finding 2026-06-09: spec
+				// grid children sank half-height while the parent sat correctly.
 				const FVector CellLoc = Calc.CalculateChildPosition(
 					GX, GY, GZ, ParentLoc, ParentRot,
-					Spec.ItemSize, C, LinearIndex, Spec.AnchorOffset);
+					Spec.ItemSize, C, LinearIndex, FVector::ZeroVector);
 				++LinearIndex;
 
 				const FName ChildName(*FString::Printf(TEXT("SFSpecCell_%d_%d_%d"), GX, GY, GZ));

--- a/Source/SmartFoundations/Private/Holograms/Core/SFScalingSpecExpansion.cpp
+++ b/Source/SmartFoundations/Private/Holograms/Core/SFScalingSpecExpansion.cpp
@@ -55,14 +55,11 @@ bool CaptureScalingSpec(AFGHologram* Hologram, FSFScalingSpec& OutSpec)
 		return false;
 	}
 
+	// NOTE: trivial 1x1x1 grids are captured too (since the #334 increment): the server-side
+	// Construct hook is also the seam where auto-connect wiring is re-derived with authority, and
+	// a SINGLE distributor with auto-connect belts needs that path as much as a grid does. The
+	// expansion loop simply spawns zero children for a 1-cell spec, and the cost scale is x1.
 	const FSFCounterState Counters = SS->GetCounterState();
-	const int32 NX = FMath::Max(1, FMath::Abs(Counters.GridCounters.X));
-	const int32 NY = FMath::Max(1, FMath::Abs(Counters.GridCounters.Y));
-	const int32 NZ = FMath::Max(1, FMath::Abs(Counters.GridCounters.Z));
-	if (NX * NY * NZ <= 1)
-	{
-		return false; // trivial grid: nothing to expand server-side
-	}
 
 	USFBuildableSizeRegistry::Initialize();
 	const FSFBuildableSizeProfile Profile = USFBuildableSizeRegistry::GetProfile(Hologram->GetBuildClass());

--- a/Source/SmartFoundations/Private/Holograms/Core/SFScalingSpecExpansion.cpp
+++ b/Source/SmartFoundations/Private/Holograms/Core/SFScalingSpecExpansion.cpp
@@ -15,6 +15,10 @@
 #include "Buildables/FGBuildable.h"
 #include "Buildables/FGBuildableWire.h"
 #include "FGBlueprintProxy.h"
+#include "Hologram/FGPoleHologram.h"            // #354: mPoleVariationIndex / mBuildStep
+#include "Hologram/FGConveyorPoleHologram.h"
+#include "Hologram/FGFloodlightHologram.h"      // #200: mFixtureAngle / mBuildStep
+#include "Hologram/FGStandaloneSignHologram.h"  // #192: mBuildStep
 #include "Engine/World.h"
 #include "EngineUtils.h"
 #include "HAL/IConsoleManager.h"
@@ -81,6 +85,69 @@ bool CaptureScalingSpec(AFGHologram* Hologram, FSFScalingSpec& OutSpec)
 	OutSpec.BuildClass = Hologram->GetBuildClass();
 	OutSpec.bValid = true;
 	return true;
+}
+
+// Multi-step buildables carry the player's step-2 choice in PRIVATE hologram members which the
+// CLIENT preview syncs parent->child every tick via reflection (#354 standard conveyor pole
+// height, #200 floodlight fixture angle, #192 sign build step - see USFSubsystem::
+// SyncMultiStepHologramProperties). Spec-expanded server children spawn with DEFAULTS, so without
+// this they build at e.g. floor height while the captured belts route to top connectors (live
+// finding 2026-06-10, standard poles). The parent's own values crossed the wire inside the
+// construct message - copy the same properties to each child and fire the same OnRep refresh, so
+// the child's connectors/mesh state match before ConfigureActor snapshots them into the buildable.
+static void SF_SyncMultiStepPropertiesToChild(AFGHologram* Parent, AFGHologram* Child)
+{
+	// #354: STANDARD conveyor pole only - stackable/wall poles are also AFGConveyorPoleHologram
+	// and must not be touched (same gate as the client sync).
+	if (USFAutoConnectService::IsRegularConveyorPoleHologram(Parent) && Child->IsA<AFGConveyorPoleHologram>())
+	{
+		if (FIntProperty* VarProp = FindFProperty<FIntProperty>(AFGPoleHologram::StaticClass(), TEXT("mPoleVariationIndex")))
+		{
+			VarProp->SetPropertyValue_InContainer(Child, VarProp->GetPropertyValue_InContainer(Parent));
+		}
+		if (FProperty* StepProp = FindFProperty<FProperty>(AFGPoleHologram::StaticClass(), TEXT("mBuildStep")))
+		{
+			StepProp->CopyCompleteValue(
+				StepProp->ContainerPtrToValuePtr<void>(Child),
+				StepProp->ContainerPtrToValuePtr<void>(Parent));
+		}
+		if (UFunction* RepFunc = Child->FindFunction(TEXT("OnRep_PoleVariationIndex")))
+		{
+			Child->ProcessEvent(RepFunc, nullptr);
+		}
+		return;
+	}
+
+	// #200: floodlight fixture angle.
+	if (Parent->IsA<AFGFloodlightHologram>() && Child->IsA<AFGFloodlightHologram>())
+	{
+		if (FIntProperty* AngleProp = FindFProperty<FIntProperty>(AFGFloodlightHologram::StaticClass(), TEXT("mFixtureAngle")))
+		{
+			AngleProp->SetPropertyValue_InContainer(Child, AngleProp->GetPropertyValue_InContainer(Parent));
+		}
+		if (FProperty* StepProp = FindFProperty<FProperty>(AFGFloodlightHologram::StaticClass(), TEXT("mBuildStep")))
+		{
+			StepProp->CopyCompleteValue(
+				StepProp->ContainerPtrToValuePtr<void>(Child),
+				StepProp->ContainerPtrToValuePtr<void>(Parent));
+		}
+		if (UFunction* RepFunc = Child->FindFunction(TEXT("OnRep_FixtureAngle")))
+		{
+			Child->ProcessEvent(RepFunc, nullptr);
+		}
+		return;
+	}
+
+	// #192: standalone sign build step.
+	if (Parent->IsA<AFGStandaloneSignHologram>() && Child->IsA<AFGStandaloneSignHologram>())
+	{
+		if (FProperty* StepProp = FindFProperty<FProperty>(AFGStandaloneSignHologram::StaticClass(), TEXT("mBuildStep")))
+		{
+			StepProp->CopyCompleteValue(
+				StepProp->ContainerPtrToValuePtr<void>(Child),
+				StepProp->ContainerPtrToValuePtr<void>(Parent));
+		}
+	}
 }
 
 int32 ExpandScalingSpecIntoChildren(AFGHologram* Parent, const FSFScalingSpec& Spec,
@@ -163,6 +230,11 @@ int32 ExpandScalingSpecIntoChildren(AFGHologram* Parent, const FSFScalingSpec& S
 					// holograms carry FGCDInitializing/FGCDInvalidFloor/FGCDInvalidAimLocation that
 					// programmatic spawns cannot clear, and the whole construct gets rejected.)
 					Child->SetActorLocationAndRotation(CellLoc, ParentRot);
+
+					// Multi-step parents (pole height / floodlight angle / sign step): copy the
+					// player's step-2 choice from the parent so the child builds with it.
+					SF_SyncMultiStepPropertiesToChild(Parent, Child);
+
 					++SpawnedChildren;
 				}
 			}

--- a/Source/SmartFoundations/Private/Holograms/Core/SFScalingSpecExpansion.cpp
+++ b/Source/SmartFoundations/Private/Holograms/Core/SFScalingSpecExpansion.cpp
@@ -48,7 +48,7 @@ bool IsSpecConstructionEnabled()
 	if (!bLoggedOnce)
 	{
 		bLoggedOnce = true;
-		UE_LOG(LogSmartFoundations, Display,
+		UE_LOG(LogSmartFoundations, Verbose,
 			TEXT("[MP-SPEC] Spec-based scaling construction is %s (sf.MP.SpecConstruction=%d)."),
 			bEnabled ? TEXT("ENABLED") : TEXT("DISABLED"),
 			CVarSFMPSpecConstruction.GetValueOnAnyThread());
@@ -241,7 +241,7 @@ int32 ExpandScalingSpecIntoChildren(AFGHologram* Parent, const FSFScalingSpec& S
 		}
 	}
 
-	UE_LOG(LogSmartFoundations, Display,
+	UE_LOG(LogSmartFoundations, Verbose,
 		TEXT("[MP-SPEC] ExpandScalingSpecIntoChildren: regenerated %d/%d grid children server-side ")
 		TEXT("for %s (recipe=%s). Vanilla cost + Construct will now build the full grid."),
 		SpawnedChildren, Spec.CellCount() - 1, *Parent->GetName(), *Recipe->GetName());
@@ -403,7 +403,7 @@ void CaptureConduitPlan(AFGHologram* Hologram, FSFScalingSpec& InOutSpec)
 
 	if (InOutSpec.ConduitPlan.Num() > 0)
 	{
-		UE_LOG(LogSmartFoundations, Display,
+		UE_LOG(LogSmartFoundations, Verbose,
 			TEXT("[MP-334] Client fire: captured conduit plan - %d belt(s), %d pipe(s), %d stackable belt(s), %d stackable pipe(s), %d wire(s) (%d cost item type(s))."),
 			PerKind[0], PerKind[1], PerKind[2], PerKind[3], PerKind[4], InOutSpec.ConduitPlanCost.Num());
 	}
@@ -650,7 +650,7 @@ int32 SpawnConduitPlanChildren(AFGHologram* Parent, const FSFScalingSpec& Spec)
 			++WireEntries;
 		}
 	}
-	UE_LOG(LogSmartFoundations, Display,
+	UE_LOG(LogSmartFoundations, Verbose,
 		TEXT("[MP-334] SpawnConduitPlanChildren: %d/%d staged conduit(s) attached to %s (%d wire(s) deferred to post-construct); vanilla construct will build + wire them."),
 		Spawned, Spec.ConduitPlan.Num() - WireEntries, *Parent->GetName(), WireEntries);
 
@@ -751,7 +751,7 @@ int32 SpawnWirePlanPostConstruct(AActor* BuiltParent, const TArray<AActor*>& Out
 
 	if (WireEntries > 0)
 	{
-		UE_LOG(LogSmartFoundations, Display,
+		UE_LOG(LogSmartFoundations, Verbose,
 			TEXT("[MP-334] SpawnWirePlanPostConstruct: built %d/%d staged wire(s) for %s."),
 			Built, WireEntries, *GetNameSafe(BuiltParent));
 	}

--- a/Source/SmartFoundations/Private/Holograms/Core/SFScalingSpecExpansion.cpp
+++ b/Source/SmartFoundations/Private/Holograms/Core/SFScalingSpecExpansion.cpp
@@ -1,0 +1,145 @@
+// Copyright (c) 2025-present Finalomega. All rights reserved. See LICENSE.md.
+
+#include "Holograms/Core/SFScalingSpecExpansion.h"
+#include "SmartFoundations.h"
+#include "Hologram/FGHologram.h"
+#include "Subsystem/SFSubsystem.h"
+#include "Subsystem/SFPositionCalculator.h"
+#include "Data/SFBuildableSizeRegistry.h"
+#include "HAL/IConsoleManager.h"
+
+// MP spec-based construction toggle. Off by default: the existing path (and the oversized-grid
+// safety guard) remain authoritative until this is validated in a live multiplayer session.
+// Enable on the CLIENT via console `sf.MP.SpecConstruction 1`, or in a Shipping build via
+// %LOCALAPPDATA%/FactoryGame/Saved/Config/Windows/Engine.ini:
+//   [SystemSettings]
+//   sf.MP.SpecConstruction=1
+static TAutoConsoleVariable<int32> CVarSFMPSpecConstruction(
+	TEXT("sf.MP.SpecConstruction"),
+	0,
+	TEXT("Smart!: when 1, scaling grids commit via a compact server-expanded spec (MP) instead of ")
+	TEXT("serializing N child holograms. Experimental; default 0 (legacy path + oversized guard)."),
+	ECVF_Default);
+
+namespace SFScalingSpecExpansion
+{
+
+bool IsSpecConstructionEnabled()
+{
+	return CVarSFMPSpecConstruction.GetValueOnAnyThread() != 0;
+}
+
+bool CaptureScalingSpec(AFGHologram* Hologram, FSFScalingSpec& OutSpec)
+{
+	if (!Hologram)
+	{
+		return false;
+	}
+
+	USFSubsystem* SS = USFSubsystem::Get(Hologram->GetWorld());
+	if (!SS)
+	{
+		return false;
+	}
+
+	const FSFCounterState Counters = SS->GetCounterState();
+	const int32 NX = FMath::Max(1, FMath::Abs(Counters.GridCounters.X));
+	const int32 NY = FMath::Max(1, FMath::Abs(Counters.GridCounters.Y));
+	const int32 NZ = FMath::Max(1, FMath::Abs(Counters.GridCounters.Z));
+	if (NX * NY * NZ <= 1)
+	{
+		return false; // trivial grid: nothing to expand server-side
+	}
+
+	USFBuildableSizeRegistry::Initialize();
+	const FSFBuildableSizeProfile Profile = USFBuildableSizeRegistry::GetProfile(Hologram->GetBuildClass());
+
+	OutSpec.Counters = Counters;
+	OutSpec.ItemSize = Profile.DefaultSize;
+	OutSpec.AnchorOffset = Profile.AnchorOffset;
+	OutSpec.bValid = true;
+	return true;
+}
+
+int32 ExpandScalingSpecIntoChildren(AFGHologram* Parent, const FSFScalingSpec& Spec,
+	TSubclassOf<UFGRecipe> Recipe)
+{
+	if (!Parent || !Parent->GetWorld() || !Spec.bValid)
+	{
+		return 0;
+	}
+	if (!Recipe)
+	{
+		UE_LOG(LogSmartFoundations, Warning,
+			TEXT("[MP-SPEC] ExpandScalingSpecIntoChildren: no recipe on parent hologram %s; cannot expand."),
+			*Parent->GetName());
+		return 0;
+	}
+
+	const FSFCounterState& C = Spec.Counters;
+	const FVector ParentLoc = Parent->GetActorLocation();
+	const FRotator ParentRot = Parent->GetActorRotation();
+
+	const int32 NX = FMath::Max(1, FMath::Abs(C.GridCounters.X));
+	const int32 NY = FMath::Max(1, FMath::Abs(C.GridCounters.Y));
+	const int32 NZ = FMath::Max(1, FMath::Abs(C.GridCounters.Z));
+	const int32 SgnX = (C.GridCounters.X < 0) ? -1 : 1;
+	const int32 SgnY = (C.GridCounters.Y < 0) ? -1 : 1;
+	const int32 SgnZ = (C.GridCounters.Z < 0) ? -1 : 1;
+
+	FSFPositionCalculator Calc;
+	AActor* HoloOwner = Parent->GetOwner();
+	int32 SpawnedChildren = 0;
+	int32 LinearIndex = 0;
+
+	for (int32 ZI = 0; ZI < NZ; ++ZI)
+	{
+		for (int32 YI = 0; YI < NY; ++YI)
+		{
+			for (int32 XI = 0; XI < NX; ++XI)
+			{
+				// (0,0,0) is the parent buildable itself (built by Super::Construct), not a child.
+				if (XI == 0 && YI == 0 && ZI == 0)
+				{
+					continue;
+				}
+
+				const int32 GX = XI * SgnX;
+				const int32 GY = YI * SgnY;
+				const int32 GZ = ZI * SgnZ;
+
+				const FVector CellLoc = Calc.CalculateChildPosition(
+					GX, GY, GZ, ParentLoc, ParentRot,
+					Spec.ItemSize, C, LinearIndex, Spec.AnchorOffset);
+				++LinearIndex;
+
+				const FName ChildName(*FString::Printf(TEXT("SFSpecCell_%d_%d_%d"), GX, GY, GZ));
+
+				AFGHologram* Child = AFGHologram::SpawnChildHologramFromRecipe(
+					Parent, ChildName, Recipe, HoloOwner, CellLoc,
+					[ParentRot](AFGHologram* NewChild)
+					{
+						if (NewChild)
+						{
+							NewChild->SetActorRotation(ParentRot);
+							NewChild->Tags.AddUnique(FName(TEXT("SF_GridChild")));
+						}
+					});
+
+				if (Child)
+				{
+					++SpawnedChildren;
+				}
+			}
+		}
+	}
+
+	UE_LOG(LogSmartFoundations, Display,
+		TEXT("[MP-SPEC] ExpandScalingSpecIntoChildren: regenerated %d/%d grid children server-side ")
+		TEXT("for %s (recipe=%s). Vanilla cost + Construct will now build the full grid."),
+		SpawnedChildren, Spec.CellCount() - 1, *Parent->GetName(), *Recipe->GetName());
+
+	return SpawnedChildren;
+}
+
+} // namespace SFScalingSpecExpansion

--- a/Source/SmartFoundations/Private/Holograms/Core/SFScalingSpecExpansion.cpp
+++ b/Source/SmartFoundations/Private/Holograms/Core/SFScalingSpecExpansion.cpp
@@ -8,17 +8,17 @@
 #include "Data/SFBuildableSizeRegistry.h"
 #include "HAL/IConsoleManager.h"
 
-// MP spec-based construction toggle. Off by default: the existing path (and the oversized-grid
-// safety guard) remain authoritative until this is validated in a live multiplayer session.
-// Enable on the CLIENT via console `sf.MP.SpecConstruction 1`, or in a Shipping build via
-// %LOCALAPPDATA%/FactoryGame/Saved/Config/Windows/Engine.ini:
-//   [SystemSettings]
-//   sf.MP.SpecConstruction=1
+// MP spec-based construction. ON by default - the mod must be self-contained (no launch options /
+// ini edits for players; Saved/Engine.ini is rewritten by the game's diff-config system anyway).
+// The CVar exists ONLY as a developer escape hatch: in a dev/debug session it can be set to 0 to
+// fall back to the legacy serialize-children path + oversized guard while isolating a regression.
+// Players never touch it. (This branch does not ship until the complete MP solution is validated.)
 static TAutoConsoleVariable<int32> CVarSFMPSpecConstruction(
 	TEXT("sf.MP.SpecConstruction"),
-	0,
-	TEXT("Smart!: when 1, scaling grids commit via a compact server-expanded spec (MP) instead of ")
-	TEXT("serializing N child holograms. Experimental; default 0 (legacy path + oversized guard)."),
+	1,
+	TEXT("Smart!: when 1 (default), scaling grids commit via a compact server-expanded spec (MP) ")
+	TEXT("instead of serializing N child holograms. Set 0 to fall back to the legacy path + ")
+	TEXT("oversized guard (developer debugging only)."),
 	ECVF_Default);
 
 namespace SFScalingSpecExpansion
@@ -26,7 +26,20 @@ namespace SFScalingSpecExpansion
 
 bool IsSpecConstructionEnabled()
 {
-	return CVarSFMPSpecConstruction.GetValueOnAnyThread() != 0;
+	const bool bEnabled = CVarSFMPSpecConstruction.GetValueOnAnyThread() != 0;
+
+	// One-time visibility: make the gate state unambiguous in every session log.
+	static bool bLoggedOnce = false;
+	if (!bLoggedOnce)
+	{
+		bLoggedOnce = true;
+		UE_LOG(LogSmartFoundations, Display,
+			TEXT("[MP-SPEC] Spec-based scaling construction is %s (sf.MP.SpecConstruction=%d)."),
+			bEnabled ? TEXT("ENABLED") : TEXT("DISABLED"),
+			CVarSFMPSpecConstruction.GetValueOnAnyThread());
+	}
+
+	return bEnabled;
 }
 
 bool CaptureScalingSpec(AFGHologram* Hologram, FSFScalingSpec& OutSpec)

--- a/Source/SmartFoundations/Private/Holograms/Core/SFScalingSpecExpansion.cpp
+++ b/Source/SmartFoundations/Private/Holograms/Core/SFScalingSpecExpansion.cpp
@@ -5,7 +5,11 @@
 #include "Hologram/FGHologram.h"
 #include "Subsystem/SFSubsystem.h"
 #include "Subsystem/SFPositionCalculator.h"
+#include "Subsystem/SFHologramDataService.h"
 #include "Data/SFBuildableSizeRegistry.h"
+#include "Features/AutoConnect/SFAutoConnectService.h"
+#include "Holograms/Logistics/SFConveyorBeltHologram.h"
+#include "Engine/World.h"
 #include "HAL/IConsoleManager.h"
 
 // MP spec-based construction. ON by default - the mod must be self-contained (no launch options /
@@ -164,6 +168,159 @@ int32 ExpandScalingSpecIntoChildren(AFGHologram* Parent, const FSFScalingSpec& S
 		SpawnedChildren, Spec.CellCount() - 1, *Parent->GetName(), *Recipe->GetName());
 
 	return SpawnedChildren;
+}
+
+void CaptureBeltPlan(AFGHologram* Hologram, FSFScalingSpec& InOutSpec)
+{
+	if (!Hologram)
+	{
+		return;
+	}
+	USFSubsystem* SS = USFSubsystem::Get(Hologram->GetWorld());
+	USFAutoConnectService* AutoConnect = SS ? SS->GetAutoConnectService() : nullptr;
+	if (!AutoConnect)
+	{
+		return;
+	}
+
+	// The service stores previews keyed per distributor hologram: the parent itself and/or any of
+	// its grid children (manifold lanes are stored on their SOURCE distributor, so walking each
+	// distributor once visits every belt exactly once).
+	TArray<AFGHologram*> Sources;
+	Sources.Add(Hologram);
+	for (AFGHologram* Child : Hologram->GetHologramChildren())
+	{
+		if (Child)
+		{
+			Sources.Add(Child);
+		}
+	}
+
+	for (AFGHologram* Source : Sources)
+	{
+		const TArray<TSharedPtr<FBeltPreviewHelper>>* Previews = AutoConnect->GetBeltPreviews(Source);
+		if (!Previews)
+		{
+			continue;
+		}
+		for (const TSharedPtr<FBeltPreviewHelper>& Helper : *Previews)
+		{
+			if (!Helper.IsValid())
+			{
+				continue;
+			}
+			ASFConveyorBeltHologram* BeltHolo = Helper->GetTypedHologram();
+			if (!IsValid(BeltHolo) || BeltHolo->GetSplineData().Num() < 2)
+			{
+				continue;
+			}
+
+			FSFBeltPlanEntry Entry;
+			Entry.BeltClass = BeltHolo->GetBuildClass();
+			Entry.Recipe = BeltHolo->GetRecipe();
+			Entry.Location = BeltHolo->GetActorLocation();
+			Entry.Rotation = BeltHolo->GetActorRotation();
+			Entry.SplinePoints = BeltHolo->GetSplineData();
+			InOutSpec.BeltPlan.Add(MoveTemp(Entry));
+
+			// Exact vanilla length-based cost of this preview, merged per item class. Charged by
+			// the server's GetCost hook alongside the cell-scaled grid cost.
+			for (const FItemAmount& Item : BeltHolo->GetCost(false))
+			{
+				bool bMerged = false;
+				for (FItemAmount& Existing : InOutSpec.BeltPlanCost)
+				{
+					if (Existing.ItemClass == Item.ItemClass)
+					{
+						Existing.Amount += Item.Amount;
+						bMerged = true;
+						break;
+					}
+				}
+				if (!bMerged)
+				{
+					InOutSpec.BeltPlanCost.Add(Item);
+				}
+			}
+		}
+	}
+
+	if (InOutSpec.BeltPlan.Num() > 0)
+	{
+		UE_LOG(LogSmartFoundations, Display,
+			TEXT("[MP-334] Client fire: captured belt plan with %d belt(s) (%d cost item type(s)) from live previews."),
+			InOutSpec.BeltPlan.Num(), InOutSpec.BeltPlanCost.Num());
+	}
+}
+
+int32 SpawnBeltPlanChildren(AFGHologram* Parent, const FSFScalingSpec& Spec)
+{
+	UWorld* World = Parent ? Parent->GetWorld() : nullptr;
+	if (!World || Spec.BeltPlan.Num() == 0)
+	{
+		return 0;
+	}
+
+	int32 Spawned = 0;
+	int32 BeltIndex = 0;
+	for (const FSFBeltPlanEntry& Entry : Spec.BeltPlan)
+	{
+		++BeltIndex;
+		if (!Entry.BeltClass || Entry.SplinePoints.Num() < 2)
+		{
+			UE_LOG(LogSmartFoundations, Warning,
+				TEXT("[MP-334] SpawnBeltPlanChildren: plan entry %d invalid (class=%s, points=%d) - skipped."),
+				BeltIndex, *GetNameSafe(*Entry.BeltClass), Entry.SplinePoints.Num());
+			continue;
+		}
+
+		// Mirror the proven Extend clone-spawner recipe (SFExtendCloneSpawner belt_segment path),
+		// minus the client-only visual finalization (the server doesn't render previews).
+		FActorSpawnParameters SpawnParams;
+		SpawnParams.Owner = Parent->GetOwner();
+		SpawnParams.SpawnCollisionHandlingOverride = ESpawnActorCollisionHandlingMethod::AlwaysSpawn;
+		SpawnParams.bDeferConstruction = true;
+
+		ASFConveyorBeltHologram* Belt = World->SpawnActor<ASFConveyorBeltHologram>(
+			ASFConveyorBeltHologram::StaticClass(), Entry.Location, Entry.Rotation, SpawnParams);
+		if (!Belt)
+		{
+			UE_LOG(LogSmartFoundations, Warning,
+				TEXT("[MP-334] SpawnBeltPlanChildren: belt %d failed to spawn."), BeltIndex);
+			continue;
+		}
+
+		Belt->SetReplicates(false);
+		Belt->SetReplicateMovement(false);
+		Belt->SetBuildClass(Entry.BeltClass);
+		Belt->SetRecipe(Entry.Recipe);
+
+		// The SF_BeltAutoConnectChild tag routes this hologram's Construct through the auto-connect
+		// path: Super::Construct builds the belt, then it self-wires each free end to the nearest
+		// free, direction-compatible connector within 50cm among BUILT actors only - by then the
+		// parent buildable and all grid-cell distributors exist (belts are appended LAST in
+		// mChildren), and pre-existing world targets always did. Same mechanism SP uses.
+		Belt->Tags.AddUnique(FName(TEXT("SF_BeltAutoConnectChild")));
+		USFHologramDataService::DisableValidation(Belt);
+
+		Belt->FinishSpawning(FTransform(Entry.Rotation, Entry.Location));
+		Belt->SetActorEnableCollision(false);
+		Belt->SetSplineDataAndUpdate(Entry.SplinePoints);
+
+		Parent->AddChild(Belt, Belt->GetFName());
+
+		// Defensive re-apply AFTER AddChild (Extend-proven: vanilla can reset spline data on
+		// child registration; an empty mSplineData crashes OnRep_SplineData/UpdateSplineComponent).
+		Belt->SetSplineDataAndUpdate(Entry.SplinePoints);
+
+		++Spawned;
+	}
+
+	UE_LOG(LogSmartFoundations, Display,
+		TEXT("[MP-334] SpawnBeltPlanChildren: %d/%d staged belt(s) attached to %s; vanilla construct will build + wire them."),
+		Spawned, Spec.BeltPlan.Num(), *Parent->GetName());
+
+	return Spawned;
 }
 
 } // namespace SFScalingSpecExpansion

--- a/Source/SmartFoundations/Private/Holograms/Core/SFScalingSpecExpansion.h
+++ b/Source/SmartFoundations/Private/Holograms/Core/SFScalingSpecExpansion.h
@@ -35,19 +35,22 @@ namespace SFScalingSpecExpansion
 		TSubclassOf<UFGRecipe> Recipe);
 
 	/**
-	 * Client-side (#334): capture the auto-connect belt wiring plan from the live preview helpers
-	 * into the spec, BEFORE the fire hook strips/destroys those previews. Walks the parent + every
-	 * child hologram and snapshots each stored belt preview (class, recipe, transform, routed
-	 * spline) plus its exact vanilla length-based cost into Spec.BeltPlan / Spec.BeltPlanCost.
+	 * Client-side (#334): capture the auto-connect conduit wiring plan (belts, pipes, stackable
+	 * runs, power wires) from the parent's tagged preview child holograms into the spec, BEFORE
+	 * the fire hook strips/destroys those previews. Snapshots each preview's family kind, class,
+	 * recipe, transform, routed spline (or wire endpoints) plus its exact vanilla preview cost
+	 * into Spec.ConduitPlan / Spec.ConduitPlanCost.
 	 */
-	void CaptureBeltPlan(AFGHologram* Hologram, FSFScalingSpec& InOutSpec);
+	void CaptureConduitPlan(AFGHologram* Hologram, FSFScalingSpec& InOutSpec);
 
 	/**
-	 * Server-side (#334): replay the staged belt plan as fresh ASFConveyorBeltHologram children of
-	 * the constructing parent. MUST be called AFTER ExpandScalingSpecIntoChildren so the belts sit
-	 * after the grid cells in mChildren: the vanilla child-construct loop then builds the
-	 * distributors first and each belt's SF_BeltAutoConnectChild Construct path wires it by
-	 * geometric coincidence against BUILT actors only. Returns the number of belts spawned.
+	 * Server-side (#334): replay the staged conduit plan as fresh tagged child holograms of the
+	 * constructing parent (the same spawn recipes the client preview pipeline uses, minus the
+	 * client-only visuals). MUST be called AFTER ExpandScalingSpecIntoChildren so the conduits sit
+	 * after the grid cells in mChildren: the vanilla child-construct loop then builds the grid
+	 * cells first and each family's existing Construct wiring path connects its conduit against
+	 * BUILT actors. Wire endpoints are resolved by world location against the pre-construct
+	 * hologram set. Returns the number of conduits spawned.
 	 */
-	int32 SpawnBeltPlanChildren(AFGHologram* Parent, const FSFScalingSpec& Spec);
+	int32 SpawnConduitPlanChildren(AFGHologram* Parent, const FSFScalingSpec& Spec);
 }

--- a/Source/SmartFoundations/Private/Holograms/Core/SFScalingSpecExpansion.h
+++ b/Source/SmartFoundations/Private/Holograms/Core/SFScalingSpecExpansion.h
@@ -53,4 +53,16 @@ namespace SFScalingSpecExpansion
 	 * hologram set. Returns the number of conduits spawned.
 	 */
 	int32 SpawnConduitPlanChildren(AFGHologram* Parent, const FSFScalingSpec& Spec);
+
+	/**
+	 * Server-side (#334): build the staged WIRE entries AFTER the grid has constructed. Wires are
+	 * never built from holograms - even in SP the wire child holograms exist only for cost, and
+	 * the persistent wire is direct-spawned post-build (unconnected wires self-destruct). Resolves
+	 * each endpoint power connection by world location among the BUILT actors (parent +
+	 * out_children, falling back to the world), dedupes against wires the power manager already
+	 * spawned, then AFGBuildableWire + Connect (the proven OnPowerPoleBuilt primitive). Registers
+	 * each wire into GroupProxy (may be null). Returns the number of wires built.
+	 */
+	int32 SpawnWirePlanPostConstruct(AActor* BuiltParent, const TArray<AActor*>& OutChildren,
+		const FSFScalingSpec& Spec, class AFGBlueprintProxy* GroupProxy);
 }

--- a/Source/SmartFoundations/Private/Holograms/Core/SFScalingSpecExpansion.h
+++ b/Source/SmartFoundations/Private/Holograms/Core/SFScalingSpecExpansion.h
@@ -33,4 +33,21 @@ namespace SFScalingSpecExpansion
 	 */
 	int32 ExpandScalingSpecIntoChildren(AFGHologram* Parent, const FSFScalingSpec& Spec,
 		TSubclassOf<UFGRecipe> Recipe);
+
+	/**
+	 * Client-side (#334): capture the auto-connect belt wiring plan from the live preview helpers
+	 * into the spec, BEFORE the fire hook strips/destroys those previews. Walks the parent + every
+	 * child hologram and snapshots each stored belt preview (class, recipe, transform, routed
+	 * spline) plus its exact vanilla length-based cost into Spec.BeltPlan / Spec.BeltPlanCost.
+	 */
+	void CaptureBeltPlan(AFGHologram* Hologram, FSFScalingSpec& InOutSpec);
+
+	/**
+	 * Server-side (#334): replay the staged belt plan as fresh ASFConveyorBeltHologram children of
+	 * the constructing parent. MUST be called AFTER ExpandScalingSpecIntoChildren so the belts sit
+	 * after the grid cells in mChildren: the vanilla child-construct loop then builds the
+	 * distributors first and each belt's SF_BeltAutoConnectChild Construct path wires it by
+	 * geometric coincidence against BUILT actors only. Returns the number of belts spawned.
+	 */
+	int32 SpawnBeltPlanChildren(AFGHologram* Parent, const FSFScalingSpec& Spec);
 }

--- a/Source/SmartFoundations/Private/Holograms/Core/SFScalingSpecExpansion.h
+++ b/Source/SmartFoundations/Private/Holograms/Core/SFScalingSpecExpansion.h
@@ -1,0 +1,36 @@
+// Copyright (c) 2025-present Finalomega. All rights reserved. See LICENSE.md.
+// Smart! Mod - shared helpers for MP spec-based scaling construction.
+//
+// Used by the spec-capable parent holograms (ASFFactoryHologram for production buildings,
+// ASFFoundationHologram for flat foundations). Keeps the capture + server-expansion logic in one
+// place; the mChildren strip/restore stays in each class (protected member access).
+// See docs/Features/Multiplayer/PLAN_MP_ScalingConstruction_Impl.md.
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Features/Scaling/SFScalingSpec.h"
+
+class AFGHologram;
+class UFGRecipe;
+
+namespace SFScalingSpecExpansion
+{
+	/** True when the sf.MP.SpecConstruction console variable is enabled. */
+	bool IsSpecConstructionEnabled();
+
+	/**
+	 * Client-side: capture the active Smart grid into a compact spec.
+	 * Reads the authoritative FSFCounterState from the subsystem and ItemSize/AnchorOffset from the
+	 * buildable size registry. Returns false (and leaves OutSpec invalid) for trivial 1x1x1 grids.
+	 */
+	bool CaptureScalingSpec(AFGHologram* Hologram, FSFScalingSpec& OutSpec);
+
+	/**
+	 * Server-side: expand the spec into one child hologram per non-origin grid cell, parented to
+	 * Parent via the vanilla AFGHologram::SpawnChildHologramFromRecipe path, positioned with
+	 * FSFPositionCalculator (the same math the client preview uses). Returns the number spawned.
+	 */
+	int32 ExpandScalingSpecIntoChildren(AFGHologram* Parent, const FSFScalingSpec& Spec,
+		TSubclassOf<UFGRecipe> Recipe);
+}

--- a/Source/SmartFoundations/Private/Holograms/Core/SFSmartChildHologram.cpp
+++ b/Source/SmartFoundations/Private/Holograms/Core/SFSmartChildHologram.cpp
@@ -33,7 +33,7 @@ AActor* ASFSmartChildHologram::Construct(TArray<AActor*>& out_children, FNetCons
     // NetMode: 0=Standalone 1=DedicatedServer 2=ListenServer 3=Client.
     {
         const int32 NetMode = GetWorld() ? (int32)GetWorld()->GetNetMode() : -1;
-        UE_LOG(LogSmartHologram, Display,
+        UE_LOG(LogSmartHologram, Verbose,
             TEXT("[MP-SLICE0] SmartChild::Construct: %s NetMode=%d HasAuthority=%d"),
             *GetName(), NetMode, HasAuthority() ? 1 : 0);
     }

--- a/Source/SmartFoundations/Private/Holograms/Core/SFSmartChildHologram.cpp
+++ b/Source/SmartFoundations/Private/Holograms/Core/SFSmartChildHologram.cpp
@@ -26,7 +26,18 @@ void ASFSmartChildHologram::CheckValidPlacement() {
 
 AActor* ASFSmartChildHologram::Construct(TArray<AActor*>& out_children, FNetConstructionID constructionID) {
     UE_LOG(LogSmartHologram, Log, TEXT("SFSmartChildHologram::Construct: Building from hologram %s"), *GetName());
-    
+
+    // [MP-SLICE0] TEMP multiplayer instrumentation — remove before release.
+    // Server-side per-child signal (foundation family): if this fires with HasAuthority=1 on
+    // a CLIENT-initiated build, the previewed foundation child round-tripped to the server.
+    // NetMode: 0=Standalone 1=DedicatedServer 2=ListenServer 3=Client.
+    {
+        const int32 NetMode = GetWorld() ? (int32)GetWorld()->GetNetMode() : -1;
+        UE_LOG(LogSmartHologram, Display,
+            TEXT("[MP-SLICE0] SmartChild::Construct: %s NetMode=%d HasAuthority=%d"),
+            *GetName(), NetMode, HasAuthority() ? 1 : 0);
+    }
+
     // Call base construction to create the actual building
     AActor* ConstructedActor = Super::Construct(out_children, constructionID);
     

--- a/Source/SmartFoundations/Private/Module/SFGameInstanceModule.cpp
+++ b/Source/SmartFoundations/Private/Module/SFGameInstanceModule.cpp
@@ -22,6 +22,11 @@
 #include "Features/AutoConnect/SFAutoConnectService.h"
 #include "Features/Extend/SFExtendService.h"
 
+// MP Slice 0 (Phase 1): client construct chunk guard
+#include "Equipment/FGBuildGunBuild.h"        // UFGBuildGunStateBuild::InternalConstructHologram / GetHologram
+#include "Core/Helpers/SFNetworkHelper.h"     // FSFNetworkHelper::IsClient
+#include "Engine/Engine.h"                     // GEngine on-screen message
+
 // For chain actor rebuilding
 #include "Buildables/FGBuildableConveyorBase.h"
 #include "Buildables/FGBuildableConveyorBelt.h"
@@ -75,6 +80,10 @@ void USFGameInstanceModule::DispatchLifecycleEvent(ELifecyclePhase Phase)
 		// #341: Register SML hook on the belt-support parent Construct (in-frame chain registration;
 		// one hook covers stackable / wall / ceiling - see RegisterBeltSupportConstructHook).
 		RegisterBeltSupportConstructHook();
+
+		// MP Slice 0 (Phase 1): guard a client against committing an oversized scaled grid in one
+		// construct RPC (the all-or-nothing drop + orphaned-preview bug). See the method comment.
+		RegisterClientConstructChunkGuardHook();
 
 	}
 }
@@ -290,4 +299,83 @@ void USFGameInstanceModule::RegisterBeltSupportConstructHook()
 	);
 
 	UE_LOG(LogSmartFoundations, Verbose, TEXT("✅ AFGConveyorPoleHologram::Construct hook registered (#341 belt-support chain registration: stackable/wall/ceiling)"));
+}
+
+// MP Slice 0 (Phase 1) - construct chunk guard.
+// Empirical hard ceiling on a single client->server construct: ~137 foundations / ~135 constructors per
+// placement (the parent + all child holograms serialize into one reliable Server_ConstructHologram RPC whose
+// blob exceeds UE's reliable partial-bunch byte limit and is dropped at the net layer). We refuse a client
+// placement above a conservative cell count BELOW that edge (heavier holograms may serialize larger and fail
+// sooner, so we leave margin). This is a temporary safety net; Phase 2 will auto-chunk into sub-constructs.
+static constexpr int32 SF_MP_MAX_SINGLE_CONSTRUCT_CELLS = 120;
+
+void USFGameInstanceModule::RegisterClientConstructChunkGuardHook()
+{
+	SUBSCRIBE_METHOD(
+		UFGBuildGunStateBuild::InternalConstructHologram,
+		[](auto& scope, UFGBuildGunStateBuild* self, FNetConstructionID clientNetConstructID)
+		{
+			if (!self)
+			{
+				return;
+			}
+
+			// Only a true network client (NM_Client) serializes the construct over the wire and can hit the
+			// byte ceiling. Single-player, listen-server host, and dedicated-server authority construct locally
+			// (or already have authority) and must take the untouched vanilla one-shot path.
+			UWorld* World = self->GetWorld();
+			if (!World || !FSFNetworkHelper::IsClient(World))
+			{
+				return;
+			}
+
+			AFGHologram* Holo = self->GetHologram();
+			if (!Holo)
+			{
+				return;
+			}
+
+			// Count Smart grid child holograms (tagged SF_GridChild during scaled-grid spawn). +1 for the
+			// parent/origin cell, which is the active hologram itself (not a child).
+			static const FName GridChildTag(TEXT("SF_GridChild"));
+			int32 GridChildCount = 0;
+			for (const AFGHologram* Child : Holo->GetHologramChildren())
+			{
+				if (Child && Child->Tags.Contains(GridChildTag))
+				{
+					++GridChildCount;
+				}
+			}
+
+			if (GridChildCount == 0)
+			{
+				return; // Not a Smart scaled grid (no tagged children) -> vanilla path.
+			}
+
+			const int32 TotalCells = GridChildCount + 1;
+			if (TotalCells <= SF_MP_MAX_SINGLE_CONSTRUCT_CELLS)
+			{
+				return; // Small enough to fit one construct RPC -> vanilla path (works in MP).
+			}
+
+			// Oversized grid on a client: the single Server_ConstructHologram RPC would be dropped at the net
+			// layer (all-or-nothing) and orphan the previews (no failure callback fires because the server
+			// never processes it). Cancel the construct BEFORE it is sent. Nothing orphans - the active
+			// hologram and its preview children stay live, so the player can scale down and build.
+			UE_LOG(LogSmartFoundations, Display,
+				TEXT("[MP-CHUNK] Blocked oversized client construct: %d cells (> %d). A single-RPC construct of this size exceeds the multiplayer limit (~135) and would be dropped. Preview kept; advise smaller sections."),
+				TotalCells, SF_MP_MAX_SINGLE_CONSTRUCT_CELLS);
+
+			if (GEngine)
+			{
+				GEngine->AddOnScreenDebugMessage(-1, 6.0f, FColor::Orange,
+					FString::Printf(TEXT("Smart!: grid too large for multiplayer (%d cells, max ~%d). Build in smaller sections."),
+						TotalCells, SF_MP_MAX_SINGLE_CONSTRUCT_CELLS));
+			}
+
+			scope.Cancel(); // suppress vanilla InternalConstructHologram -> no oversized RPC is sent.
+		}
+	);
+
+	UE_LOG(LogSmartFoundations, Verbose, TEXT("✅ Client construct chunk-guard hook registered (MP Slice 0 Phase 1)"));
 }

--- a/Source/SmartFoundations/Private/Module/SFGameInstanceModule.cpp
+++ b/Source/SmartFoundations/Private/Module/SFGameInstanceModule.cpp
@@ -1044,11 +1044,24 @@ void USFGameInstanceModule::RegisterSpecConstructionHooks()
 			// [EXTEND-MP] A staged Extend commit overrides with the EXACT preview cost captured
 			// client-side (parent + all clone children) - the childless server parent would
 			// otherwise charge the bare factory only.
+			//
+			// THE 12-CRASH WILD-FREE BUG LIVED HERE (root-caused via hardware watchpoint,
+			// 2026-06-10): scope.Override() WITHOUT a prior scope() invocation. For a hooked
+			// method returning TArray BY VALUE, SML's invoker (ApplyCallUserTypeByValue)
+			// move-ASSIGNS the override into the return slot - and if the original was never
+			// invoked, that slot is UNINITIALIZED, so TArray::operator= frees whatever garbage
+			// Data pointer the stack held. In CheckCanAfford's frame (dedi mirror build gun,
+			// costs ON, every tick while aiming) that garbage was the AIMED-AT BUILDING's
+			// address: FMemory::Free(liveActor) -> freelist scribble over its vtable -> the
+			// freed-pointer factory-tick AV minutes later. RULE: NEVER Override a by-value
+			// return without invoking scope() first to construct the slot (the scaling branch
+			// below always did - which is why scaled costs never crashed).
 			FSFExtendCommitSpec ExtendSpec;
 			if (FindStagedExtendCommit(self, ExtendSpec, /*bConsume=*/false))
 			{
 				if (MutableSelf->GetHologramChildren().Num() == 0 && ExtendSpec.Cost.Num() > 0)
 				{
+					scope(self, includeChildren); // initialize the return slot FIRST
 					scope.Override(ExtendSpec.Cost);
 				}
 				return;

--- a/Source/SmartFoundations/Private/Module/SFGameInstanceModule.cpp
+++ b/Source/SmartFoundations/Private/Module/SFGameInstanceModule.cpp
@@ -812,6 +812,34 @@ void USFGameInstanceModule::RegisterSpecConstructionHooks()
 {
 	static const FName GridChildTag(TEXT("SF_GridChild"));
 
+	// [CHAIN-FIX] Stale tick-group entry guard. A conveyor whose cached mConveyorBucketID points
+	// at the WRONG tick group makes vanilla RemoveConveyor silently fail in shipping (the assert
+	// is compiled out) - the belt stays in some OTHER TG->Conveyors array, gets destroyed by the
+	// dismantle, GC frees the memory ~1-2 min later, and TickFactoryActors' ParallelFor calls
+	// through the freed pointer (EXCEPTION_ACCESS_VIOLATION at FGBuildableSubsystem.cpp:644 -
+	// reproduced three times on 2026-06-10, each ~2 min after building/dismantling auto-connect
+	// belts). AFTER vanilla RemoveConveyor runs, sweep every tick group and force-remove any
+	// lingering entry for this belt. Plain SUBSCRIBE_METHOD is correct: RemoveConveyor is a
+	// non-virtual member (the no-plain-subscribe rule applies to virtuals only).
+	SUBSCRIBE_METHOD(
+		AFGBuildableSubsystem::RemoveConveyor,
+		[](auto& scope, AFGBuildableSubsystem* self, AFGBuildableConveyorBase* conveyor)
+		{
+			scope(self, conveyor);
+			if (!self || !conveyor)
+			{
+				return;
+			}
+			// Sweep lives in the chain service (mConveyorTickGroup access grant).
+			if (USFSubsystem* SS = USFSubsystem::Get(self->GetWorld()))
+			{
+				if (USFChainActorService* ChainSvc = SS->GetChainActorService())
+				{
+					ChainSvc->RemoveConveyorFromAllTickGroups(conveyor);
+				}
+			}
+		});
+
 	// Count the Smart grid children currently attached to a hologram (the strip/expand targets).
 	auto CountGridChildren = [](AFGHologram* Holo) -> int32
 	{

--- a/Source/SmartFoundations/Private/Module/SFGameInstanceModule.cpp
+++ b/Source/SmartFoundations/Private/Module/SFGameInstanceModule.cpp
@@ -544,6 +544,9 @@ void USFGameInstanceModule::RegisterClientGridChunkFireHook()
 								ExtendSpec.Cost = Holo->GetCost(true); // parent + preview children
 								ExtendSpec.BuildClass = Holo->GetBuildClass();
 								ExtendSpec.SourceBuilding = Topo.SourceBuilding.Get();
+								// Scaled Extend: ship the per-clone PARAMETERS; the server re-runs
+								// the same spawn pipeline against its own authoritative walk.
+								Extend->GetScaledClonePlanForCommit(ExtendSpec.ScaledClones);
 								ExtendSpec.bValid = ExtendSpec.Clone.ChildHolograms.Num() > 0;
 							}
 						}
@@ -1007,6 +1010,11 @@ void USFGameInstanceModule::RegisterSpecConstructionHooks()
 						UE_LOG(LogSmartFoundations, Display,
 							TEXT("[EXTEND-MP] Server reconstructed %d/%d clone children (%d pre-wired) for %s; vanilla construct will build them."),
 							NumSpawned, ExtendSpec.Clone.ChildHolograms.Num(), NumWired, *self->GetName());
+
+						// Scaled Extend: re-run the SP spawn pipeline for the additional clone
+						// sets (factory children + infrastructure + lanes) from the shipped
+						// per-clone parameters + the server's own authoritative topology walk.
+						Extend->ReconstructScaledCommitOnServer(self, ExtendSpec.ScaledClones);
 					}
 				}
 			}

--- a/Source/SmartFoundations/Private/Module/SFGameInstanceModule.cpp
+++ b/Source/SmartFoundations/Private/Module/SFGameInstanceModule.cpp
@@ -840,6 +840,38 @@ void USFGameInstanceModule::RegisterSpecConstructionHooks()
 			}
 		});
 
+	// [CHAIN-FIX] Destruction chokepoint guard. The 4th freed-pointer tick AV reproduced with NO
+	// dismantle and NO build (hover extend -> look away -> re-aim), with the RemoveConveyor guard
+	// silent - so some conveyor destruction path never calls RemoveConveyor at all and leaves the
+	// belt in a tick-group array. EndPlay fires for EVERY destruction path; the before-hook sweeps
+	// the tick groups while the object is still alive and logs WHICH belt + WHY it died, naming
+	// the leaking path. AFGBuildableConveyorBase overrides EndPlay (primary-class virtual), so the
+	// CDO resolves the conveyor-specific body - the hook fires only for conveyors.
+	AFGBuildableConveyorBase* ConveyorBaseCDO = GetMutableDefault<AFGBuildableConveyorBase>();
+	SUBSCRIBE_METHOD_VIRTUAL(AFGBuildableConveyorBase::EndPlay, ConveyorBaseCDO,
+		[](auto& scope, AFGBuildableConveyorBase* self, const EEndPlayReason::Type endPlayReason)
+		{
+			if (self && self->HasAuthority())
+			{
+				if (UWorld* World = self->GetWorld())
+				{
+					if (USFSubsystem* SS = USFSubsystem::Get(World))
+					{
+						if (USFChainActorService* ChainSvc = SS->GetChainActorService())
+						{
+							const int32 Removed = ChainSvc->RemoveConveyorFromAllTickGroups(self);
+							if (Removed > 0)
+							{
+								UE_LOG(LogSmartFoundations, Display,
+									TEXT("[CHAIN-DIAG] EndPlay guard: %s died (reason=%d) while STILL in %d tick group(s) - leak path identified, freed-pointer tick AV prevented."),
+									*self->GetName(), static_cast<int32>(endPlayReason), Removed);
+							}
+						}
+					}
+				}
+			}
+		});
+
 	// Count the Smart grid children currently attached to a hologram (the strip/expand targets).
 	auto CountGridChildren = [](AFGHologram* Holo) -> int32
 	{

--- a/Source/SmartFoundations/Private/Module/SFGameInstanceModule.cpp
+++ b/Source/SmartFoundations/Private/Module/SFGameInstanceModule.cpp
@@ -748,10 +748,23 @@ void USFGameInstanceModule::RegisterSpecConstructionHooks()
 						}
 
 						FSFReservedInputsMap ReservedInputs;
-						int32 BeltPreviews = AutoConnect->ProcessSingleDistributor(self, &ReservedInputs).Num();
-						for (AFGHologram* Distributor : DistributorChildren)
+						int32 BeltPreviews = 0;
+
+						TArray<AFGHologram*> AllDistributors;
+						AllDistributors.Add(self);
+						AllDistributors.Append(DistributorChildren);
+						for (AFGHologram* Distributor : AllDistributors)
 						{
-							BeltPreviews += AutoConnect->ProcessSingleDistributor(Distributor, &ReservedInputs).Num();
+							// [MP-334] TEMP diagnostic: the first live round returned 0 previews for
+							// every distributor while the aim-time pipeline succeeds on the same
+							// hologram - log the raw inputs of the decision at this exact moment.
+							const FVector DistLoc = Distributor->GetActorLocation();
+							const int32 NearbyCount = SS->FindNearbyBuildings(DistLoc, 2500.0f).Num();
+							const int32 Made = AutoConnect->ProcessSingleDistributor(Distributor, &ReservedInputs).Num();
+							BeltPreviews += Made;
+							UE_LOG(LogSmartFoundations, Display,
+								TEXT("[MP-334]   distributor %s at %s: nearbyBuildings=%d -> beltPreviews=%d"),
+								*Distributor->GetName(), *DistLoc.ToCompactString(), NearbyCount, Made);
 						}
 
 						UE_LOG(LogSmartFoundations, Display,

--- a/Source/SmartFoundations/Private/Module/SFGameInstanceModule.cpp
+++ b/Source/SmartFoundations/Private/Module/SFGameInstanceModule.cpp
@@ -403,9 +403,11 @@ static constexpr int32 SF_MP_CHUNK_CHILDREN  = 100; // grid children to build pe
 // straight through to vanilla without re-chunking.
 static bool GSFChunkingInProgress = false;
 
-// Set the active hologram's child list to exactly the given actors (friend access to mChildren/lookup map).
-static void SF_SetHologramChildren(AFGHologram* Holo, const TArray<AFGHologram*>& NewChildren)
+// Set the active hologram's child list to exactly the given actors. Static member of USFGameInstanceModule so
+// it inherits the friend access to AFGHologram::mChildren / mChildrenNameLookupMap (AccessTransformers.ini).
+void USFGameInstanceModule::SetActiveHologramChildren(AFGHologram* Holo, const TArray<AFGHologram*>& NewChildren)
 {
+	if (!Holo) { return; }
 	Holo->mChildren.Reset();
 	Holo->mChildrenNameLookupMap.Reset();
 	for (AFGHologram* C : NewChildren)
@@ -504,7 +506,7 @@ void USFGameInstanceModule::RegisterClientGridChunkFireHook()
 
 			// Chunk 0
 			Holo->SetActorTransform(OriginXform);
-			SF_SetHologramChildren(Holo, Chunk0);
+			USFGameInstanceModule::SetActiveHologramChildren(Holo, Chunk0);
 			UE_LOG(LogSmartFoundations, Display, TEXT("[MP-CHUNK] Increment 2a: firing chunk 0 (%d children) at origin"), Chunk0.Num());
 			self->InternalExecuteDuBuildStepInput(false);
 
@@ -512,13 +514,13 @@ void USFGameInstanceModule::RegisterClientGridChunkFireHook()
 			if (Chunk1Anchor)
 			{
 				Holo->SetActorTransform(Chunk1Xform);
-				SF_SetHologramChildren(Holo, Chunk1);
+				USFGameInstanceModule::SetActiveHologramChildren(Holo, Chunk1);
 				UE_LOG(LogSmartFoundations, Display, TEXT("[MP-CHUNK] Increment 2a: firing chunk 1 (%d children) at repositioned parent (Kids[100])"), Chunk1.Num());
 				self->InternalExecuteDuBuildStepInput(false);
 			}
 
 			// Clean up: clear any leftover children + restore the parent to the crosshair origin.
-			SF_SetHologramChildren(Holo, TArray<AFGHologram*>());
+			USFGameInstanceModule::SetActiveHologramChildren(Holo, TArray<AFGHologram*>());
 			Holo->SetActorTransform(OriginXform);
 			GSFChunkingInProgress = false;
 		}

--- a/Source/SmartFoundations/Private/Module/SFGameInstanceModule.cpp
+++ b/Source/SmartFoundations/Private/Module/SFGameInstanceModule.cpp
@@ -428,6 +428,10 @@ static const FName GSFAutoConnectChildTags[] = {
 };
 static constexpr int32 GSFAutoConnectChildTagCount = UE_ARRAY_COUNT(GSFAutoConnectChildTags);
 
+// Alias: a TMap<A,B> inside a SUBSCRIBE macro argument splits the macro args on the template
+// comma (third occurrence of this gotcha - see the multi-capture and brace-initializer notes).
+using FSFReservedInputsMap = TMap<UFGFactoryConnectionComponent*, AFGHologram*>;
+
 void USFGameInstanceModule::RegisterClientGridChunkFireHook()
 {
 	SUBSCRIBE_METHOD(
@@ -520,11 +524,12 @@ void USFGameInstanceModule::RegisterClientGridChunkFireHook()
 				USFBuildableSizeRegistry::Initialize();
 				if (USFBuildableSizeRegistry::GetProfile(Holo->GetBuildClass()).bSupportsScaling)
 				{
+					// Capture even for a 1x1 (no grid children): the staged spec is also what routes
+					// the construct through the server-side Construct hook, where auto-connect
+					// wiring is re-derived with authority (#334) - a single distributor with belts
+					// needs that as much as a grid does.
 					FSFScalingSpec Spec; // bValid=false by default = explicit clear
-					if (GridChildCount > 0)
-					{
-						SFScalingSpecExpansion::CaptureScalingSpec(Holo, Spec);
-					}
+					SFScalingSpecExpansion::CaptureScalingSpec(Holo, Spec);
 
 					// Stage (or clear) the spec server-side BEFORE the construct RPC goes out.
 					bool bStaged = false;
@@ -716,6 +721,45 @@ void USFGameInstanceModule::RegisterSpecConstructionHooks()
 			if (CountGridChildren(self) == 0)
 			{
 				SFScalingSpecExpansion::ExpandScalingSpecIntoChildren(self, Spec, self->GetRecipe());
+			}
+
+			// [MP-334] Server-side auto-connect wiring. Re-run the belt decision pipeline on the
+			// parent + the expanded grid children RIGHT BEFORE construct: the service attaches the
+			// resulting belt previews as REAL child holograms (the conduit base AddChilds them),
+			// so the vanilla child-construct loop below builds + wires them - the exact mechanism
+			// SP uses, executed where authority lives. (The client's preview belt children are
+			// stripped at fire - they crash the server in deserialization - and the server's own
+			// mirror previews are clobbered when the construct message deserializes into it, so
+			// this re-derivation is the authoritative source of MP wiring.)
+			if (USFSubsystem* SS = USFSubsystem::Get(self->GetWorld()))
+			{
+				if (USFAutoConnectService* AutoConnect = SS->GetAutoConnectService())
+				{
+					if (USFAutoConnectService::IsDistributorHologram(self))
+					{
+						// Copy the child list first: processing appends belt children to it.
+						TArray<AFGHologram*> DistributorChildren;
+						for (AFGHologram* Child : self->GetHologramChildren())
+						{
+							if (Child && USFAutoConnectService::IsDistributorHologram(Child))
+							{
+								DistributorChildren.Add(Child);
+							}
+						}
+
+						FSFReservedInputsMap ReservedInputs;
+						int32 BeltPreviews = AutoConnect->ProcessSingleDistributor(self, &ReservedInputs).Num();
+						for (AFGHologram* Distributor : DistributorChildren)
+						{
+							BeltPreviews += AutoConnect->ProcessSingleDistributor(Distributor, &ReservedInputs).Num();
+						}
+
+						UE_LOG(LogSmartFoundations, Display,
+							TEXT("[MP-334] Server-side auto-connect: %d belt previews attached pre-construct ")
+							TEXT("(parent + %d grid distributors); vanilla construct will build + wire them."),
+							BeltPreviews, DistributorChildren.Num());
+					}
+				}
 			}
 
 			// Spawn the group proxy BEFORE construction and expose it for the window of this

--- a/Source/SmartFoundations/Private/Module/SFGameInstanceModule.cpp
+++ b/Source/SmartFoundations/Private/Module/SFGameInstanceModule.cpp
@@ -885,6 +885,26 @@ void USFGameInstanceModule::RegisterSpecConstructionHooks()
 			}
 		});
 
+	// [CHAIN-DIAG] Mid-tick SPAWN detector. Live forensics (repro 12) proved: Num grew 1843->1844
+	// DURING the crashing tick (the AddBuildable hook missed it - inlined call site), and the
+	// corrupt entry was a real actor whose first 16 bytes held an allocator freelist link with
+	// the rest of the actor (PrimaryActorTick vftable at +0x30) intact - i.e. a buildable is
+	// spawned, registered, destroyed, AND freed by the concurrent purge ALL WITHIN ONE FACTORY
+	// TICK. BeginPlay is virtual - it cannot be inlined away from this hook - so this names the
+	// short-lived buildable and its spawn callstack.
+	AFGBuildable* BuildableBeginPlayCDO = GetMutableDefault<AFGBuildable>();
+	SUBSCRIBE_METHOD_VIRTUAL(AFGBuildable::BeginPlay, BuildableBeginPlayCDO,
+		[](auto& scope, AFGBuildable* self)
+		{
+			if (bInsideFactoryTick && self && self->HasAuthority())
+			{
+				UE_LOG(LogSmartFoundations, Error,
+					TEXT("[CHAIN-DIAG] AFGBuildable::BeginPlay(%s / %s) DURING TickFactory - the mid-tick registration. Callstack follows."),
+					*self->GetName(), *GetNameSafe(self->GetClass()));
+				FDebug::DumpStackTraceToLog(ELogVerbosity::Error);
+			}
+		});
+
 	// Symmetric detector: a REMOVAL mid-tick can shrink-reallocate mFactoryBuildings, freeing the
 	// buffer under the ParallelFor workers just like a growth realloc (9th repro: Add detector
 	// silent, pre-tick scrub valid -> the mutation, whatever it is, happens DURING the tick).

--- a/Source/SmartFoundations/Private/Module/SFGameInstanceModule.cpp
+++ b/Source/SmartFoundations/Private/Module/SFGameInstanceModule.cpp
@@ -26,8 +26,6 @@
 #include "Equipment/FGBuildGunBuild.h"        // UFGBuildGunStateBuild::InternalConstructHologram / GetHologram
 #include "Core/Helpers/SFNetworkHelper.h"     // FSFNetworkHelper::IsClient
 #include "Engine/Engine.h"                     // GEngine on-screen message
-#include "Containers/Ticker.h"                 // FTSTicker for deferred one-per-frame chunk fires
-#include "UObject/CoreNet.h"                   // FNetBitWriter for hand-serializing the construct message
 
 // For chain actor rebuilding
 #include "Buildables/FGBuildableConveyorBase.h"
@@ -321,15 +319,6 @@ void USFGameInstanceModule::RegisterBeltSupportConstructHook()
 static constexpr int32 SF_MP_CONSTRUCT_MAX_BYTES = 60000; // cancel a Smart-grid construct above this
 static constexpr int32 SF_MP_CONSTRUCT_LOG_BYTES = 20000; // log any Smart-grid construct above this (capture real sizes)
 
-// Hand-serialization (full-auto) state. Declared before the guard hook because the guard hook captures
-// chunk 0's NetConstructionID into these. Chunk 0 is the player's natural fire; we capture the valid
-// FNetConstructionID vanilla minted for it, then derive subsequent chunk IDs (Client_ID + n) and hand-build
-// + send each remaining chunk's Server_ConstructHologram ourselves (the build gun only constructs on real
-// input). The biggest unknown is whether the server accepts the derived IDs.
-static FNetConstructionID GSFBaseConstructID;
-static bool GSFExpectingChunk0ID = false;
-static int32 GSFChunkSeq = 0;
-
 void USFGameInstanceModule::RegisterClientConstructChunkGuardHook()
 {
 	SUBSCRIBE_METHOD(
@@ -371,17 +360,6 @@ void USFGameInstanceModule::RegisterClientConstructChunkGuardHook()
 				return; // not a Smart scaled grid -> vanilla path (incl. blueprints)
 			}
 
-			// Chunk-0 of a chunked placement: capture the valid FNetConstructionID vanilla minted so the
-			// deferred ticker can derive IDs for the hand-sent chunks.
-			if (GSFExpectingChunk0ID)
-			{
-				GSFBaseConstructID = clientNetConstructID;
-				GSFExpectingChunk0ID = false;
-				UE_LOG(LogSmartFoundations, Display,
-					TEXT("[MP-CHUNK] captured chunk-0 NetConstructionID: NetPlayerID=%d Server_ID=%u Client_ID=%u"),
-					(int32)clientNetConstructID.NetPlayerID, clientNetConstructID.Server_ID, clientNetConstructID.Client_ID);
-			}
-
 			const int32 Bytes = data.SerializedHologramData.Num();
 
 			// Diagnostic: capture the real serialized size near/over the ceiling (confirms the byte limit).
@@ -417,112 +395,15 @@ void USFGameInstanceModule::RegisterClientConstructChunkGuardHook()
 	UE_LOG(LogSmartFoundations, Verbose, TEXT("✅ Client construct chunk-guard hook registered (MP Slice 0 Phase 1, Server_ConstructHologram)"));
 }
 
-// MP Slice 0 chunking. A Smart grid above this many total cells will not fit one 64KB Server_ConstructHologram.
-static constexpr int32 SF_MP_OVERSIZED_CELLS = 130; // trigger chunking above this (total cells incl. parent)
-static constexpr int32 SF_MP_CHUNK_CHILDREN  = 100; // grid children to build per chunk (parent adds 1 cell)
-static constexpr int32 SF_MP_CHUNK_WAIT_FRAMES = 6; // frames to let the build gun settle between chunk fires
-
-// Re-entrancy guard: the deferred chunk fires re-invoke InternalExecuteDuBuildStepInput; those nested calls
-// must pass straight through to vanilla without re-chunking.
-static bool GSFChunkingInProgress = false;
-
-// Deferred-chunk queue. chunk 0 builds on the player's natural fire; chunks 1+ are fired one-per-frame from a
-// ticker, AFTER the build gun settles, so each is a fresh fire instead of a synchronous re-entry (which the
-// build-gun state machine refuses). Each pending chunk repositions the active hologram to its anchor (a cell
-// the parent builds) and re-homes the chunk's other child holograms onto it.
-struct FSFPendingChunk
-{
-	FTransform AnchorXform;
-	TArray<TWeakObjectPtr<AFGHologram>> Children;
-};
-static TArray<FSFPendingChunk> GSFPendingChunks;
-static TWeakObjectPtr<UFGBuildGunStateBuild> GSFPendingGun;
-static int32 GSFChunkWait = 0;
-static FTSTicker::FDelegateHandle GSFChunkTicker;
-
-bool USFGameInstanceModule::TickPendingGridChunks(float /*Dt*/)
-{
-	if (GSFPendingChunks.Num() == 0)
-	{
-		GSFChunkTicker.Reset();
-		return false; // unregister
-	}
-	if (--GSFChunkWait > 0)
-	{
-		return true; // still letting the gun settle
-	}
-
-	UFGBuildGunStateBuild* Gun = GSFPendingGun.Get();
-	AFGHologram* Holo = Gun ? Gun->GetHologram() : nullptr;
-	if (!Gun || !Holo)
-	{
-		UE_LOG(LogSmartFoundations, Warning, TEXT("[MP-CHUNK] deferred: gun/hologram gone; aborting %d remaining chunk(s)."), GSFPendingChunks.Num());
-		GSFPendingChunks.Reset();
-		GSFChunkTicker.Reset();
-		return false;
-	}
-
-	FSFPendingChunk Chunk = GSFPendingChunks[0];
-	GSFPendingChunks.RemoveAt(0);
-
-	TArray<AFGHologram*> Kids;
-	for (const TWeakObjectPtr<AFGHologram>& W : Chunk.Children)
-	{
-		if (AFGHologram* C = W.Get()) { Kids.Add(C); }
-	}
-
-	// Set up the hologram as this chunk: repositioned to the anchor cell, children = the chunk's holograms.
-	Holo->SetActorTransform(Chunk.AnchorXform);
-	USFGameInstanceModule::SetActiveHologramChildren(Holo, Kids);
-
-	// Hand-build the construct message and send it directly (bypassing the build gun, which only constructs
-	// on real input). Derive this chunk's NetConstructionID from the captured chunk-0 ID (Client_ID + seq).
-	UWorld* World = Holo->GetWorld();
-	APlayerController* PC = World ? World->GetFirstPlayerController() : nullptr; // local PC on a client
-	UPackageMap* PackageMap = UFGBuildGunStateBuild::FindPackageMapForPlayerController(PC);
-
-	FNetConstructionID ChunkID = GSFBaseConstructID;
-	ChunkID.Server_ID = 0;
-	ChunkID.Client_ID = (uint16)(GSFBaseConstructID.Client_ID + (uint16)(++GSFChunkSeq));
-
-	Holo->PreConstructMessageSerialization();
-	FNetBitWriter Writer(PackageMap, 1 << 21); // 256 KB bit budget (a chunk is <64KB)
-	FNetConstructionID SerId = ChunkID;
-	Holo->SerializeConstructMessage(Writer, SerId);
-
-	FConstructHologramMessage Msg;
-	Msg.ConstructionID = ChunkID;
-	Msg.Recipe = Holo->GetRecipe();
-	Msg.NumBits = Writer.GetNumBits();
-	Msg.SerializedHologramData.Append(Writer.GetData(), (int32)Writer.GetNumBytes());
-
-	UE_LOG(LogSmartFoundations, Display,
-		TEXT("[MP-CHUNK] deferred: hand-sending chunk (%d children, %d bytes, Client_ID=%u, PackageMap=%s); %d chunk(s) left after this."),
-		Kids.Num(), Msg.SerializedHologramData.Num(), ChunkID.Client_ID, PackageMap ? TEXT("ok") : TEXT("NULL"), GSFPendingChunks.Num());
-
-	GSFChunkingInProgress = true;
-	Gun->Server_ConstructHologram(ChunkID, Msg);
-	GSFChunkingInProgress = false;
-
-	USFGameInstanceModule::SetActiveHologramChildren(Holo, TArray<AFGHologram*>());
-	GSFChunkWait = SF_MP_CHUNK_WAIT_FRAMES;
-	return true;
-}
-
-// Set the active hologram's child list to exactly the given actors. Static member of USFGameInstanceModule so
-// it inherits the friend access to AFGHologram::mChildren / mChildrenNameLookupMap (AccessTransformers.ini).
-void USFGameInstanceModule::SetActiveHologramChildren(AFGHologram* Holo, const TArray<AFGHologram*>& NewChildren)
-{
-	if (!Holo) { return; }
-	Holo->mChildren.Reset();
-	Holo->mChildrenNameLookupMap.Reset();
-	for (AFGHologram* C : NewChildren)
-	{
-		if (!C) { continue; }
-		Holo->mChildren.Add(C);
-		Holo->mChildrenNameLookupMap.Add(C->GetNameWithinParentHologram(), C);
-	}
-}
+// MP Slice 0 SAFETY GUARD. A Smart grid above this many total cells will not fit one 64KB
+// Server_ConstructHologram (empirical ceiling ~135 cells / 65536 bytes). Building such a grid on a CLIENT is
+// not safely achievable today: re-firing the build gun never constructs (single-construct-per-fire state
+// machine, proven), and hand-building the construct message CRASHES the dedicated server (proven - server
+// fatal in UNetDriver::InternalTickDispatch). So we REFUSE an oversized client grid at the fire handler,
+// BEFORE anything is serialized or sent: the grid stays live so the player can scale down and place in
+// smaller sections. This is a temporary guard, NOT a multiplayer feature - large-grid MP placement is part
+// of the future complete multiplayer solution (which cannot ship partially; see AGENTS.md).
+static constexpr int32 SF_MP_OVERSIZED_CELLS = 130; // refuse a client grid above this (total cells incl. parent)
 
 void USFGameInstanceModule::RegisterClientGridChunkFireHook()
 {
@@ -530,15 +411,15 @@ void USFGameInstanceModule::RegisterClientGridChunkFireHook()
 		UFGBuildGunStateBuild::InternalExecuteDuBuildStepInput,
 		[](auto& scope, UFGBuildGunStateBuild* self, bool isInputFromARelease)
 		{
-			if (!self || GSFChunkingInProgress)
+			if (!self)
 			{
-				return; // nested re-fire -> let vanilla run unmodified
+				return;
 			}
 
 			UWorld* World = self->GetWorld();
 			if (!World || !FSFNetworkHelper::IsClient(World))
 			{
-				return; // only a network client serializes over the wire
+				return; // only a network client serializes the construct over the wire
 			}
 
 			AFGHologram* Holo = self->GetHologram();
@@ -547,74 +428,44 @@ void USFGameInstanceModule::RegisterClientGridChunkFireHook()
 				return;
 			}
 
-			// Snapshot the Smart grid child holograms (tagged SF_GridChild), in order.
+			// Count Smart grid child holograms (tagged SF_GridChild). +1 for the parent/origin cell.
 			static const FName GridChildTag(TEXT("SF_GridChild"));
-			TArray<AFGHologram*> Kids;
-			for (const TObjectPtr<AFGHologram>& C : Holo->mChildren)
+			int32 GridChildCount = 0;
+			for (const AFGHologram* Child : Holo->GetHologramChildren())
 			{
-				if (C && C->Tags.Contains(GridChildTag))
+				if (Child && Child->Tags.Contains(GridChildTag))
 				{
-					Kids.Add(C.Get());
+					++GridChildCount;
 				}
 			}
-			if (Kids.Num() == 0)
+			if (GridChildCount == 0)
 			{
 				return; // not a Smart scaled grid
 			}
 
-			const int32 TotalCells = Kids.Num() + 1; // + parent/origin cell
+			const int32 TotalCells = GridChildCount + 1;
 			if (TotalCells <= SF_MP_OVERSIZED_CELLS)
 			{
-				return; // fits one construct -> untouched vanilla path
+				return; // fits one construct -> untouched vanilla path (builds fine in MP)
 			}
 
-			// INCREMENT 2b (deferred full-auto): chunk 0 builds on THIS natural fire; the rest are queued and
-			// fired one-per-frame from a ticker (after the build gun settles), because the build gun refuses a
-			// synchronous second construct in one fire (proven in 2a).
-
-			// Chunk 0: keep the first SF_MP_CHUNK_CHILDREN grid children on the parent. Vanilla builds the
-			// parent's own origin cell + these on this fire (do NOT cancel).
-			TArray<AFGHologram*> Chunk0;
-			for (int32 i = 0; i < Kids.Num() && Chunk0.Num() < SF_MP_CHUNK_CHILDREN; ++i)
-			{
-				Chunk0.Add(Kids[i]);
-			}
-			USFGameInstanceModule::SetActiveHologramChildren(Holo, Chunk0);
-
-			// Queue the remaining cells as deferred chunks. Each chunk's first leftover cell becomes the
-			// repositioned-parent anchor (its preview is destroyed now; the repositioned parent builds that
-			// cell in the ticker); the rest become the chunk's re-homed children.
-			GSFPendingChunks.Reset();
-			for (int32 Start = SF_MP_CHUNK_CHILDREN; Start < Kids.Num(); Start += SF_MP_CHUNK_CHILDREN)
-			{
-				AFGHologram* Anchor = Kids[Start];
-				if (!Anchor) { continue; }
-				FSFPendingChunk PC;
-				PC.AnchorXform = Anchor->GetActorTransform();
-				for (int32 j = Start + 1; j < Kids.Num() && (j - Start) < SF_MP_CHUNK_CHILDREN; ++j)
-				{
-					if (Kids[j]) { PC.Children.Add(Kids[j]); }
-				}
-				GSFPendingChunks.Add(MoveTemp(PC));
-				Anchor->Destroy();
-			}
-
-			GSFPendingGun = self;
-			GSFChunkWait = SF_MP_CHUNK_WAIT_FRAMES;
-			GSFExpectingChunk0ID = true; // capture chunk 0's NetConstructionID in the Server_ConstructHologram hook
-			GSFChunkSeq = 0;
-			if (!GSFChunkTicker.IsValid())
-			{
-				GSFChunkTicker = FTSTicker::GetCoreTicker().AddTicker(FTickerDelegate::CreateStatic(&USFGameInstanceModule::TickPendingGridChunks), 0.0f);
-			}
-
+			// Oversized: refuse the fire BEFORE vanilla serializes/sends. The active hologram + preview stay
+			// live (no teardown, no orphaned previews, no dropped RPC, no server crash). The player scales
+			// down and places in smaller sections.
 			UE_LOG(LogSmartFoundations, Display,
-				TEXT("[MP-CHUNK] Increment 2b (deferred): %d cells -> chunk 0 = parent + %d (building now); queued %d more chunk(s) for one-per-frame fire."),
-				TotalCells, Chunk0.Num(), GSFPendingChunks.Num());
+				TEXT("[MP-CHUNK] Refused oversized client grid: %d cells (> %d). One construct can't carry this many over the wire safely; build in smaller sections."),
+				TotalCells, SF_MP_OVERSIZED_CELLS);
 
-			// Do NOT cancel: vanilla builds chunk 0 now; the ticker fires the queued chunks.
+			if (GEngine)
+			{
+				GEngine->AddOnScreenDebugMessage(-1, 6.0f, FColor::Orange,
+					FString::Printf(TEXT("Smart!: grid too large for multiplayer (%d cells, max ~%d). Build in smaller sections."),
+						TotalCells, SF_MP_OVERSIZED_CELLS));
+			}
+
+			scope.Cancel(); // suppress the fire -> nothing is serialized or sent; the grid stays live.
 		}
 	);
 
-	UE_LOG(LogSmartFoundations, Verbose, TEXT("✅ Client grid chunk fire-hook registered (MP Slice 0 chunking, InternalExecuteDuBuildStepInput)"));
+	UE_LOG(LogSmartFoundations, Verbose, TEXT("✅ Client grid oversized-guard fire-hook registered (MP Slice 0 safety, InternalExecuteDuBuildStepInput)"));
 }

--- a/Source/SmartFoundations/Private/Module/SFGameInstanceModule.cpp
+++ b/Source/SmartFoundations/Private/Module/SFGameInstanceModule.cpp
@@ -22,6 +22,7 @@
 // SML hooking for cost aggregation and blueprint construct
 #include "Patching/NativeHookManager.h"
 #include "Subsystem/SFSubsystem.h"
+#include "Services/SFChainActorService.h"  // [CHAIN-FIX] post-construct chain-hygiene sweep
 #include "Features/AutoConnect/SFAutoConnectService.h"
 #include "Features/Extend/SFExtendService.h"
 
@@ -1143,6 +1144,21 @@ void USFGameInstanceModule::RegisterSpecConstructionHooks()
 					*GetNameSafe(BuiltParent), out_children.Num());
 				// If nothing registered (neither actors nor lightweights), let it clean itself up.
 				GroupProxy->ValidateExistanceOtherwiseSelfDestruct();
+			}
+
+			// [CHAIN-FIX] Run the chain-hygiene sweep shortly after EVERY server-side spec/extend
+			// construct: it purges detached chains AND re-registers any connected-but-chainless
+			// belt. The thesis factory-tick AV (FGBuildableSubsystem.cpp:644, virtual call into
+			// freed/garbage memory minutes after a build) reproduced twice on 2026-06-10 in
+			// sessions whose only Smart activity was 1x1 conduit-plan builds - the sweep only ran
+			// at boot and post-upgrade, leaving the spec-build path uncovered. Timer is coalesced;
+			// scheduling per construct is cheap.
+			if (USFSubsystem* SweepSS = USFSubsystem::Get(self->GetWorld()))
+			{
+				if (USFChainActorService* ChainSvc = SweepSS->GetChainActorService())
+				{
+					ChainSvc->ScheduleDeferredZombiePurge(3.0f);
+				}
 			}
 
 			scope.Override(BuiltParent);

--- a/Source/SmartFoundations/Private/Module/SFGameInstanceModule.cpp
+++ b/Source/SmartFoundations/Private/Module/SFGameInstanceModule.cpp
@@ -27,11 +27,12 @@
 #include "Core/Helpers/SFNetworkHelper.h"     // FSFNetworkHelper::IsClient
 #include "Engine/Engine.h"                     // GEngine on-screen message
 
-// MP spec-based construction: class-agnostic hooks + guard bypass
+// MP spec-based construction: class-agnostic hooks + RCO spec staging
 #include "Holograms/Core/SFScalingSpecExpansion.h"
 #include "Data/SFBuildableSizeRegistry.h"
-#include "Data/SFHologramDataRegistry.h"
-#include "Subsystem/SFHologramDataService.h"
+#include "Subsystem/SFHologramHelperService.h"
+#include "SFRCO.h"
+#include "FGPlayerController.h"
 
 // For chain actor rebuilding
 #include "Buildables/FGBuildableConveyorBase.h"
@@ -438,22 +439,6 @@ void USFGameInstanceModule::RegisterClientGridChunkFireHook()
 				return;
 			}
 
-			// [MP-SPEC] When spec-based construction is enabled and the buildable is Smart-scalable
-			// (size registry), the SerializeConstructMessage hook strips the grid children and the
-			// message is O(1) - the oversized refusal must NOT fire. Non-scalable grids (none today)
-			// keep the guard; with the CVar off the guard stays fully authoritative.
-			if (SFScalingSpecExpansion::IsSpecConstructionEnabled())
-			{
-				USFBuildableSizeRegistry::Initialize();
-				if (USFBuildableSizeRegistry::GetProfile(Holo->GetBuildClass()).bSupportsScaling)
-				{
-					UE_LOG(LogSmartFoundations, Display,
-						TEXT("[MP-SPEC] Oversized guard bypassed: %s commits via the compact spec path."),
-						*Holo->GetName());
-					return;
-				}
-			}
-
 			// Count Smart grid child holograms (tagged SF_GridChild). +1 for the parent/origin cell.
 			static const FName GridChildTag(TEXT("SF_GridChild"));
 			int32 GridChildCount = 0;
@@ -464,6 +449,73 @@ void USFGameInstanceModule::RegisterClientGridChunkFireHook()
 					++GridChildCount;
 				}
 			}
+
+			// [MP-SPEC] Spec path (class-agnostic): when enabled and the buildable is Smart-scalable
+			// (size registry), the CLIENT commits the grid as a compact spec:
+			//   1. capture the spec from the live grid (invalid when no grid - an explicit CLEAR),
+			//   2. stage it on the server via the USFRCO reliable RPC (overwrite semantics, so a
+			//      stale spec from an earlier failed construct can never leak into a later fire),
+			//   3. destroy the local preview children through the grid-spawner's own proven cleanup
+			//      (no strip/restore around vanilla serialization - that timing caused the orphan
+			//      bug and the interface-virtual hook crash; the sticky grid counters regenerate the
+			//      preview on the next hologram automatically, matching legacy UX),
+			//   4. let the fire proceed: it serializes a clean 1-cell hologram (O(1) message); the
+			//      server's Construct hook consumes the staged spec and expands the grid.
+			if (SFScalingSpecExpansion::IsSpecConstructionEnabled())
+			{
+				USFBuildableSizeRegistry::Initialize();
+				if (USFBuildableSizeRegistry::GetProfile(Holo->GetBuildClass()).bSupportsScaling)
+				{
+					FSFScalingSpec Spec; // bValid=false by default = explicit clear
+					if (GridChildCount > 0)
+					{
+						SFScalingSpecExpansion::CaptureScalingSpec(Holo, Spec);
+					}
+
+					// Stage (or clear) the spec server-side BEFORE the construct RPC goes out.
+					bool bStaged = false;
+					if (APawn* InstigatorPawn = Holo->GetConstructionInstigator())
+					{
+						if (AFGPlayerController* PC = Cast<AFGPlayerController>(InstigatorPawn->GetController()))
+						{
+							if (USFRCO* RCO = PC->GetRemoteCallObjectOfClass<USFRCO>())
+							{
+								RCO->Server_StageScalingSpec(Spec);
+								bStaged = true;
+							}
+						}
+					}
+
+					if (Spec.bValid && bStaged)
+					{
+						UE_LOG(LogSmartFoundations, Display,
+							TEXT("[MP-SPEC] Client fire: staged spec (%d cells of %s), destroying %d preview children; construct message will be O(1)."),
+							Spec.CellCount(), *GetNameSafe(*Spec.BuildClass), GridChildCount);
+
+						// Destroy the preview grid through the helper's own cleanup (tracking stays
+						// consistent; the sticky counters regenerate the grid on the next hologram).
+						if (USFSubsystem* SS = USFSubsystem::Get(World))
+						{
+							if (FSFHologramHelperService* Helper = SS->GetHologramHelper())
+							{
+								Helper->DestroyAllChildren();
+							}
+						}
+					}
+					else if (!bStaged && Spec.bValid)
+					{
+						UE_LOG(LogSmartFoundations, Warning,
+							TEXT("[MP-SPEC] Client fire: could not reach USFRCO to stage the spec - falling through to the legacy path/guard."));
+					}
+
+					if (Spec.bValid && bStaged)
+					{
+						return; // fire proceeds with the (now childless) hologram
+					}
+					// else: no grid (clear staged) or no RCO -> fall through to legacy guard logic
+				}
+			}
+
 			if (GridChildCount == 0)
 			{
 				return; // not a Smart scaled grid
@@ -519,96 +571,38 @@ void USFGameInstanceModule::RegisterSpecConstructionHooks()
 	// FNativeHookManagerInternal::RegisterHookFunction). SUBSCRIBE_METHOD_VIRTUAL resolves the
 	// actual body from the CDO's vtable - and hooking the BASE body fires for the entire Super
 	// chain (same mechanism the belt-support Construct hook above relies on).
+	//
+	// IMPORTANT: only PRIMARY-class virtuals may be hooked. SerializeConstructMessage (and the
+	// Pre/Post message methods) come from IFGConstructionMessageInterface - a SECONDARY base - and
+	// hooking them delivers an interface-adjusted `this` (live crash 2026-06-09: self off by the
+	// interface offset, EXCEPTION_ACCESS_VIOLATION in the first member read). The spec therefore
+	// crosses the wire via USFRCO::Server_StageScalingSpec (staged per player at fire time by the
+	// fire hook above), NOT by injecting into the construct message.
 	AFGHologram* HologramCDO = GetMutableDefault<AFGHologram>();
 	AFGBuildableHologram* BuildableHologramCDO = GetMutableDefault<AFGBuildableHologram>();
 
-	// ── Hook 1: the construct message. AFGHologram::SerializeConstructMessage is the base body of
-	// the Super chain for every hologram class (BP wrappers cannot override C++ virtuals), and it
-	// is where the child tree is serialized. Wrap it symmetrically on both sides.
-	SUBSCRIBE_METHOD_VIRTUAL(AFGHologram::SerializeConstructMessage, HologramCDO,
-		[CountGridChildren](auto& scope, AFGHologram* self, FArchive& ar, FNetConstructionID id)
+	// Resolve the staged spec for a constructing/costing hologram (server side).
+	auto FindStagedSpec = [](const AFGHologram* Holo, FSFScalingSpec& OutSpec, bool bConsume) -> bool
+	{
+		AFGHologram* MutableHolo = const_cast<AFGHologram*>(Holo);
+		USFSubsystem* SS = USFSubsystem::Get(MutableHolo->GetWorld());
+		if (!SS)
 		{
-			if (!self || !SFScalingSpecExpansion::IsSpecConstructionEnabled())
-			{
-				return; // original runs untouched; no spec byte is written/read (symmetric: CVar
-				        // matches across client+server because both run this same module).
-			}
+			return false;
+		}
+		APawn* Instigator = MutableHolo->GetConstructionInstigator();
+		UClass* BuildClass = MutableHolo->GetBuildClass();
+		return bConsume
+			? SS->ConsumeScalingSpecForInstigator(Instigator, BuildClass, OutSpec)
+			: SS->PeekScalingSpecForInstigator(Instigator, BuildClass, OutSpec);
+	};
 
-			if (ar.IsSaving())
-			{
-				// CLIENT (fire): capture the grid into a compact spec and strip the grid children
-				// so the original writes an O(1) message; append the spec; restore the children so
-				// the post-fire teardown destroys the previews normally.
-				FSFScalingSpec Spec;
-				TArray<AFGHologram*> Stash;
-
-				const int32 TaggedChildren = CountGridChildren(self);
-				bool bHasSpec = false;
-				if (TaggedChildren > 0)
-				{
-					USFBuildableSizeRegistry::Initialize();
-					if (USFBuildableSizeRegistry::GetProfile(self->GetBuildClass()).bSupportsScaling
-						&& SFScalingSpecExpansion::CaptureScalingSpec(self, Spec))
-					{
-						bHasSpec = true;
-						for (int32 i = self->mChildren.Num() - 1; i >= 0; --i)
-						{
-							AFGHologram* Child = self->mChildren[i];
-							if (Child && Child->Tags.Contains(GridChildTag))
-							{
-								Stash.Add(Child);
-								self->mChildren.RemoveAt(i);
-							}
-						}
-					}
-				}
-
-				scope(self, ar, id); // original writes the (possibly childless) hologram
-
-				ar << bHasSpec;
-				if (bHasSpec)
-				{
-					FSFScalingSpec::StaticStruct()->SerializeBin(ar, &Spec);
-					UE_LOG(LogSmartFoundations, Display,
-						TEXT("[MP-SPEC] SerializeConstructMessage(%s): captured spec (%d cells), stripped %d grid children, message is O(1)."),
-						*self->GetClass()->GetName(), Spec.CellCount(), Stash.Num());
-				}
-
-				for (AFGHologram* Child : Stash)
-				{
-					self->mChildren.Add(Child);
-				}
-			}
-			else
-			{
-				// SERVER (receive): original reads the childless hologram, then read the spec into
-				// the per-hologram data registry. Expansion happens later, inside Construct
-				// (post-validation - fresh holograms cannot pass vanilla placement validation).
-				scope(self, ar, id);
-
-				bool bHasSpec = false;
-				ar << bHasSpec;
-				if (bHasSpec)
-				{
-					FSFScalingSpec Spec;
-					FSFScalingSpec::StaticStruct()->SerializeBin(ar, &Spec);
-					if (FSFHologramData* Data = USFHologramDataService::GetOrCreateData(self))
-					{
-						Data->ScalingSpec = Spec;
-					}
-					UE_LOG(LogSmartFoundations, Display,
-						TEXT("[MP-SPEC] SerializeConstructMessage(%s): server received spec (%d cells)."),
-						*self->GetClass()->GetName(), Spec.CellCount());
-				}
-			}
-		});
-
-	// ── Hook 2: cost. Charged server-side BEFORE Construct, when the grid children do not exist
-	// yet - scale the uniform per-cell cost by the cell count. Fires at the AFGHologram::GetCost
-	// base body (the scalable parents' classes do not override GetCost; spline types that do never
-	// carry a spec).
+	// ── Hook A: cost. Charged server-side BEFORE Construct, when the grid children do not exist
+	// yet - scale the uniform per-cell cost by the staged cell count. Fires at the
+	// AFGHologram::GetCost base body (primary virtual; the scalable parents' classes do not
+	// override GetCost, and spline types that do never carry a staged spec).
 	SUBSCRIBE_METHOD_VIRTUAL(AFGHologram::GetCost, HologramCDO,
-		[CountGridChildren](auto& scope, const AFGHologram* self, bool includeChildren)
+		[=](auto& scope, const AFGHologram* self, bool includeChildren)
 		{
 			if (!self || !includeChildren || !SFScalingSpecExpansion::IsSpecConstructionEnabled())
 			{
@@ -619,14 +613,14 @@ void USFGameInstanceModule::RegisterSpecConstructionHooks()
 			{
 				return; // client cost comes from its real preview children via vanilla aggregation
 			}
-			FSFHologramData* Data = USFHologramDataRegistry::GetData(MutableSelf);
-			if (!Data || !Data->ScalingSpec.bValid || CountGridChildren(MutableSelf) > 0)
+			FSFScalingSpec Spec;
+			if (!FindStagedSpec(self, Spec, /*bConsume=*/false) || CountGridChildren(MutableSelf) > 0)
 			{
-				return; // no pending spec (or already expanded) -> vanilla cost
+				return; // no staged spec (or children already present) -> vanilla cost
 			}
 
 			TArray<FItemAmount> Cost = scope(self, includeChildren);
-			const int32 Cells = Data->ScalingSpec.CellCount();
+			const int32 Cells = Spec.CellCount();
 			for (FItemAmount& Item : Cost)
 			{
 				Item.Amount *= Cells;
@@ -634,28 +628,28 @@ void USFGameInstanceModule::RegisterSpecConstructionHooks()
 			scope.Override(Cost);
 		});
 
-	// ── Hook 3: expansion. Fires at the AFGBuildableHologram::Construct body - inside the Super
-	// chain of every buildable hologram, before the base child-construct loop - on the server,
-	// after Server_ConstructHologram validation has already passed on the childless parent.
+	// ── Hook B: expansion. Fires at the AFGBuildableHologram::Construct body (primary virtual) -
+	// inside the Super chain of every buildable hologram, before the base child-construct loop -
+	// on the server, after Server_ConstructHologram validation has already passed on the childless
+	// parent. Consumes the staged spec (matched by instigator + build class).
 	SUBSCRIBE_METHOD_VIRTUAL(AFGBuildableHologram::Construct, BuildableHologramCDO,
-		[CountGridChildren](auto& scope, AFGBuildableHologram* self, TArray<AActor*>& out_children, FNetConstructionID constructionID)
+		[=](auto& scope, AFGBuildableHologram* self, TArray<AActor*>& out_children, FNetConstructionID constructionID)
 		{
 			if (!self || !self->HasAuthority() || !SFScalingSpecExpansion::IsSpecConstructionEnabled())
 			{
 				return;
 			}
-			FSFHologramData* Data = USFHologramDataRegistry::GetData(self);
-			if (!Data || !Data->ScalingSpec.bValid)
+			FSFScalingSpec Spec;
+			if (!FindStagedSpec(self, Spec, /*bConsume=*/true))
 			{
-				return; // not a spec parent (e.g. one of the children constructing in the loop)
+				return; // no staged spec for this instigator/class (e.g. a child in the loop)
 			}
 			if (CountGridChildren(self) == 0)
 			{
-				SFScalingSpecExpansion::ExpandScalingSpecIntoChildren(self, Data->ScalingSpec, self->GetRecipe());
+				SFScalingSpecExpansion::ExpandScalingSpecIntoChildren(self, Spec, self->GetRecipe());
 			}
-			Data->ScalingSpec.bValid = false; // one-shot
 			// original runs after return and constructs parent + expanded children
 		});
 
-	UE_LOG(LogSmartFoundations, Verbose, TEXT("✅ Spec-construction hooks registered (SerializeConstructMessage / GetCost / Construct - class-agnostic)"));
+	UE_LOG(LogSmartFoundations, Verbose, TEXT("✅ Spec-construction hooks registered (GetCost / Construct - class-agnostic; spec staged via USFRCO)"));
 }

--- a/Source/SmartFoundations/Private/Module/SFGameInstanceModule.cpp
+++ b/Source/SmartFoundations/Private/Module/SFGameInstanceModule.cpp
@@ -470,6 +470,10 @@ static const FName GSFAutoConnectChildTags[] = {
 };
 static constexpr int32 GSFAutoConnectChildTagCount = UE_ARRAY_COUNT(GSFAutoConnectChildTags);
 
+// Alias: a TMap<A,B> inside a SUBSCRIBE macro argument splits the macro args on the template
+// comma (the recurring gotcha - see the multi-capture and brace-initializer notes above).
+using FSFSpawnedCloneMap = TMap<FString, AFGHologram*>;
+
 void USFGameInstanceModule::RegisterClientGridChunkFireHook()
 {
 	SUBSCRIBE_METHOD(
@@ -500,28 +504,102 @@ void USFGameInstanceModule::RegisterClientGridChunkFireHook()
 				return;
 			}
 
-			// [EXTEND-MP] INTERIM GUARD until the Extend commit is ported (slice 2): a client
-			// fire with Extend clone children serializes them into the construct message, and the
-			// recipe-less belt/lift clones assert the CLIENT in SerializeConstructMessage (live
-			// crash 2026-06-10: "Assertion failed: hologramRecipe" via the pending-ghost path in
-			// SetupPendingConstructionHologram). Refuse the fire; the preview stays live.
+			// [EXTEND-MP] Extend commit (slice 2): an active Extend session fires with
+			// SF_ExtendChild clone children attached. They must NEVER serialize into the construct
+			// message (the recipe-less belt/lift clones assert the CLIENT in
+			// SerializeConstructMessage - live crash 2026-06-10). Instead, mirror the scaling
+			// model: re-emit a FRESH clone topology at the FINAL fire position (the preview's
+			// stored topology has stale transforms - children are re-positioned while aiming),
+			// stage it via the RCO with the exact preview cost, destroy the preview children, and
+			// fire the childless O(1) parent; the server's Construct hook reconstructs the clones.
 			{
 				static const FName ExtendChildTag(TEXT("SF_ExtendChild"));
+				bool bExtendFire = false;
 				for (AFGHologram* Child : Holo->GetHologramChildren())
 				{
 					if (Child && Child->Tags.Contains(ExtendChildTag))
 					{
-						UE_LOG(LogSmartFoundations, Display,
-							TEXT("[EXTEND-MP] Refused client Extend fire on %s: the Extend commit is not ported to multiplayer yet (slice 2)."),
-							*Holo->GetName());
-						if (GEngine)
-						{
-							GEngine->AddOnScreenDebugMessage(-1, 6.0f, FColor::Orange,
-								TEXT("Smart!: Extend building in multiplayer is not supported yet."));
-						}
-						scope.Cancel();
-						return;
+						bExtendFire = true;
+						break;
 					}
+				}
+
+				if (bExtendFire)
+				{
+					bool bCommitted = false;
+					if (SFScalingSpecExpansion::IsSpecConstructionEnabled())
+					{
+						FSFExtendCommitSpec ExtendSpec;
+						USFSubsystem* SS = USFSubsystem::Get(World);
+						USFExtendService* Extend = SS ? SS->GetExtendService() : nullptr;
+						if (Extend)
+						{
+							const FSFExtendTopology& Topo = Extend->GetLastExtendTopology();
+							if (Topo.bIsValid && Topo.SourceBuilding.IsValid())
+							{
+								const FVector FinalOffset =
+									Holo->GetActorLocation() - Topo.SourceBuilding->GetActorLocation();
+								const FSFSourceTopology Source = FSFSourceTopology::CaptureFromTopology(Topo);
+								ExtendSpec.Clone = FSFCloneTopology::FromSource(Source, FinalOffset);
+								ExtendSpec.Cost = Holo->GetCost(true); // parent + preview children
+								ExtendSpec.BuildClass = Holo->GetBuildClass();
+								ExtendSpec.bValid = ExtendSpec.Clone.ChildHolograms.Num() > 0;
+							}
+						}
+
+						if (ExtendSpec.bValid)
+						{
+							if (APawn* InstigatorPawn = Holo->GetConstructionInstigator())
+							{
+								if (AFGPlayerController* PC = Cast<AFGPlayerController>(InstigatorPawn->GetController()))
+								{
+									if (USFRCO* RCO = PC->GetRemoteCallObjectOfClass<USFRCO>())
+									{
+										RCO->Server_StageExtendCommit(ExtendSpec);
+										// Explicit scaling CLEAR: Extend hijacks the grid counters,
+										// and a stale scaling spec must never expand a factory grid
+										// on top of the Extend commit.
+										RCO->Server_StageScalingSpec(FSFScalingSpec());
+										bCommitted = true;
+									}
+								}
+							}
+						}
+
+						if (bCommitted)
+						{
+							TArray<AFGHologram*> ToDestroy;
+							for (AFGHologram* Child : Holo->mChildren)
+							{
+								if (Child && Child->Tags.Contains(ExtendChildTag))
+								{
+									ToDestroy.Add(Child);
+								}
+							}
+							for (AFGHologram* Child : ToDestroy)
+							{
+								Holo->mChildren.Remove(Child);
+								Child->Destroy();
+							}
+							UE_LOG(LogSmartFoundations, Display,
+								TEXT("[EXTEND-MP] Client fire: staged Extend commit (%d clone children), destroyed %d previews; construct message will be O(1)."),
+								ExtendSpec.Clone.ChildHolograms.Num(), ToDestroy.Num());
+							return; // fire proceeds with the childless parent
+						}
+					}
+
+					// Could not stage (spec disabled / no topology / RCO unreachable): refuse the
+					// fire - serializing the clone children would assert this client.
+					UE_LOG(LogSmartFoundations, Display,
+						TEXT("[EXTEND-MP] Refused client Extend fire on %s: could not stage the Extend commit."),
+						*Holo->GetName());
+					if (GEngine)
+					{
+						GEngine->AddOnScreenDebugMessage(-1, 6.0f, FColor::Orange,
+							TEXT("Smart!: Extend commit could not be staged - try again."));
+					}
+					scope.Cancel();
+					return;
 				}
 			}
 
@@ -780,6 +858,22 @@ void USFGameInstanceModule::RegisterSpecConstructionHooks()
 			: SS->PeekScalingSpecForInstigator(Instigator, BuildClass, OutSpec);
 	};
 
+	// [EXTEND-MP] Resolve the staged Extend commit for a constructing/costing hologram.
+	auto FindStagedExtendCommit = [](const AFGHologram* Holo, FSFExtendCommitSpec& OutSpec, bool bConsume) -> bool
+	{
+		AFGHologram* MutableHolo = const_cast<AFGHologram*>(Holo);
+		USFSubsystem* SS = USFSubsystem::Get(MutableHolo->GetWorld());
+		if (!SS)
+		{
+			return false;
+		}
+		APawn* Instigator = MutableHolo->GetConstructionInstigator();
+		UClass* BuildClass = MutableHolo->GetBuildClass();
+		return bConsume
+			? SS->ConsumeExtendCommitForInstigator(Instigator, BuildClass, OutSpec)
+			: SS->PeekExtendCommitForInstigator(Instigator, BuildClass, OutSpec);
+	};
+
 	// ── Hook A: cost. Charged server-side BEFORE Construct, when the grid children do not exist
 	// yet - scale the uniform per-cell cost by the staged cell count. Fires at the
 	// AFGHologram::GetCost base body (primary virtual; the scalable parents' classes do not
@@ -796,6 +890,20 @@ void USFGameInstanceModule::RegisterSpecConstructionHooks()
 			{
 				return; // client cost comes from its real preview children via vanilla aggregation
 			}
+
+			// [EXTEND-MP] A staged Extend commit overrides with the EXACT preview cost captured
+			// client-side (parent + all clone children) - the childless server parent would
+			// otherwise charge the bare factory only.
+			FSFExtendCommitSpec ExtendSpec;
+			if (FindStagedExtendCommit(self, ExtendSpec, /*bConsume=*/false))
+			{
+				if (MutableSelf->GetHologramChildren().Num() == 0 && ExtendSpec.Cost.Num() > 0)
+				{
+					scope.Override(ExtendSpec.Cost);
+				}
+				return;
+			}
+
 			FSFScalingSpec Spec;
 			if (!FindStagedSpec(self, Spec, /*bConsume=*/false) || CountGridChildren(MutableSelf) > 0)
 			{
@@ -850,24 +958,56 @@ void USFGameInstanceModule::RegisterSpecConstructionHooks()
 				return;
 			}
 			FSFScalingSpec Spec;
-			if (!FindStagedSpec(self, Spec, /*bConsume=*/true))
+			const bool bHasScaling = FindStagedSpec(self, Spec, /*bConsume=*/true);
+			FSFExtendCommitSpec ExtendSpec;
+			const bool bHasExtend = !bHasScaling && FindStagedExtendCommit(self, ExtendSpec, /*bConsume=*/true);
+			if (!bHasScaling && !bHasExtend)
 			{
-				return; // no staged spec for this instigator/class (e.g. a child in the loop)
-			}
-			if (CountGridChildren(self) == 0)
-			{
-				SFScalingSpecExpansion::ExpandScalingSpecIntoChildren(self, Spec, self->GetRecipe());
+				return; // nothing staged for this instigator/class (e.g. a child in the loop)
 			}
 
-			// [MP-334] Server-side auto-connect belt wiring: replay the CLIENT'S staged belt plan.
-			// The client's fire-time previews are the only complete, real plan that ever exists -
-			// server-side re-derivation (ProcessSingleDistributor) returned 0 at this seam, and the
-			// server's own aim-time previews are empty here / not construct-grade (three failed
-			// approaches, live-proven 2026-06-09; see PLAN_MP_AutoConnect_334.md). The plan belts
-			// are appended AFTER the grid children, so the vanilla child-construct loop below
-			// builds the distributors first and each belt's SF_BeltAutoConnectChild Construct path
-			// wires it geometrically against BUILT actors - the same mechanism SP uses.
-			SFScalingSpecExpansion::SpawnConduitPlanChildren(self, Spec);
+			if (bHasScaling)
+			{
+				if (CountGridChildren(self) == 0)
+				{
+					SFScalingSpecExpansion::ExpandScalingSpecIntoChildren(self, Spec, self->GetRecipe());
+				}
+
+				// [MP-334] Server-side auto-connect belt wiring: replay the CLIENT'S staged belt
+				// plan. The client's fire-time previews are the only complete, real plan that ever
+				// exists - server-side re-derivation (ProcessSingleDistributor) returned 0 at this
+				// seam, and the server's own aim-time previews are empty here / not construct-grade
+				// (three failed approaches, live-proven 2026-06-09; see PLAN_MP_AutoConnect_334.md).
+				// The plan belts are appended AFTER the grid children, so the vanilla child-
+				// construct loop below builds the distributors first and each belt's
+				// SF_BeltAutoConnectChild Construct path wires it geometrically against BUILT
+				// actors - the same mechanism SP uses.
+				SFScalingSpecExpansion::SpawnConduitPlanChildren(self, Spec);
+			}
+			else
+			{
+				// [EXTEND-MP] Reconstruct the clone children from the staged commit - the SAME
+				// executor the client preview uses (FSFCloneTopology::SpawnChildHolograms +
+				// WireChildHologramConnections), run server-side pre-scope(). The children's own
+				// Construct paths populate the Extend wiring registries (RegisterJsonBuiltActor,
+				// chain registrations), and the deferred post-build wiring (OnActorSpawned on the
+				// built factory, authority-side) finishes the wiring exactly as SP does. The
+				// staged topology is installed as StoredCloneTopology so that pass finds the
+				// same state an SP build would have.
+				if (USFSubsystem* SS = USFSubsystem::Get(self->GetWorld()))
+				{
+					if (USFExtendService* Extend = SS->GetExtendService())
+					{
+						Extend->SetStoredCloneTopologyForServerCommit(ExtendSpec.Clone);
+						FSFSpawnedCloneMap SpawnedClones;
+						const int32 NumSpawned = ExtendSpec.Clone.SpawnChildHolograms(self, Extend, SpawnedClones);
+						const int32 NumWired = ExtendSpec.Clone.WireChildHologramConnections(SpawnedClones, self);
+						UE_LOG(LogSmartFoundations, Display,
+							TEXT("[EXTEND-MP] Server reconstructed %d/%d clone children (%d pre-wired) for %s; vanilla construct will build them."),
+							NumSpawned, ExtendSpec.Clone.ChildHolograms.Num(), NumWired, *self->GetName());
+					}
+				}
+			}
 
 			// Spawn the group proxy BEFORE construction and expose it for the window of this
 			// construct: the ConfigureActor hook below assigns it to every buildable configured
@@ -920,7 +1060,10 @@ void USFGameInstanceModule::RegisterSpecConstructionHooks()
 			// hologram-replayed wires came out as unconnected zombies, live 2026-06-10). Direct
 			// AFGBuildableWire spawn + Connect, the proven OnPowerPoleBuilt primitive. Registers
 			// the wires into the group proxy itself (they are not in out_children).
-			SFScalingSpecExpansion::SpawnWirePlanPostConstruct(BuiltParent, out_children, Spec, GroupProxy);
+			if (bHasScaling)
+			{
+				SFScalingSpecExpansion::SpawnWirePlanPostConstruct(BuiltParent, out_children, Spec, GroupProxy);
+			}
 
 			if (GroupProxy)
 			{

--- a/Source/SmartFoundations/Private/Module/SFGameInstanceModule.cpp
+++ b/Source/SmartFoundations/Private/Module/SFGameInstanceModule.cpp
@@ -840,6 +840,27 @@ void USFGameInstanceModule::RegisterSpecConstructionHooks()
 			}
 		});
 
+	// [CHAIN-FIX] Pre-tick integrity scrub. 7 freed-pointer tick AV repros with three falsified
+	// theories (RemoveConveyor skip, conveyor EndPlay skip, buildable EndPlay skip, arrows) - the
+	// corrupt entry appears in mFactoryBuildings by some path none of the chokepoint guards see.
+	// Validate the arrays IMMEDIATELY before vanilla's ParallelFor walks them: the corrupt entry
+	// is removed (server survives) and the log pinpoints its index + valid neighbors.
+	SUBSCRIBE_METHOD(
+		AFGBuildableSubsystem::TickFactory,
+		[](auto& scope, AFGBuildableSubsystem* self, float dt, ELevelTick TickType)
+		{
+			if (self && self->HasAuthority())
+			{
+				if (USFSubsystem* SS = USFSubsystem::Get(self->GetWorld()))
+				{
+					if (USFChainActorService* ChainSvc = SS->GetChainActorService())
+					{
+						ChainSvc->ScrubFactoryTickArrays();
+					}
+				}
+			}
+		});
+
 	// [CHAIN-FIX] Destruction chokepoint guard, ALL buildables. cdb on the 5th freed-pointer tick
 	// AV (2026-06-10) identified the crashing loop: TickFactoryActors' lambda walks
 	// mFactoryBuildings (subsystem +0x3C0, confirmed via PDB) and virtual-calls each entry - the

--- a/Source/SmartFoundations/Private/Module/SFGameInstanceModule.cpp
+++ b/Source/SmartFoundations/Private/Module/SFGameInstanceModule.cpp
@@ -40,6 +40,8 @@
 #include "FGBlueprintProxy.h"   // server-side Smart Dismantle group for spec-built grids
 
 // For chain actor rebuilding
+#include "Buildables/FGBuildableFactory.h"   // [EXTEND-MP] commit wiring pass anchor
+#include "TimerManager.h"                    // [EXTEND-MP] next-tick commit wiring pass
 #include "Buildables/FGBuildableConveyorBase.h"
 #include "Buildables/FGBuildableConveyorBelt.h"
 #include "Buildables/FGBuildableConveyorLift.h"
@@ -1043,6 +1045,31 @@ void USFGameInstanceModule::RegisterSpecConstructionHooks()
 				{
 					if (USFExtendService* Extend = SS->GetExtendService())
 					{
+						// [EXTEND-MP] Schedule the post-build wiring pass OURSELVES, next tick,
+						// with the BUILT PARENT as the factory anchor. The legacy OnActorSpawned
+						// trigger queues per factory spawn and proved unreliable at the commit
+						// seam (live 2026-06-10: only the LAST junction's lambda ran, so
+						// "parent"/"Factory" targets resolved against a junction and every
+						// factory-end connection failed). Our pass runs first; the legacy lambdas
+						// no-op afterwards via their HasPendingPostBuildWiring re-check.
+						if (AFGBuildableFactory* BuiltFactory = Cast<AFGBuildableFactory>(BuiltParent))
+						{
+							TWeakObjectPtr<AFGBuildableFactory> WeakFactory = BuiltFactory;
+							TWeakObjectPtr<USFExtendService> WeakExtend = Extend;
+							self->GetWorld()->GetTimerManager().SetTimerForNextTick([=]()
+							{
+								if (WeakFactory.IsValid() && WeakExtend.IsValid()
+									&& WeakExtend->HasPendingPostBuildWiring())
+								{
+									UE_LOG(LogSmartFoundations, Display,
+										TEXT("[EXTEND-MP] Commit wiring pass executing for %s."),
+										*WeakFactory->GetName());
+									WeakExtend->ConnectAllChainElements(WeakFactory.Get());
+									WeakExtend->WireBuiltChildConnections(WeakFactory.Get());
+								}
+							});
+						}
+
 						int32 RegisteredAnchors = 0;
 						for (AFGHologram* ChildHolo : self->mChildren)
 						{
@@ -1137,6 +1164,31 @@ void USFGameInstanceModule::RegisterSpecConstructionHooks()
 			}
 
 			scope.Override(BuiltParent);
+		});
+
+	// ── Hook D: server-side placement leniency for staged Extend commits. SP's swapped parent
+	// (ASFFactoryHologram) SKIPS clearance checks during Extend - the clone is deliberately placed
+	// adjacent to the source with logistics in between, which full vanilla clearance rejects. The
+	// server constructs through the VANILLA hologram, so the same fire that previews valid on the
+	// client was refused server-side (live 2026-06-10: FGCDEncroachingClearance from
+	// ValidatePlacementAndCost). Mirror SP: when a staged Extend commit exists for this hologram,
+	// clear the disqualifiers after vanilla evaluates them.
+	// NOTE: hooked at the AFGBuildableHologram override, NOT the AFGHologram base -
+	// &AFGHologram::CheckValidPlacement resolves to an unhookable import thunk (live dedi
+	// startup FATAL 2026-06-10: "resulting function still points to a thunk"). The override
+	// covers every buildable hologram, which is exactly the set that can carry a staged commit.
+	SUBSCRIBE_METHOD_VIRTUAL_AFTER(AFGBuildableHologram::CheckValidPlacement, BuildableHologramCDO,
+		[=](AFGBuildableHologram* self)
+		{
+			if (!self || !self->HasAuthority() || !SFScalingSpecExpansion::IsSpecConstructionEnabled())
+			{
+				return;
+			}
+			FSFExtendCommitSpec ExtendSpec;
+			if (FindStagedExtendCommit(self, ExtendSpec, /*bConsume=*/false))
+			{
+				self->ResetConstructDisqualifiers();
+			}
 		});
 
 	// ── Hook C: group membership assignment, pre-BeginPlay. ConfigureActor is called by the

--- a/Source/SmartFoundations/Private/Module/SFGameInstanceModule.cpp
+++ b/Source/SmartFoundations/Private/Module/SFGameInstanceModule.cpp
@@ -27,6 +27,7 @@
 #include "Core/Helpers/SFNetworkHelper.h"     // FSFNetworkHelper::IsClient
 #include "Engine/Engine.h"                     // GEngine on-screen message
 #include "Containers/Ticker.h"                 // FTSTicker for deferred one-per-frame chunk fires
+#include "UObject/CoreNet.h"                   // FNetBitWriter for hand-serializing the construct message
 
 // For chain actor rebuilding
 #include "Buildables/FGBuildableConveyorBase.h"
@@ -361,6 +362,17 @@ void USFGameInstanceModule::RegisterClientConstructChunkGuardHook()
 				return; // not a Smart scaled grid -> vanilla path (incl. blueprints)
 			}
 
+			// Chunk-0 of a chunked placement: capture the valid FNetConstructionID vanilla minted so the
+			// deferred ticker can derive IDs for the hand-sent chunks.
+			if (GSFExpectingChunk0ID)
+			{
+				GSFBaseConstructID = clientNetConstructID;
+				GSFExpectingChunk0ID = false;
+				UE_LOG(LogSmartFoundations, Display,
+					TEXT("[MP-CHUNK] captured chunk-0 NetConstructionID: NetPlayerID=%d Server_ID=%u Client_ID=%u"),
+					(int32)clientNetConstructID.NetPlayerID, clientNetConstructID.Server_ID, clientNetConstructID.Client_ID);
+			}
+
 			const int32 Bytes = data.SerializedHologramData.Num();
 
 			// Diagnostic: capture the real serialized size near/over the ceiling (confirms the byte limit).
@@ -419,6 +431,14 @@ static TWeakObjectPtr<UFGBuildGunStateBuild> GSFPendingGun;
 static int32 GSFChunkWait = 0;
 static FTSTicker::FDelegateHandle GSFChunkTicker;
 
+// Hand-serialization (full-auto) state. Chunk 0 is the player's natural fire; we capture the valid
+// FNetConstructionID vanilla minted for it, then derive subsequent chunk IDs (Client_ID + n) and hand-build
+// + send each remaining chunk's Server_ConstructHologram ourselves (bypassing the build gun, which only
+// constructs on real input). The biggest unknown is whether the server accepts the derived IDs.
+static FNetConstructionID GSFBaseConstructID;
+static bool GSFExpectingChunk0ID = false;
+static int32 GSFChunkSeq = 0;
+
 bool USFGameInstanceModule::TickPendingGridChunks(float /*Dt*/)
 {
 	if (GSFPendingChunks.Num() == 0)
@@ -450,15 +470,37 @@ bool USFGameInstanceModule::TickPendingGridChunks(float /*Dt*/)
 		if (AFGHologram* C = W.Get()) { Kids.Add(C); }
 	}
 
+	// Set up the hologram as this chunk: repositioned to the anchor cell, children = the chunk's holograms.
 	Holo->SetActorTransform(Chunk.AnchorXform);
 	USFGameInstanceModule::SetActiveHologramChildren(Holo, Kids);
 
+	// Hand-build the construct message and send it directly (bypassing the build gun, which only constructs
+	// on real input). Derive this chunk's NetConstructionID from the captured chunk-0 ID (Client_ID + seq).
+	UWorld* World = Holo->GetWorld();
+	APlayerController* PC = World ? World->GetFirstPlayerController() : nullptr; // local PC on a client
+	UPackageMap* PackageMap = UFGBuildGunStateBuild::FindPackageMapForPlayerController(PC);
+
+	FNetConstructionID ChunkID = GSFBaseConstructID;
+	ChunkID.Server_ID = 0;
+	ChunkID.Client_ID = (uint16)(GSFBaseConstructID.Client_ID + (uint16)(++GSFChunkSeq));
+
+	Holo->PreConstructMessageSerialization();
+	FNetBitWriter Writer(PackageMap, 1 << 21); // 256 KB bit budget (a chunk is <64KB)
+	FNetConstructionID SerId = ChunkID;
+	Holo->SerializeConstructMessage(Writer, SerId);
+
+	FConstructHologramMessage Msg;
+	Msg.ConstructionID = ChunkID;
+	Msg.Recipe = Holo->GetRecipe();
+	Msg.NumBits = Writer.GetNumBits();
+	Msg.SerializedHologramData.Append(Writer.GetData(), (int32)Writer.GetNumBytes());
+
 	UE_LOG(LogSmartFoundations, Display,
-		TEXT("[MP-CHUNK] deferred: firing chunk (%d children) at anchor; %d chunk(s) left after this."),
-		Kids.Num(), GSFPendingChunks.Num());
+		TEXT("[MP-CHUNK] deferred: hand-sending chunk (%d children, %d bytes, Client_ID=%u, PackageMap=%s); %d chunk(s) left after this."),
+		Kids.Num(), Msg.SerializedHologramData.Num(), ChunkID.Client_ID, PackageMap ? TEXT("ok") : TEXT("NULL"), GSFPendingChunks.Num());
 
 	GSFChunkingInProgress = true;
-	Gun->InternalExecuteDuBuildStepInput(false);
+	Gun->Server_ConstructHologram(ChunkID, Msg);
 	GSFChunkingInProgress = false;
 
 	USFGameInstanceModule::SetActiveHologramChildren(Holo, TArray<AFGHologram*>());
@@ -558,6 +600,8 @@ void USFGameInstanceModule::RegisterClientGridChunkFireHook()
 
 			GSFPendingGun = self;
 			GSFChunkWait = SF_MP_CHUNK_WAIT_FRAMES;
+			GSFExpectingChunk0ID = true; // capture chunk 0's NetConstructionID in the Server_ConstructHologram hook
+			GSFChunkSeq = 0;
 			if (!GSFChunkTicker.IsValid())
 			{
 				GSFChunkTicker = FTSTicker::GetCoreTicker().AddTicker(FTickerDelegate::CreateStatic(&USFGameInstanceModule::TickPendingGridChunks), 0.0f);

--- a/Source/SmartFoundations/Private/Module/SFGameInstanceModule.cpp
+++ b/Source/SmartFoundations/Private/Module/SFGameInstanceModule.cpp
@@ -302,80 +302,91 @@ void USFGameInstanceModule::RegisterBeltSupportConstructHook()
 }
 
 // MP Slice 0 (Phase 1) - construct chunk guard.
-// Empirical hard ceiling on a single client->server construct: ~137 foundations / ~135 constructors per
-// placement (the parent + all child holograms serialize into one reliable Server_ConstructHologram RPC whose
-// blob exceeds UE's reliable partial-bunch byte limit and is dropped at the net layer). We refuse a client
-// placement above a conservative cell count BELOW that edge (heavier holograms may serialize larger and fail
-// sooner, so we leave margin). This is a temporary safety net; Phase 2 will auto-chunk into sub-constructs.
-static constexpr int32 SF_MP_MAX_SINGLE_CONSTRUCT_CELLS = 120;
+// CONFIRMED seam (live test 2026-06-08): the client builds the construct message and calls
+// Server_ConstructHologram DIRECTLY (the earlier InternalConstructHologram hook never fired). The live
+// failure is "LogNet: Error: Can't send function 'Server_ConstructHologram' ...: Failed to serialize
+// properties" - the oversized FConstructHologramMessage.SerializedHologramData blob (one TArray<uint8>
+// holding the whole hologram tree) is too large to marshal, so the reliable RPC is silently dropped ->
+// all-or-nothing + orphaned previews (no Client_OnBuildableFailedConstruction because the server never
+// processed it). We hook Server_ConstructHologram on the client and read the ACTUAL serialized byte size,
+// so the guard is robust across building types (no per-type child-count guessing). Empirically ~137
+// foundations / ~135 constructors fit; that corresponds to ~64KB of SerializedHologramData. We cancel a
+// Smart grid construct whose blob exceeds a margin below that. Phase 2 will chunk instead of refusing.
+static constexpr int32 SF_MP_CONSTRUCT_MAX_BYTES = 60000; // cancel a Smart-grid construct above this
+static constexpr int32 SF_MP_CONSTRUCT_LOG_BYTES = 20000; // log any Smart-grid construct above this (capture real sizes)
 
 void USFGameInstanceModule::RegisterClientConstructChunkGuardHook()
 {
 	SUBSCRIBE_METHOD(
-		UFGBuildGunStateBuild::InternalConstructHologram,
-		[](auto& scope, UFGBuildGunStateBuild* self, FNetConstructionID clientNetConstructID)
+		UFGBuildGunStateBuild::Server_ConstructHologram,
+		[](auto& scope, UFGBuildGunStateBuild* self, FNetConstructionID clientNetConstructID, FConstructHologramMessage data)
 		{
 			if (!self)
 			{
 				return;
 			}
 
-			// Only a true network client (NM_Client) serializes the construct over the wire and can hit the
-			// byte ceiling. Single-player, listen-server host, and dedicated-server authority construct locally
-			// (or already have authority) and must take the untouched vanilla one-shot path.
+			// Only a true network client (NM_Client) marshals the construct over the wire and can hit the
+			// serialize-too-large failure. Host / dedicated-server authority / single-player construct locally.
 			UWorld* World = self->GetWorld();
 			if (!World || !FSFNetworkHelper::IsClient(World))
 			{
 				return;
 			}
 
+			// Scope strictly to Smart scaled grids: only act when the active hologram has Smart grid children
+			// (tagged SF_GridChild). This leaves vanilla single placements AND blueprints completely untouched.
 			AFGHologram* Holo = self->GetHologram();
 			if (!Holo)
 			{
 				return;
 			}
-
-			// Count Smart grid child holograms (tagged SF_GridChild during scaled-grid spawn). +1 for the
-			// parent/origin cell, which is the active hologram itself (not a child).
 			static const FName GridChildTag(TEXT("SF_GridChild"));
-			int32 GridChildCount = 0;
+			bool bIsSmartGrid = false;
 			for (const AFGHologram* Child : Holo->GetHologramChildren())
 			{
 				if (Child && Child->Tags.Contains(GridChildTag))
 				{
-					++GridChildCount;
+					bIsSmartGrid = true;
+					break;
 				}
 			}
-
-			if (GridChildCount == 0)
+			if (!bIsSmartGrid)
 			{
-				return; // Not a Smart scaled grid (no tagged children) -> vanilla path.
+				return; // not a Smart scaled grid -> vanilla path (incl. blueprints)
 			}
 
-			const int32 TotalCells = GridChildCount + 1;
-			if (TotalCells <= SF_MP_MAX_SINGLE_CONSTRUCT_CELLS)
+			const int32 Bytes = data.SerializedHologramData.Num();
+
+			// Diagnostic: capture the real serialized size near/over the ceiling (confirms the byte limit).
+			if (Bytes >= SF_MP_CONSTRUCT_LOG_BYTES)
 			{
-				return; // Small enough to fit one construct RPC -> vanilla path (works in MP).
+				UE_LOG(LogSmartFoundations, Display,
+					TEXT("[MP-CHUNK] Smart-grid client construct: SerializedHologramData=%d bytes (NumBits=%lld), cancel threshold=%d."),
+					Bytes, (long long)data.NumBits, SF_MP_CONSTRUCT_MAX_BYTES);
 			}
 
-			// Oversized grid on a client: the single Server_ConstructHologram RPC would be dropped at the net
-			// layer (all-or-nothing) and orphan the previews (no failure callback fires because the server
-			// never processes it). Cancel the construct BEFORE it is sent. Nothing orphans - the active
-			// hologram and its preview children stay live, so the player can scale down and build.
+			if (Bytes <= SF_MP_CONSTRUCT_MAX_BYTES)
+			{
+				return; // fits one RPC -> let it send (works in MP)
+			}
+
+			// Oversized: the RPC would fail to serialize and be dropped (all-or-nothing) + orphan the previews.
+			// Cancel the send. The active hologram + preview children stay live so the player can scale down.
 			UE_LOG(LogSmartFoundations, Display,
-				TEXT("[MP-CHUNK] Blocked oversized client construct: %d cells (> %d). A single-RPC construct of this size exceeds the multiplayer limit (~135) and would be dropped. Preview kept; advise smaller sections."),
-				TotalCells, SF_MP_MAX_SINGLE_CONSTRUCT_CELLS);
+				TEXT("[MP-CHUNK] Blocked oversized client construct: %d bytes (> %d). Single-RPC construct would be dropped (Failed to serialize properties). Cancelled before send; preview kept."),
+				Bytes, SF_MP_CONSTRUCT_MAX_BYTES);
 
 			if (GEngine)
 			{
 				GEngine->AddOnScreenDebugMessage(-1, 6.0f, FColor::Orange,
-					FString::Printf(TEXT("Smart!: grid too large for multiplayer (%d cells, max ~%d). Build in smaller sections."),
-						TotalCells, SF_MP_MAX_SINGLE_CONSTRUCT_CELLS));
+					FString::Printf(TEXT("Smart!: placement too large for multiplayer (%d KB). Build in smaller sections."),
+						Bytes / 1024));
 			}
 
-			scope.Cancel(); // suppress vanilla InternalConstructHologram -> no oversized RPC is sent.
+			scope.Cancel(); // suppress the doomed Server_ConstructHologram send.
 		}
 	);
 
-	UE_LOG(LogSmartFoundations, Verbose, TEXT("✅ Client construct chunk-guard hook registered (MP Slice 0 Phase 1)"));
+	UE_LOG(LogSmartFoundations, Verbose, TEXT("✅ Client construct chunk-guard hook registered (MP Slice 0 Phase 1, Server_ConstructHologram)"));
 }

--- a/Source/SmartFoundations/Private/Module/SFGameInstanceModule.cpp
+++ b/Source/SmartFoundations/Private/Module/SFGameInstanceModule.cpp
@@ -10,6 +10,9 @@
 #include "Hologram/FGBuildableHologram.h"
 #include "Hologram/FGBlueprintHologram.h"
 #include "Hologram/FGConveyorPoleHologram.h"      // #341: belt-support parent hologram (covers stackable/wall/ceiling)
+#include "Hologram/FGPoleHologram.h"              // [MP-SPEC] multi-step gate: pole height step
+#include "Hologram/FGFloodlightHologram.h"        // [MP-SPEC] multi-step gate: floodlight angle step
+#include "Hologram/FGStandaloneSignHologram.h"    // [MP-SPEC] multi-step gate: sign height step
 #include "Holograms/Logistics/SFConveyorBeltHologram.h"  // #341: DrainStackBuiltConveyors
 #include "FGConstructDisqualifier.h"
 #include "FGCentralStorageSubsystem.h"
@@ -407,6 +410,45 @@ void USFGameInstanceModule::RegisterClientConstructChunkGuardHook()
 	UE_LOG(LogSmartFoundations, Verbose, TEXT("✅ Client construct chunk-guard hook registered (MP Slice 0 Phase 1, Server_ConstructHologram)"));
 }
 
+// [MP-SPEC] Multi-step holograms construct only on their FINAL step's input; earlier inputs merely
+// advance the step (pole base->height, floodlight angle, sign height). Treating a step-advance as
+// a fire captured + DESTROYED the previews mid-placement (live 2026-06-10: a standard conveyor
+// pole had no belt previews during height adjust and then fired with an empty plan). The pole gate
+// uses the exact-class check (Build_ConveyorPole_C): stackable/wall poles construct in one click
+// and are live-validated - they must not be gated. Unknown layouts default to "constructs"
+// (the pre-gate behavior, correct for every single-step hologram).
+static bool SF_InputWillConstruct(AFGHologram* Holo)
+{
+	auto FinalStepReached = [&](UClass* Class, uint8 FinalStep) -> bool
+	{
+		FProperty* StepProp = FindFProperty<FProperty>(Class, TEXT("mBuildStep"));
+		if (!StepProp)
+		{
+			return true;
+		}
+		uint8 Step = 0;
+		StepProp->CopyCompleteValue(&Step, StepProp->ContainerPtrToValuePtr<void>(Holo));
+		return Step == FinalStep;
+	};
+
+	if (USFAutoConnectService::IsRegularConveyorPoleHologram(Holo))
+	{
+		return FinalStepReached(AFGPoleHologram::StaticClass(),
+			static_cast<uint8>(EPoleHologramBuildStep::PHBS_AdjustHeight));
+	}
+	if (Holo->IsA<AFGFloodlightHologram>())
+	{
+		return FinalStepReached(AFGFloodlightHologram::StaticClass(),
+			static_cast<uint8>(EFloodlightHologramBuildStep::FHBS_AdjustAngle));
+	}
+	if (Holo->IsA<AFGStandaloneSignHologram>())
+	{
+		return FinalStepReached(AFGStandaloneSignHologram::StaticClass(),
+			static_cast<uint8>(ESignHologramBuildStep::ESHBS_AdjustHeight));
+	}
+	return true;
+}
+
 // MP Slice 0 SAFETY GUARD. A Smart grid above this many total cells will not fit one 64KB
 // Server_ConstructHologram (empirical ceiling ~135 cells / 65536 bytes). Building such a grid on a CLIENT is
 // not safely achievable today: re-firing the build gun never constructs (single-construct-per-fire state
@@ -447,6 +489,13 @@ void USFGameInstanceModule::RegisterClientGridChunkFireHook()
 
 			AFGHologram* Holo = self->GetHologram();
 			if (!Holo)
+			{
+				return;
+			}
+
+			// A step-advance input (multi-step holograms) is NOT a fire: nothing serializes, so
+			// nothing may be captured, staged, stripped, or destroyed here.
+			if (!SF_InputWillConstruct(Holo))
 			{
 				return;
 			}

--- a/Source/SmartFoundations/Private/Module/SFGameInstanceModule.cpp
+++ b/Source/SmartFoundations/Private/Module/SFGameInstanceModule.cpp
@@ -26,6 +26,7 @@
 #include "Equipment/FGBuildGunBuild.h"        // UFGBuildGunStateBuild::InternalConstructHologram / GetHologram
 #include "Core/Helpers/SFNetworkHelper.h"     // FSFNetworkHelper::IsClient
 #include "Engine/Engine.h"                     // GEngine on-screen message
+#include "Containers/Ticker.h"                 // FTSTicker for deferred one-per-frame chunk fires
 
 // For chain actor rebuilding
 #include "Buildables/FGBuildableConveyorBase.h"
@@ -398,10 +399,72 @@ void USFGameInstanceModule::RegisterClientConstructChunkGuardHook()
 // MP Slice 0 chunking. A Smart grid above this many total cells will not fit one 64KB Server_ConstructHologram.
 static constexpr int32 SF_MP_OVERSIZED_CELLS = 130; // trigger chunking above this (total cells incl. parent)
 static constexpr int32 SF_MP_CHUNK_CHILDREN  = 100; // grid children to build per chunk (parent adds 1 cell)
+static constexpr int32 SF_MP_CHUNK_WAIT_FRAMES = 6; // frames to let the build gun settle between chunk fires
 
-// Re-entrancy guard: the chunk loop re-invokes InternalExecuteDuBuildStepInput; those nested calls must pass
-// straight through to vanilla without re-chunking.
+// Re-entrancy guard: the deferred chunk fires re-invoke InternalExecuteDuBuildStepInput; those nested calls
+// must pass straight through to vanilla without re-chunking.
 static bool GSFChunkingInProgress = false;
+
+// Deferred-chunk queue. chunk 0 builds on the player's natural fire; chunks 1+ are fired one-per-frame from a
+// ticker, AFTER the build gun settles, so each is a fresh fire instead of a synchronous re-entry (which the
+// build-gun state machine refuses). Each pending chunk repositions the active hologram to its anchor (a cell
+// the parent builds) and re-homes the chunk's other child holograms onto it.
+struct FSFPendingChunk
+{
+	FTransform AnchorXform;
+	TArray<TWeakObjectPtr<AFGHologram>> Children;
+};
+static TArray<FSFPendingChunk> GSFPendingChunks;
+static TWeakObjectPtr<UFGBuildGunStateBuild> GSFPendingGun;
+static int32 GSFChunkWait = 0;
+static FTSTicker::FDelegateHandle GSFChunkTicker;
+
+bool USFGameInstanceModule::TickPendingGridChunks(float /*Dt*/)
+{
+	if (GSFPendingChunks.Num() == 0)
+	{
+		GSFChunkTicker.Reset();
+		return false; // unregister
+	}
+	if (--GSFChunkWait > 0)
+	{
+		return true; // still letting the gun settle
+	}
+
+	UFGBuildGunStateBuild* Gun = GSFPendingGun.Get();
+	AFGHologram* Holo = Gun ? Gun->GetHologram() : nullptr;
+	if (!Gun || !Holo)
+	{
+		UE_LOG(LogSmartFoundations, Warning, TEXT("[MP-CHUNK] deferred: gun/hologram gone; aborting %d remaining chunk(s)."), GSFPendingChunks.Num());
+		GSFPendingChunks.Reset();
+		GSFChunkTicker.Reset();
+		return false;
+	}
+
+	FSFPendingChunk Chunk = GSFPendingChunks[0];
+	GSFPendingChunks.RemoveAt(0);
+
+	TArray<AFGHologram*> Kids;
+	for (const TWeakObjectPtr<AFGHologram>& W : Chunk.Children)
+	{
+		if (AFGHologram* C = W.Get()) { Kids.Add(C); }
+	}
+
+	Holo->SetActorTransform(Chunk.AnchorXform);
+	USFGameInstanceModule::SetActiveHologramChildren(Holo, Kids);
+
+	UE_LOG(LogSmartFoundations, Display,
+		TEXT("[MP-CHUNK] deferred: firing chunk (%d children) at anchor; %d chunk(s) left after this."),
+		Kids.Num(), GSFPendingChunks.Num());
+
+	GSFChunkingInProgress = true;
+	Gun->InternalExecuteDuBuildStepInput(false);
+	GSFChunkingInProgress = false;
+
+	USFGameInstanceModule::SetActiveHologramChildren(Holo, TArray<AFGHologram*>());
+	GSFChunkWait = SF_MP_CHUNK_WAIT_FRAMES;
+	return true;
+}
 
 // Set the active hologram's child list to exactly the given actors. Static member of USFGameInstanceModule so
 // it inherits the friend access to AFGHologram::mChildren / mChildrenNameLookupMap (AccessTransformers.ini).
@@ -462,67 +525,49 @@ void USFGameInstanceModule::RegisterClientGridChunkFireHook()
 				return; // fits one construct -> untouched vanilla path
 			}
 
-			// INCREMENT 2a (bounded): build TWO chunks to prove the re-fire loop respects a repositioned parent.
-			//  - Chunk 0: parent stays at the origin, children = Kids[0..99].
-			//  - Chunk 1: parent is REPOSITIONED to Kids[100]'s transform (that cell is built as the parent),
-			//    children = Kids[101..199]. If chunk 1 lands at Kids[100]'s position (not the crosshair), the
-			//    loop mechanic works and Increment 2b generalizes to all chunks.
-			// Excess cells beyond two chunks are dropped (destroyed) for this bounded proof.
-			const FTransform OriginXform = Holo->GetActorTransform();
+			// INCREMENT 2b (deferred full-auto): chunk 0 builds on THIS natural fire; the rest are queued and
+			// fired one-per-frame from a ticker (after the build gun settles), because the build gun refuses a
+			// synchronous second construct in one fire (proven in 2a).
 
-			// Build chunk 0 child set.
+			// Chunk 0: keep the first SF_MP_CHUNK_CHILDREN grid children on the parent. Vanilla builds the
+			// parent's own origin cell + these on this fire (do NOT cancel).
 			TArray<AFGHologram*> Chunk0;
 			for (int32 i = 0; i < Kids.Num() && Chunk0.Num() < SF_MP_CHUNK_CHILDREN; ++i)
 			{
 				Chunk0.Add(Kids[i]);
 			}
+			USFGameInstanceModule::SetActiveHologramChildren(Holo, Chunk0);
 
-			// Chunk 1 anchor (becomes the repositioned parent) + its children.
-			AFGHologram* Chunk1Anchor = (Kids.Num() > SF_MP_CHUNK_CHILDREN) ? Kids[SF_MP_CHUNK_CHILDREN] : nullptr;
-			FTransform Chunk1Xform = Chunk1Anchor ? Chunk1Anchor->GetActorTransform() : OriginXform;
-			TArray<AFGHologram*> Chunk1;
-			for (int32 i = SF_MP_CHUNK_CHILDREN + 1; i < Kids.Num() && Chunk1.Num() < SF_MP_CHUNK_CHILDREN; ++i)
+			// Queue the remaining cells as deferred chunks. Each chunk's first leftover cell becomes the
+			// repositioned-parent anchor (its preview is destroyed now; the repositioned parent builds that
+			// cell in the ticker); the rest become the chunk's re-homed children.
+			GSFPendingChunks.Reset();
+			for (int32 Start = SF_MP_CHUNK_CHILDREN; Start < Kids.Num(); Start += SF_MP_CHUNK_CHILDREN)
 			{
-				Chunk1.Add(Kids[i]);
+				AFGHologram* Anchor = Kids[Start];
+				if (!Anchor) { continue; }
+				FSFPendingChunk PC;
+				PC.AnchorXform = Anchor->GetActorTransform();
+				for (int32 j = Start + 1; j < Kids.Num() && (j - Start) < SF_MP_CHUNK_CHILDREN; ++j)
+				{
+					if (Kids[j]) { PC.Children.Add(Kids[j]); }
+				}
+				GSFPendingChunks.Add(MoveTemp(PC));
+				Anchor->Destroy();
 			}
 
-			// Destroy any cells beyond the two chunks (bounded proof) + the anchor's old preview (the parent
-			// will build that cell when repositioned).
-			int32 Dropped = 0;
-			for (AFGHologram* K : Kids)
+			GSFPendingGun = self;
+			GSFChunkWait = SF_MP_CHUNK_WAIT_FRAMES;
+			if (!GSFChunkTicker.IsValid())
 			{
-				const bool bUsed = (K == Chunk1Anchor) || Chunk0.Contains(K) || Chunk1.Contains(K);
-				if (K == Chunk1Anchor) { K->Destroy(); ++Dropped; continue; }
-				if (!bUsed && K) { K->Destroy(); ++Dropped; }
+				GSFChunkTicker = FTSTicker::GetCoreTicker().AddTicker(FTickerDelegate::CreateStatic(&USFGameInstanceModule::TickPendingGridChunks), 0.0f);
 			}
 
 			UE_LOG(LogSmartFoundations, Display,
-				TEXT("[MP-CHUNK] Increment 2a: %d cells -> chunk0(parent@origin + %d), chunk1(parent@Kids[100] + %d); dropped %d beyond two chunks."),
-				TotalCells, Chunk0.Num(), Chunk1.Num(), Dropped);
+				TEXT("[MP-CHUNK] Increment 2b (deferred): %d cells -> chunk 0 = parent + %d (building now); queued %d more chunk(s) for one-per-frame fire."),
+				TotalCells, Chunk0.Num(), GSFPendingChunks.Num());
 
-			// Drive the two chunks. Cancel the original fire; we re-invoke it per chunk.
-			scope.Cancel();
-			GSFChunkingInProgress = true;
-
-			// Chunk 0
-			Holo->SetActorTransform(OriginXform);
-			USFGameInstanceModule::SetActiveHologramChildren(Holo, Chunk0);
-			UE_LOG(LogSmartFoundations, Display, TEXT("[MP-CHUNK] Increment 2a: firing chunk 0 (%d children) at origin"), Chunk0.Num());
-			self->InternalExecuteDuBuildStepInput(false);
-
-			// Chunk 1 (repositioned parent)
-			if (Chunk1Anchor)
-			{
-				Holo->SetActorTransform(Chunk1Xform);
-				USFGameInstanceModule::SetActiveHologramChildren(Holo, Chunk1);
-				UE_LOG(LogSmartFoundations, Display, TEXT("[MP-CHUNK] Increment 2a: firing chunk 1 (%d children) at repositioned parent (Kids[100])"), Chunk1.Num());
-				self->InternalExecuteDuBuildStepInput(false);
-			}
-
-			// Clean up: clear any leftover children + restore the parent to the crosshair origin.
-			USFGameInstanceModule::SetActiveHologramChildren(Holo, TArray<AFGHologram*>());
-			Holo->SetActorTransform(OriginXform);
-			GSFChunkingInProgress = false;
+			// Do NOT cancel: vanilla builds chunk 0 now; the ticker fires the queued chunks.
 		}
 	);
 

--- a/Source/SmartFoundations/Private/Module/SFGameInstanceModule.cpp
+++ b/Source/SmartFoundations/Private/Module/SFGameInstanceModule.cpp
@@ -549,6 +549,16 @@ void USFGameInstanceModule::RegisterClientGridChunkFireHook()
 	UE_LOG(LogSmartFoundations, Verbose, TEXT("✅ Client grid oversized-guard fire-hook registered (MP Slice 0 safety, InternalExecuteDuBuildStepInput)"));
 }
 
+// [MP-SPEC] The blueprint proxy for the spec-construct currently executing on the server.
+// Set by the Construct hook around scope() (construction is synchronous + single-threaded);
+// the ConfigureActor hook assigns it to every buildable configured inside that window. The
+// assignment MUST happen pre-BeginPlay: lightweight-eligible buildables (foundations etc.)
+// convert to lightweight instances in BeginPlay and only then does vanilla transfer the proxy
+// membership to replicated lightweight indices (RegisterLightweightInstance) - a proxy assigned
+// after Construct ends up holding soon-destroyed temp actors and self-destructs (live finding
+// 2026-06-09: "no grouping persists" on spec-built foundation grids).
+static TWeakObjectPtr<AFGBlueprintProxy> GSFActiveSpecGroupProxy;
+
 void USFGameInstanceModule::RegisterSpecConstructionHooks()
 {
 	static const FName GridChildTag(TEXT("SF_GridChild"));
@@ -655,57 +665,55 @@ void USFGameInstanceModule::RegisterSpecConstructionHooks()
 				SFScalingSpecExpansion::ExpandScalingSpecIntoChildren(self, Spec, self->GetRecipe());
 			}
 
-			// Run the original construct now (parent + expanded children) so we can group the
-			// resulting actors. out_children is filled by the vanilla child-construct loop.
-			AActor* BuiltParent = scope(self, out_children, constructionID);
-
-			// Group everything that was built into one blueprint proxy (Smart Dismantle group).
-			TArray<AFGBuildable*> BuiltBuildables;
-			if (AFGBuildable* ParentBuildable = Cast<AFGBuildable>(BuiltParent))
+			// Spawn the group proxy BEFORE construction and expose it for the window of this
+			// construct: the ConfigureActor hook below assigns it to every buildable configured
+			// inside scope() - i.e. pre-BeginPlay, the timing vanilla blueprints use, so
+			// lightweight conversion transfers membership to replicated lightweight indices.
+			AFGBlueprintProxy* GroupProxy = nullptr;
+			if (UWorld* World = self->GetWorld())
 			{
-				BuiltBuildables.Add(ParentBuildable);
-			}
-			for (AActor* ChildActor : out_children)
-			{
-				if (AFGBuildable* ChildBuildable = Cast<AFGBuildable>(ChildActor))
-				{
-					BuiltBuildables.AddUnique(ChildBuildable);
-				}
-			}
-
-			if (BuiltBuildables.Num() > 1)
-			{
-				UWorld* World = self->GetWorld();
 				FActorSpawnParameters ProxyParams;
 				ProxyParams.SpawnCollisionHandlingOverride = ESpawnActorCollisionHandlingMethod::AlwaysSpawn;
-				AFGBlueprintProxy* GroupProxy = World ? World->SpawnActor<AFGBlueprintProxy>(
-					AFGBlueprintProxy::StaticClass(),
-					BuiltBuildables[0]->GetActorTransform(),
-					ProxyParams) : nullptr;
+				GroupProxy = World->SpawnActor<AFGBlueprintProxy>(
+					AFGBlueprintProxy::StaticClass(), self->GetActorTransform(), ProxyParams);
+			}
+			GSFActiveSpecGroupProxy = GroupProxy;
 
-				if (GroupProxy)
-				{
-					for (AFGBuildable* Buildable : BuiltBuildables)
-					{
-						if (!Buildable->GetBlueprintProxy())
-						{
-							Buildable->SetBlueprintProxy(GroupProxy);
-							GroupProxy->RegisterBuildable(Buildable);
-						}
-					}
-					UE_LOG(LogSmartFoundations, Display,
-						TEXT("[MP-SPEC] Grouped %d spec-built buildables into blueprint proxy %s (Smart Dismantle group)."),
-						BuiltBuildables.Num(), *GroupProxy->GetName());
-				}
-				else
-				{
-					UE_LOG(LogSmartFoundations, Warning,
-						TEXT("[MP-SPEC] Could not spawn blueprint proxy for spec-built group (%d buildables)."),
-						BuiltBuildables.Num());
-				}
+			AActor* BuiltParent = scope(self, out_children, constructionID);
+
+			GSFActiveSpecGroupProxy.Reset();
+			if (GroupProxy)
+			{
+				UE_LOG(LogSmartFoundations, Display,
+					TEXT("[MP-SPEC] Spec group proxy %s: %d actor buildables registered (+ lightweight instances tracked by index); built parent=%s, out_children=%d."),
+					*GroupProxy->GetName(), GroupProxy->GetBuildables().Num(),
+					*GetNameSafe(BuiltParent), out_children.Num());
+				// If nothing registered (neither actors nor lightweights), let it clean itself up.
+				GroupProxy->ValidateExistanceOtherwiseSelfDestruct();
 			}
 
 			scope.Override(BuiltParent);
+		});
+
+	// ── Hook C: group membership assignment, pre-BeginPlay. ConfigureActor is called by the
+	// hologram on the deferred-spawned buildable BEFORE FinishSpawning/BeginPlay - the only window
+	// where lightweight-eligible buildables (foundations etc.) can join a blueprint proxy, because
+	// their BeginPlay converts them to lightweight instances and transfers proxy membership to
+	// replicated indices. Assigns the active spec-construct's proxy to every buildable configured
+	// inside the Construct window above. (Primary-class virtual; same hook InfiniteZoop uses.)
+	SUBSCRIBE_METHOD_VIRTUAL_AFTER(AFGBuildableHologram::ConfigureActor, BuildableHologramCDO,
+		[](const AFGBuildableHologram* self, AFGBuildable* inBuildable)
+		{
+			AFGBlueprintProxy* GroupProxy = GSFActiveSpecGroupProxy.Get();
+			if (!GroupProxy || !inBuildable)
+			{
+				return;
+			}
+			if (!inBuildable->GetBlueprintProxy())
+			{
+				inBuildable->SetBlueprintProxy(GroupProxy);
+				GroupProxy->RegisterBuildable(inBuildable);
+			}
 		});
 
 	UE_LOG(LogSmartFoundations, Verbose, TEXT("✅ Spec-construction hooks registered (GetCost / Construct - class-agnostic; spec staged via USFRCO)"));

--- a/Source/SmartFoundations/Private/Module/SFGameInstanceModule.cpp
+++ b/Source/SmartFoundations/Private/Module/SFGameInstanceModule.cpp
@@ -841,6 +841,13 @@ void USFGameInstanceModule::RegisterSpecConstructionHooks()
 				}
 			}
 
+			// [MP-334] Staged power wires build AFTER the grid, against BUILT actors - wires are
+			// never built from holograms (even in SP the wire child holograms exist only for cost;
+			// hologram-replayed wires came out as unconnected zombies, live 2026-06-10). Direct
+			// AFGBuildableWire spawn + Connect, the proven OnPowerPoleBuilt primitive. Registers
+			// the wires into the group proxy itself (they are not in out_children).
+			SFScalingSpecExpansion::SpawnWirePlanPostConstruct(BuiltParent, out_children, Spec, GroupProxy);
+
 			if (GroupProxy)
 			{
 				UE_LOG(LogSmartFoundations, Display,

--- a/Source/SmartFoundations/Private/Module/SFGameInstanceModule.cpp
+++ b/Source/SmartFoundations/Private/Module/SFGameInstanceModule.cpp
@@ -82,8 +82,12 @@ void USFGameInstanceModule::DispatchLifecycleEvent(ELifecyclePhase Phase)
 		RegisterBeltSupportConstructHook();
 
 		// MP Slice 0 (Phase 1): guard a client against committing an oversized scaled grid in one
-		// construct RPC (the all-or-nothing drop + orphaned-preview bug). See the method comment.
+		// construct RPC (the all-or-nothing drop + orphaned-preview bug). Backstop for the chunker below.
 		RegisterClientConstructChunkGuardHook();
+
+		// MP Slice 0 chunking: shrink an oversized client grid to a fit-in-one-RPC chunk at the fire handler,
+		// before vanilla serializes (Increment 1 = single-chunk proof). See the method comment.
+		RegisterClientGridChunkFireHook();
 
 	}
 }
@@ -389,4 +393,87 @@ void USFGameInstanceModule::RegisterClientConstructChunkGuardHook()
 	);
 
 	UE_LOG(LogSmartFoundations, Verbose, TEXT("✅ Client construct chunk-guard hook registered (MP Slice 0 Phase 1, Server_ConstructHologram)"));
+}
+
+// MP Slice 0 chunking. A Smart grid above this many total cells will not fit one 64KB Server_ConstructHologram.
+// We slice the active hologram's children down to a chunk that fits, BEFORE vanilla serializes (at the fire
+// handler). Increment 1 builds a single chunk to prove the shrink-then-vanilla-serialize mechanic.
+static constexpr int32 SF_MP_OVERSIZED_CELLS = 130; // trigger chunking above this (total cells incl. parent)
+static constexpr int32 SF_MP_CHUNK_KEEP_CHILDREN = 100; // Increment 1: keep this many grid children; drop the rest
+
+void USFGameInstanceModule::RegisterClientGridChunkFireHook()
+{
+	SUBSCRIBE_METHOD(
+		UFGBuildGunStateBuild::InternalExecuteDuBuildStepInput,
+		[](auto& scope, UFGBuildGunStateBuild* self, bool isInputFromARelease)
+		{
+			if (!self)
+			{
+				return;
+			}
+
+			UWorld* World = self->GetWorld();
+			if (!World || !FSFNetworkHelper::IsClient(World))
+			{
+				return; // only a network client serializes over the wire
+			}
+
+			AFGHologram* Holo = self->GetHologram();
+			if (!Holo)
+			{
+				return;
+			}
+
+			// mChildren / mChildrenNameLookupMap are accessible via the USFGameInstanceModule friend AT.
+			TArray<TObjectPtr<AFGHologram>>& Children = Holo->mChildren;
+
+			static const FName GridChildTag(TEXT("SF_GridChild"));
+			int32 GridChildCount = 0;
+			for (const TObjectPtr<AFGHologram>& C : Children)
+			{
+				if (C && C->Tags.Contains(GridChildTag))
+				{
+					++GridChildCount;
+				}
+			}
+			if (GridChildCount == 0)
+			{
+				return; // not a Smart scaled grid
+			}
+
+			const int32 TotalCells = GridChildCount + 1; // + parent/origin cell
+			if (TotalCells <= SF_MP_OVERSIZED_CELLS)
+			{
+				return; // fits one construct -> untouched vanilla path
+			}
+
+			// INCREMENT 1 (proof): shrink to one safe chunk before vanilla serializes. Destroy the excess grid
+			// child previews (they would otherwise orphan). If this chunk builds cleanly server-side, the
+			// shrink-then-vanilla-serialize mechanic is proven and Increment 2 will loop the remaining chunks.
+			int32 RemainingGrid = GridChildCount;
+			int32 Destroyed = 0;
+			for (int32 i = Children.Num() - 1; i >= 0 && RemainingGrid > SF_MP_CHUNK_KEEP_CHILDREN; --i)
+			{
+				AFGHologram* C = Children[i].Get();
+				if (!C || !C->Tags.Contains(GridChildTag))
+				{
+					continue; // never drop non-grid / structural children
+				}
+				const FName ChildName = C->GetNameWithinParentHologram();
+				Holo->mChildrenNameLookupMap.Remove(ChildName);
+				Children.RemoveAt(i);
+				C->Destroy();
+				--RemainingGrid;
+				++Destroyed;
+			}
+
+			UE_LOG(LogSmartFoundations, Display,
+				TEXT("[MP-CHUNK] Increment 1: oversized grid (%d cells) shrank to %d cells (destroyed %d excess child previews) before serialize. Letting vanilla build the chunk."),
+				TotalCells, RemainingGrid + 1, Destroyed);
+
+			// Do NOT cancel: vanilla now serializes + constructs the fit-in-one-RPC grid.
+		}
+	);
+
+	UE_LOG(LogSmartFoundations, Verbose, TEXT("✅ Client grid chunk fire-hook registered (MP Slice 0 chunking, InternalExecuteDuBuildStepInput)"));
 }

--- a/Source/SmartFoundations/Private/Module/SFGameInstanceModule.cpp
+++ b/Source/SmartFoundations/Private/Module/SFGameInstanceModule.cpp
@@ -27,6 +27,11 @@
 #include "Core/Helpers/SFNetworkHelper.h"     // FSFNetworkHelper::IsClient
 #include "Engine/Engine.h"                     // GEngine on-screen message
 
+// MP spec-based construction: guard bypass for spec-capable parents
+#include "Holograms/Core/SFFactoryHologram.h"
+#include "Holograms/Core/SFFoundationHologram.h"
+#include "Holograms/Core/SFScalingSpecExpansion.h"
+
 // For chain actor rebuilding
 #include "Buildables/FGBuildableConveyorBase.h"
 #include "Buildables/FGBuildableConveyorBelt.h"
@@ -425,6 +430,20 @@ void USFGameInstanceModule::RegisterClientGridChunkFireHook()
 			AFGHologram* Holo = self->GetHologram();
 			if (!Holo)
 			{
+				return;
+			}
+
+			// [MP-SPEC] When spec-based construction is enabled AND the active hologram is one of the
+			// spec-capable parents (swapped at registration), the grid children are stripped from the
+			// wire in PreConstructMessageSerialization and the message is O(1) - the oversized refusal
+			// must NOT fire. Legacy holograms (e.g. ramp subclasses not yet covered by the swap) still
+			// serialize all children, so for them the guard stays authoritative.
+			if (SFScalingSpecExpansion::IsSpecConstructionEnabled()
+				&& (Holo->IsA(ASFFactoryHologram::StaticClass()) || Holo->IsA(ASFFoundationHologram::StaticClass())))
+			{
+				UE_LOG(LogSmartFoundations, Display,
+					TEXT("[MP-SPEC] Oversized guard bypassed: %s commits via the compact spec path."),
+					*Holo->GetName());
 				return;
 			}
 

--- a/Source/SmartFoundations/Private/Module/SFGameInstanceModule.cpp
+++ b/Source/SmartFoundations/Private/Module/SFGameInstanceModule.cpp
@@ -417,6 +417,17 @@ void USFGameInstanceModule::RegisterClientConstructChunkGuardHook()
 // of the future complete multiplayer solution (which cannot ship partially; see AGENTS.md).
 static constexpr int32 SF_MP_OVERSIZED_CELLS = 130; // refuse a client grid above this (total cells incl. parent)
 
+// [MP-SPEC] #334 stopgap: Smart auto-connect preview child tags stripped before a client fire
+// (defined at file scope - a brace-initializer inside a SUBSCRIBE_METHOD macro argument splits
+// the macro args on its commas, same gotcha as multi-capture lambda lists).
+static const FName GSFAutoConnectChildTags[] = {
+	FName(TEXT("SF_BeltAutoConnectChild")),
+	FName(TEXT("SF_PipeAutoConnectChild")),
+	FName(TEXT("SF_PowerAutoConnectChild")),
+	FName(TEXT("SF_StackableChild")),
+};
+static constexpr int32 GSFAutoConnectChildTagCount = UE_ARRAY_COUNT(GSFAutoConnectChildTags);
+
 void USFGameInstanceModule::RegisterClientGridChunkFireHook()
 {
 	SUBSCRIBE_METHOD(
@@ -438,6 +449,48 @@ void USFGameInstanceModule::RegisterClientGridChunkFireHook()
 			if (!Holo)
 			{
 				return;
+			}
+
+			// [MP-SPEC] #334 STOPGAP: Smart auto-connect preview children (belts / pipes / wires /
+			// stackable poles) must NEVER cross the construct message - the server crashes
+			// deserializing them (live 2026-06-09: assert in AFGConveyorBeltHologram::
+			// UpdateSplineComponent via OnRep_SplineData inside Server_ConstructHologram, empty
+			// spline array; a 1x1 merger fire with auto-connect belts killed the dedi). Until the
+			// #334 slice rebuilds the wiring server-side with authority, strip + destroy these
+			// preview children at fire time. Auto-connect therefore does not WIRE in MP yet - the
+			// pre-existing #334 status - but it no longer crashes the server. SP/listen-host are
+			// unaffected (this hook is NM_Client-only). Applies to ALL client fires when the spec
+			// path is enabled, grid or not (the crash case was a 1x1).
+			if (SFScalingSpecExpansion::IsSpecConstructionEnabled())
+			{
+				TArray<AFGHologram*> AutoConnectToStrip;
+				for (AFGHologram* Child : Holo->mChildren)
+				{
+					if (!Child)
+					{
+						continue;
+					}
+					for (int32 TagIdx = 0; TagIdx < GSFAutoConnectChildTagCount; ++TagIdx)
+					{
+						if (Child->Tags.Contains(GSFAutoConnectChildTags[TagIdx]))
+						{
+							AutoConnectToStrip.Add(Child);
+							break;
+						}
+					}
+				}
+				if (AutoConnectToStrip.Num() > 0)
+				{
+					for (AFGHologram* Child : AutoConnectToStrip)
+					{
+						Holo->mChildren.Remove(Child);
+						Child->Destroy();
+					}
+					UE_LOG(LogSmartFoundations, Display,
+						TEXT("[MP-SPEC] Stripped %d auto-connect preview children before the fire ")
+						TEXT("(server-side wiring pending, #334)."),
+						AutoConnectToStrip.Num());
+				}
 			}
 
 			// Count Smart grid child holograms (tagged SF_GridChild). +1 for the parent/origin cell.

--- a/Source/SmartFoundations/Private/Module/SFGameInstanceModule.cpp
+++ b/Source/SmartFoundations/Private/Module/SFGameInstanceModule.cpp
@@ -885,6 +885,23 @@ void USFGameInstanceModule::RegisterSpecConstructionHooks()
 			}
 		});
 
+	// Symmetric detector: a REMOVAL mid-tick can shrink-reallocate mFactoryBuildings, freeing the
+	// buffer under the ParallelFor workers just like a growth realloc (9th repro: Add detector
+	// silent, pre-tick scrub valid -> the mutation, whatever it is, happens DURING the tick).
+	SUBSCRIBE_METHOD(
+		AFGBuildableSubsystem::RemoveBuildable,
+		[](auto& scope, AFGBuildableSubsystem* self, AFGBuildable* buildable)
+		{
+			if (bInsideFactoryTick)
+			{
+				UE_LOG(LogSmartFoundations, Error,
+					TEXT("[CHAIN-DIAG] RemoveBuildable(%s / %s) DURING TickFactory! A shrink-realloc frees the buffer under the ParallelFor - THE freed-buffer tick AV. Callstack follows."),
+					buildable ? *buildable->GetName() : TEXT("null"),
+					buildable ? *GetNameSafe(buildable->GetClass()) : TEXT("null"));
+				FDebug::DumpStackTraceToLog(ELogVerbosity::Error);
+			}
+		});
+
 	// [CHAIN-FIX] Destruction chokepoint guard, ALL buildables. cdb on the 5th freed-pointer tick
 	// AV (2026-06-10) identified the crashing loop: TickFactoryActors' lambda walks
 	// mFactoryBuildings (subsystem +0x3C0, confirmed via PDB) and virtual-calls each entry - the

--- a/Source/SmartFoundations/Private/Module/SFGameInstanceModule.cpp
+++ b/Source/SmartFoundations/Private/Module/SFGameInstanceModule.cpp
@@ -396,10 +396,25 @@ void USFGameInstanceModule::RegisterClientConstructChunkGuardHook()
 }
 
 // MP Slice 0 chunking. A Smart grid above this many total cells will not fit one 64KB Server_ConstructHologram.
-// We slice the active hologram's children down to a chunk that fits, BEFORE vanilla serializes (at the fire
-// handler). Increment 1 builds a single chunk to prove the shrink-then-vanilla-serialize mechanic.
 static constexpr int32 SF_MP_OVERSIZED_CELLS = 130; // trigger chunking above this (total cells incl. parent)
-static constexpr int32 SF_MP_CHUNK_KEEP_CHILDREN = 100; // Increment 1: keep this many grid children; drop the rest
+static constexpr int32 SF_MP_CHUNK_CHILDREN  = 100; // grid children to build per chunk (parent adds 1 cell)
+
+// Re-entrancy guard: the chunk loop re-invokes InternalExecuteDuBuildStepInput; those nested calls must pass
+// straight through to vanilla without re-chunking.
+static bool GSFChunkingInProgress = false;
+
+// Set the active hologram's child list to exactly the given actors (friend access to mChildren/lookup map).
+static void SF_SetHologramChildren(AFGHologram* Holo, const TArray<AFGHologram*>& NewChildren)
+{
+	Holo->mChildren.Reset();
+	Holo->mChildrenNameLookupMap.Reset();
+	for (AFGHologram* C : NewChildren)
+	{
+		if (!C) { continue; }
+		Holo->mChildren.Add(C);
+		Holo->mChildrenNameLookupMap.Add(C->GetNameWithinParentHologram(), C);
+	}
+}
 
 void USFGameInstanceModule::RegisterClientGridChunkFireHook()
 {
@@ -407,9 +422,9 @@ void USFGameInstanceModule::RegisterClientGridChunkFireHook()
 		UFGBuildGunStateBuild::InternalExecuteDuBuildStepInput,
 		[](auto& scope, UFGBuildGunStateBuild* self, bool isInputFromARelease)
 		{
-			if (!self)
+			if (!self || GSFChunkingInProgress)
 			{
-				return;
+				return; // nested re-fire -> let vanilla run unmodified
 			}
 
 			UWorld* World = self->GetWorld();
@@ -424,54 +439,88 @@ void USFGameInstanceModule::RegisterClientGridChunkFireHook()
 				return;
 			}
 
-			// mChildren / mChildrenNameLookupMap are accessible via the USFGameInstanceModule friend AT.
-			TArray<TObjectPtr<AFGHologram>>& Children = Holo->mChildren;
-
+			// Snapshot the Smart grid child holograms (tagged SF_GridChild), in order.
 			static const FName GridChildTag(TEXT("SF_GridChild"));
-			int32 GridChildCount = 0;
-			for (const TObjectPtr<AFGHologram>& C : Children)
+			TArray<AFGHologram*> Kids;
+			for (const TObjectPtr<AFGHologram>& C : Holo->mChildren)
 			{
 				if (C && C->Tags.Contains(GridChildTag))
 				{
-					++GridChildCount;
+					Kids.Add(C.Get());
 				}
 			}
-			if (GridChildCount == 0)
+			if (Kids.Num() == 0)
 			{
 				return; // not a Smart scaled grid
 			}
 
-			const int32 TotalCells = GridChildCount + 1; // + parent/origin cell
+			const int32 TotalCells = Kids.Num() + 1; // + parent/origin cell
 			if (TotalCells <= SF_MP_OVERSIZED_CELLS)
 			{
 				return; // fits one construct -> untouched vanilla path
 			}
 
-			// INCREMENT 1 (proof): shrink to one safe chunk before vanilla serializes. Destroy the excess grid
-			// child previews (they would otherwise orphan). If this chunk builds cleanly server-side, the
-			// shrink-then-vanilla-serialize mechanic is proven and Increment 2 will loop the remaining chunks.
-			int32 RemainingGrid = GridChildCount;
-			int32 Destroyed = 0;
-			for (int32 i = Children.Num() - 1; i >= 0 && RemainingGrid > SF_MP_CHUNK_KEEP_CHILDREN; --i)
+			// INCREMENT 2a (bounded): build TWO chunks to prove the re-fire loop respects a repositioned parent.
+			//  - Chunk 0: parent stays at the origin, children = Kids[0..99].
+			//  - Chunk 1: parent is REPOSITIONED to Kids[100]'s transform (that cell is built as the parent),
+			//    children = Kids[101..199]. If chunk 1 lands at Kids[100]'s position (not the crosshair), the
+			//    loop mechanic works and Increment 2b generalizes to all chunks.
+			// Excess cells beyond two chunks are dropped (destroyed) for this bounded proof.
+			const FTransform OriginXform = Holo->GetActorTransform();
+
+			// Build chunk 0 child set.
+			TArray<AFGHologram*> Chunk0;
+			for (int32 i = 0; i < Kids.Num() && Chunk0.Num() < SF_MP_CHUNK_CHILDREN; ++i)
 			{
-				AFGHologram* C = Children[i].Get();
-				if (!C || !C->Tags.Contains(GridChildTag))
-				{
-					continue; // never drop non-grid / structural children
-				}
-				const FName ChildName = C->GetNameWithinParentHologram();
-				Holo->mChildrenNameLookupMap.Remove(ChildName);
-				Children.RemoveAt(i);
-				C->Destroy();
-				--RemainingGrid;
-				++Destroyed;
+				Chunk0.Add(Kids[i]);
+			}
+
+			// Chunk 1 anchor (becomes the repositioned parent) + its children.
+			AFGHologram* Chunk1Anchor = (Kids.Num() > SF_MP_CHUNK_CHILDREN) ? Kids[SF_MP_CHUNK_CHILDREN] : nullptr;
+			FTransform Chunk1Xform = Chunk1Anchor ? Chunk1Anchor->GetActorTransform() : OriginXform;
+			TArray<AFGHologram*> Chunk1;
+			for (int32 i = SF_MP_CHUNK_CHILDREN + 1; i < Kids.Num() && Chunk1.Num() < SF_MP_CHUNK_CHILDREN; ++i)
+			{
+				Chunk1.Add(Kids[i]);
+			}
+
+			// Destroy any cells beyond the two chunks (bounded proof) + the anchor's old preview (the parent
+			// will build that cell when repositioned).
+			int32 Dropped = 0;
+			for (AFGHologram* K : Kids)
+			{
+				const bool bUsed = (K == Chunk1Anchor) || Chunk0.Contains(K) || Chunk1.Contains(K);
+				if (K == Chunk1Anchor) { K->Destroy(); ++Dropped; continue; }
+				if (!bUsed && K) { K->Destroy(); ++Dropped; }
 			}
 
 			UE_LOG(LogSmartFoundations, Display,
-				TEXT("[MP-CHUNK] Increment 1: oversized grid (%d cells) shrank to %d cells (destroyed %d excess child previews) before serialize. Letting vanilla build the chunk."),
-				TotalCells, RemainingGrid + 1, Destroyed);
+				TEXT("[MP-CHUNK] Increment 2a: %d cells -> chunk0(parent@origin + %d), chunk1(parent@Kids[100] + %d); dropped %d beyond two chunks."),
+				TotalCells, Chunk0.Num(), Chunk1.Num(), Dropped);
 
-			// Do NOT cancel: vanilla now serializes + constructs the fit-in-one-RPC grid.
+			// Drive the two chunks. Cancel the original fire; we re-invoke it per chunk.
+			scope.Cancel();
+			GSFChunkingInProgress = true;
+
+			// Chunk 0
+			Holo->SetActorTransform(OriginXform);
+			SF_SetHologramChildren(Holo, Chunk0);
+			UE_LOG(LogSmartFoundations, Display, TEXT("[MP-CHUNK] Increment 2a: firing chunk 0 (%d children) at origin"), Chunk0.Num());
+			self->InternalExecuteDuBuildStepInput(false);
+
+			// Chunk 1 (repositioned parent)
+			if (Chunk1Anchor)
+			{
+				Holo->SetActorTransform(Chunk1Xform);
+				SF_SetHologramChildren(Holo, Chunk1);
+				UE_LOG(LogSmartFoundations, Display, TEXT("[MP-CHUNK] Increment 2a: firing chunk 1 (%d children) at repositioned parent (Kids[100])"), Chunk1.Num());
+				self->InternalExecuteDuBuildStepInput(false);
+			}
+
+			// Clean up: clear any leftover children + restore the parent to the crosshair origin.
+			SF_SetHologramChildren(Holo, TArray<AFGHologram*>());
+			Holo->SetActorTransform(OriginXform);
+			GSFChunkingInProgress = false;
 		}
 	);
 

--- a/Source/SmartFoundations/Private/Module/SFGameInstanceModule.cpp
+++ b/Source/SmartFoundations/Private/Module/SFGameInstanceModule.cpp
@@ -428,10 +428,6 @@ static const FName GSFAutoConnectChildTags[] = {
 };
 static constexpr int32 GSFAutoConnectChildTagCount = UE_ARRAY_COUNT(GSFAutoConnectChildTags);
 
-// Alias: a TMap<A,B> inside a SUBSCRIBE macro argument splits the macro args on the template
-// comma (third occurrence of this gotcha - see the multi-capture and brace-initializer notes).
-using FSFReservedInputsMap = TMap<UFGFactoryConnectionComponent*, AFGHologram*>;
-
 void USFGameInstanceModule::RegisterClientGridChunkFireHook()
 {
 	SUBSCRIBE_METHOD(
@@ -455,17 +451,63 @@ void USFGameInstanceModule::RegisterClientGridChunkFireHook()
 				return;
 			}
 
-			// [MP-SPEC] #334 STOPGAP: Smart auto-connect preview children (belts / pipes / wires /
+			const bool bSpecEnabled = SFScalingSpecExpansion::IsSpecConstructionEnabled();
+
+			// [MP-SPEC] Capture the spec AND the auto-connect belt plan (#334) BEFORE the strip
+			// below destroys the preview holograms - the client's fire-time previews are the only
+			// complete, real wiring plan that ever exists (server-side re-derivation and aim-time
+			// preview reuse both failed live; see PLAN_MP_AutoConnect_334.md). Captured even for a
+			// 1x1: a single distributor with belts needs the server Construct seam as much as a
+			// grid does.
+			FSFScalingSpec Spec; // bValid=false by default = explicit clear
+			bool bScalable = false;
+			if (bSpecEnabled)
+			{
+				USFBuildableSizeRegistry::Initialize();
+				bScalable = USFBuildableSizeRegistry::GetProfile(Holo->GetBuildClass()).bSupportsScaling;
+				if (bScalable)
+				{
+					SFScalingSpecExpansion::CaptureScalingSpec(Holo, Spec);
+					SFScalingSpecExpansion::CaptureBeltPlan(Holo, Spec);
+
+					// [MP-334] Reliable-RPC ceiling guard: a very large belt plan could overflow
+					// Server_StageScalingSpec the same way the construct message itself once did
+					// (a silently dropped staging RPC would leave the server constructing a bare
+					// 1x1). Refuse the fire BEFORE the previews are destroyed - the grid stays
+					// live so the player can place in smaller sections. Conservative estimate:
+					// ~100B fixed + ~80B per spline point per belt (FVectors are doubles in UE5).
+					int32 PlanBytesEstimate = 0;
+					for (const FSFBeltPlanEntry& Entry : Spec.BeltPlan)
+					{
+						PlanBytesEstimate += 100 + Entry.SplinePoints.Num() * 80;
+					}
+					if (PlanBytesEstimate > 45000)
+					{
+						UE_LOG(LogSmartFoundations, Display,
+							TEXT("[MP-334] Refused client fire: belt plan too large to stage reliably (%d belts, ~%d bytes). Build in smaller sections."),
+							Spec.BeltPlan.Num(), PlanBytesEstimate);
+						if (GEngine)
+						{
+							GEngine->AddOnScreenDebugMessage(-1, 6.0f, FColor::Orange,
+								FString::Printf(TEXT("Smart!: too many auto-connect belts for one multiplayer placement (%d). Build in smaller sections."),
+									Spec.BeltPlan.Num()));
+						}
+						scope.Cancel();
+						return;
+					}
+				}
+			}
+
+			// [MP-SPEC] #334: Smart auto-connect preview children (belts / pipes / wires /
 			// stackable poles) must NEVER cross the construct message - the server crashes
 			// deserializing them (live 2026-06-09: assert in AFGConveyorBeltHologram::
 			// UpdateSplineComponent via OnRep_SplineData inside Server_ConstructHologram, empty
-			// spline array; a 1x1 merger fire with auto-connect belts killed the dedi). Until the
-			// #334 slice rebuilds the wiring server-side with authority, strip + destroy these
-			// preview children at fire time. Auto-connect therefore does not WIRE in MP yet - the
-			// pre-existing #334 status - but it no longer crashes the server. SP/listen-host are
-			// unaffected (this hook is NM_Client-only). Applies to ALL client fires when the spec
-			// path is enabled, grid or not (the crash case was a 1x1).
-			if (SFScalingSpecExpansion::IsSpecConstructionEnabled())
+			// spline array; a 1x1 merger fire with auto-connect belts killed the dedi). The belts
+			// are rebuilt server-side from the staged plan above; pipes/power wiring is still
+			// pending (#334 remaining increments). SP/listen-host are unaffected (this hook is
+			// NM_Client-only). Applies to ALL client fires when the spec path is enabled, grid or
+			// not (the crash case was a 1x1).
+			if (bSpecEnabled)
 			{
 				TArray<AFGHologram*> AutoConnectToStrip;
 				for (AFGHologram* Child : Holo->mChildren)
@@ -519,17 +561,15 @@ void USFGameInstanceModule::RegisterClientGridChunkFireHook()
 			//      preview on the next hologram automatically, matching legacy UX),
 			//   4. let the fire proceed: it serializes a clean 1-cell hologram (O(1) message); the
 			//      server's Construct hook consumes the staged spec and expands the grid.
-			if (SFScalingSpecExpansion::IsSpecConstructionEnabled())
+			if (bSpecEnabled)
 			{
-				USFBuildableSizeRegistry::Initialize();
-				if (USFBuildableSizeRegistry::GetProfile(Holo->GetBuildClass()).bSupportsScaling)
+				if (bScalable)
 				{
-					// Capture even for a 1x1 (no grid children): the staged spec is also what routes
-					// the construct through the server-side Construct hook, where auto-connect
-					// wiring is re-derived with authority (#334) - a single distributor with belts
-					// needs that as much as a grid does.
-					FSFScalingSpec Spec; // bValid=false by default = explicit clear
-					SFScalingSpecExpansion::CaptureScalingSpec(Holo, Spec);
+					// Spec (+ belt plan) was captured ABOVE, before the strip destroyed the
+					// previews. Even a 1x1 spec is staged: it routes the construct through the
+					// server-side Construct hook, where the staged belt plan is replayed with
+					// authority (#334) - a single distributor with belts needs that as much as a
+					// grid does.
 
 					// Stage (or clear) the spec server-side BEFORE the construct RPC goes out.
 					bool bStaged = false;
@@ -548,8 +588,8 @@ void USFGameInstanceModule::RegisterClientGridChunkFireHook()
 					if (Spec.bValid && bStaged)
 					{
 						UE_LOG(LogSmartFoundations, Display,
-							TEXT("[MP-SPEC] Client fire: staged spec (%d cells of %s), destroying %d preview children; construct message will be O(1)."),
-							Spec.CellCount(), *GetNameSafe(*Spec.BuildClass), GridChildCount);
+							TEXT("[MP-SPEC] Client fire: staged spec (%d cells of %s, %d planned belt(s)), destroying %d preview children; construct message will be O(1)."),
+							Spec.CellCount(), *GetNameSafe(*Spec.BuildClass), Spec.BeltPlan.Num(), GridChildCount);
 
 						// Destroy the preview grid through the helper's own cleanup (tracking stays
 						// consistent; the sticky counters regenerate the grid on the next hologram).
@@ -694,6 +734,28 @@ void USFGameInstanceModule::RegisterSpecConstructionHooks()
 			{
 				Item.Amount *= Cells;
 			}
+
+			// [MP-334] Charge the staged auto-connect belts too: exact vanilla length-based
+			// preview costs, summed client-side at capture. Without this the server-built plan
+			// belts would be free (they join mChildren only inside Construct, after costing).
+			for (const FItemAmount& BeltItem : Spec.BeltPlanCost)
+			{
+				bool bMerged = false;
+				for (FItemAmount& Item : Cost)
+				{
+					if (Item.ItemClass == BeltItem.ItemClass)
+					{
+						Item.Amount += BeltItem.Amount;
+						bMerged = true;
+						break;
+					}
+				}
+				if (!bMerged)
+				{
+					Cost.Add(BeltItem);
+				}
+			}
+
 			scope.Override(Cost);
 		});
 
@@ -723,85 +785,15 @@ void USFGameInstanceModule::RegisterSpecConstructionHooks()
 				SFScalingSpecExpansion::ExpandScalingSpecIntoChildren(self, Spec, self->GetRecipe());
 			}
 
-			// [MP-334] Server-side auto-connect wiring. Re-run the belt decision pipeline on the
-			// parent + the expanded grid children RIGHT BEFORE construct: the service attaches the
-			// resulting belt previews as REAL child holograms (the conduit base AddChilds them),
-			// so the vanilla child-construct loop below builds + wires them - the exact mechanism
-			// SP uses, executed where authority lives. (The client's preview belt children are
-			// stripped at fire - they crash the server in deserialization - and the server's own
-			// mirror previews are clobbered when the construct message deserializes into it, so
-			// this re-derivation is the authoritative source of MP wiring.)
-			if (USFSubsystem* SS = USFSubsystem::Get(self->GetWorld()))
-			{
-				if (USFAutoConnectService* AutoConnect = SS->GetAutoConnectService())
-				{
-					if (USFAutoConnectService::IsDistributorHologram(self))
-					{
-						// Copy the child list first: processing appends belt children to it.
-						TArray<AFGHologram*> DistributorChildren;
-						for (AFGHologram* Child : self->GetHologramChildren())
-						{
-							if (Child && USFAutoConnectService::IsDistributorHologram(Child))
-							{
-								DistributorChildren.Add(Child);
-							}
-						}
-
-						// PRIMARY PATH: re-attach the server's own AIM-TIME previews. The server's
-						// mirror pipeline already derived the wiring plan for the parent (fully
-						// routed belt holograms with snapped connectors, stored in the service map,
-						// proven alive at this moment by the gate diagnostics) - the construct-
-						// message deserialization merely knocked them out of mChildren. Re-derive
-						// via ProcessSingleDistributor returned 0 here for every distributor even
-						// with 20+ nearby buildings found (live rounds 1-2), so reuse beats
-						// re-derivation for the parent.
-						int32 BeltPreviews = 0;
-						if (TArray<TSharedPtr<FBeltPreviewHelper>>* StoredPreviews = AutoConnect->GetBeltPreviews(self))
-						{
-							for (const TSharedPtr<FBeltPreviewHelper>& Helper : *StoredPreviews)
-							{
-								if (!Helper.IsValid())
-								{
-									continue;
-								}
-								AFGSplineHologram* BeltHolo = Helper->GetHologram();
-								if (!IsValid(BeltHolo))
-								{
-									continue;
-								}
-								if (!self->GetHologramChildren().Contains(BeltHolo))
-								{
-									self->AddChild(BeltHolo, BeltHolo->GetFName());
-								}
-								++BeltPreviews;
-							}
-						}
-						UE_LOG(LogSmartFoundations, Display,
-							TEXT("[MP-334]   parent %s: re-attached %d stored aim-time belt previews."),
-							*self->GetName(), BeltPreviews);
-
-						// Grid children have no aim-time previews (they exist only at construct);
-						// re-derivation is still the plan for them, but it currently yields 0 -
-						// keep the diagnostic to debug with the parent as a working comparison.
-						FSFReservedInputsMap ReservedInputs;
-						for (AFGHologram* Distributor : DistributorChildren)
-						{
-							const FVector DistLoc = Distributor->GetActorLocation();
-							const int32 NearbyCount = SS->FindNearbyBuildings(DistLoc, 2500.0f).Num();
-							const int32 Made = AutoConnect->ProcessSingleDistributor(Distributor, &ReservedInputs).Num();
-							BeltPreviews += Made;
-							UE_LOG(LogSmartFoundations, Display,
-								TEXT("[MP-334]   grid child %s at %s: nearbyBuildings=%d -> beltPreviews=%d"),
-								*Distributor->GetName(), *DistLoc.ToCompactString(), NearbyCount, Made);
-						}
-
-						UE_LOG(LogSmartFoundations, Display,
-							TEXT("[MP-334] Server-side auto-connect: %d belt previews attached pre-construct ")
-							TEXT("(parent + %d grid distributors); vanilla construct will build + wire them."),
-							BeltPreviews, DistributorChildren.Num());
-					}
-				}
-			}
+			// [MP-334] Server-side auto-connect belt wiring: replay the CLIENT'S staged belt plan.
+			// The client's fire-time previews are the only complete, real plan that ever exists -
+			// server-side re-derivation (ProcessSingleDistributor) returned 0 at this seam, and the
+			// server's own aim-time previews are empty here / not construct-grade (three failed
+			// approaches, live-proven 2026-06-09; see PLAN_MP_AutoConnect_334.md). The plan belts
+			// are appended AFTER the grid children, so the vanilla child-construct loop below
+			// builds the distributors first and each belt's SF_BeltAutoConnectChild Construct path
+			// wires it geometrically against BUILT actors - the same mechanism SP uses.
+			SFScalingSpecExpansion::SpawnBeltPlanChildren(self, Spec);
 
 			// Spawn the group proxy BEFORE construction and expose it for the window of this
 			// construct: the ConfigureActor hook below assigns it to every buildable configured

--- a/Source/SmartFoundations/Private/Module/SFGameInstanceModule.cpp
+++ b/Source/SmartFoundations/Private/Module/SFGameInstanceModule.cpp
@@ -543,6 +543,7 @@ void USFGameInstanceModule::RegisterClientGridChunkFireHook()
 								ExtendSpec.Clone = FSFCloneTopology::FromSource(Source, FinalOffset);
 								ExtendSpec.Cost = Holo->GetCost(true); // parent + preview children
 								ExtendSpec.BuildClass = Holo->GetBuildClass();
+								ExtendSpec.SourceBuilding = Topo.SourceBuilding.Get();
 								ExtendSpec.bValid = ExtendSpec.Clone.ChildHolograms.Num() > 0;
 							}
 						}
@@ -999,6 +1000,7 @@ void USFGameInstanceModule::RegisterSpecConstructionHooks()
 					if (USFExtendService* Extend = SS->GetExtendService())
 					{
 						Extend->SetStoredCloneTopologyForServerCommit(ExtendSpec.Clone);
+						Extend->SetServerCommitSourceBuilding(ExtendSpec.SourceBuilding);
 						FSFSpawnedCloneMap SpawnedClones;
 						const int32 NumSpawned = ExtendSpec.Clone.SpawnChildHolograms(self, Extend, SpawnedClones);
 						const int32 NumWired = ExtendSpec.Clone.WireChildHologramConnections(SpawnedClones, self);

--- a/Source/SmartFoundations/Private/Module/SFGameInstanceModule.cpp
+++ b/Source/SmartFoundations/Private/Module/SFGameInstanceModule.cpp
@@ -577,8 +577,8 @@ void USFGameInstanceModule::RegisterClientGridChunkFireHook()
 								Child->Destroy();
 							}
 							UE_LOG(LogSmartFoundations, Display,
-								TEXT("[EXTEND-MP] Client fire: staged Extend commit (%d clone children), destroyed %d previews; construct message will be O(1)."),
-								ExtendSpec.Clone.ChildHolograms.Num(), ToDestroy.Num());
+								TEXT("[EXTEND-MP] Client fire: staged Extend commit (offset %s, %d scaled clone(s)), destroyed %d previews; construct message will be O(1)."),
+								*ExtendSpec.ParentOffset.ToCompactString(), ExtendSpec.ScaledClones.Num(), ToDestroy.Num());
 							return; // fire proceeds with the childless parent
 						}
 					}
@@ -984,31 +984,19 @@ void USFGameInstanceModule::RegisterSpecConstructionHooks()
 			}
 			else
 			{
-				// [EXTEND-MP] Reconstruct the clone children from the staged commit - the SAME
-				// executor the client preview uses (FSFCloneTopology::SpawnChildHolograms +
-				// WireChildHologramConnections), run server-side pre-scope(). The children's own
-				// Construct paths populate the Extend wiring registries (RegisterJsonBuiltActor,
-				// chain registrations), and the deferred post-build wiring (OnActorSpawned on the
-				// built factory, authority-side) finishes the wiring exactly as SP does. The
-				// staged topology is installed as StoredCloneTopology so that pass finds the
-				// same state an SP build would have.
+				// [EXTEND-MP] Reconstruct the FULL commit server-side, pre-scope(): authoritative
+				// graph walk -> CaptureFromTopology -> FromSource(ParentOffset) -> spawn parent
+				// clone set + scaled clone sets. The topology MUST be derived here, never shipped
+				// from the client - client-side capture poisons every segment connection because
+				// GetConnection() is null on clients (live root cause 2026-06-10: empty wiring
+				// manifests, every MP Extend built unwired). The children's Construct paths
+				// populate the wiring registries; the synchronous wiring pass below finishes the
+				// job with authority.
 				if (USFSubsystem* SS = USFSubsystem::Get(self->GetWorld()))
 				{
 					if (USFExtendService* Extend = SS->GetExtendService())
 					{
-						Extend->SetStoredCloneTopologyForServerCommit(ExtendSpec.Clone);
-						Extend->SetServerCommitSourceBuilding(ExtendSpec.SourceBuilding);
-						FSFSpawnedCloneMap SpawnedClones;
-						const int32 NumSpawned = ExtendSpec.Clone.SpawnChildHolograms(self, Extend, SpawnedClones);
-						const int32 NumWired = ExtendSpec.Clone.WireChildHologramConnections(SpawnedClones, self);
-						UE_LOG(LogSmartFoundations, Display,
-							TEXT("[EXTEND-MP] Server reconstructed %d/%d clone children (%d pre-wired) for %s; vanilla construct will build them."),
-							NumSpawned, ExtendSpec.Clone.ChildHolograms.Num(), NumWired, *self->GetName());
-
-						// Scaled Extend: re-run the SP spawn pipeline for the additional clone
-						// sets (factory children + infrastructure + lanes) from the shipped
-						// per-clone parameters + the server's own authoritative topology walk.
-						Extend->ReconstructScaledCommitOnServer(self, ExtendSpec.ScaledClones);
+						Extend->ReconstructCommitOnServer(self, ExtendSpec);
 					}
 				}
 			}

--- a/Source/SmartFoundations/Private/Module/SFGameInstanceModule.cpp
+++ b/Source/SmartFoundations/Private/Module/SFGameInstanceModule.cpp
@@ -468,7 +468,7 @@ void USFGameInstanceModule::RegisterClientGridChunkFireHook()
 				if (bScalable)
 				{
 					SFScalingSpecExpansion::CaptureScalingSpec(Holo, Spec);
-					SFScalingSpecExpansion::CaptureBeltPlan(Holo, Spec);
+					SFScalingSpecExpansion::CaptureConduitPlan(Holo, Spec);
 
 					// [MP-334] Reliable-RPC ceiling guard: a very large belt plan could overflow
 					// Server_StageScalingSpec the same way the construct message itself once did
@@ -477,20 +477,20 @@ void USFGameInstanceModule::RegisterClientGridChunkFireHook()
 					// live so the player can place in smaller sections. Conservative estimate:
 					// ~100B fixed + ~80B per spline point per belt (FVectors are doubles in UE5).
 					int32 PlanBytesEstimate = 0;
-					for (const FSFBeltPlanEntry& Entry : Spec.BeltPlan)
+					for (const FSFConduitPlanEntry& Entry : Spec.ConduitPlan)
 					{
 						PlanBytesEstimate += 100 + Entry.SplinePoints.Num() * 80;
 					}
 					if (PlanBytesEstimate > 45000)
 					{
 						UE_LOG(LogSmartFoundations, Display,
-							TEXT("[MP-334] Refused client fire: belt plan too large to stage reliably (%d belts, ~%d bytes). Build in smaller sections."),
-							Spec.BeltPlan.Num(), PlanBytesEstimate);
+							TEXT("[MP-334] Refused client fire: conduit plan too large to stage reliably (%d conduits, ~%d bytes). Build in smaller sections."),
+							Spec.ConduitPlan.Num(), PlanBytesEstimate);
 						if (GEngine)
 						{
 							GEngine->AddOnScreenDebugMessage(-1, 6.0f, FColor::Orange,
-								FString::Printf(TEXT("Smart!: too many auto-connect belts for one multiplayer placement (%d). Build in smaller sections."),
-									Spec.BeltPlan.Num()));
+								FString::Printf(TEXT("Smart!: too many auto-connect belts/pipes/wires for one multiplayer placement (%d). Build in smaller sections."),
+									Spec.ConduitPlan.Num()));
 						}
 						scope.Cancel();
 						return;
@@ -588,8 +588,8 @@ void USFGameInstanceModule::RegisterClientGridChunkFireHook()
 					if (Spec.bValid && bStaged)
 					{
 						UE_LOG(LogSmartFoundations, Display,
-							TEXT("[MP-SPEC] Client fire: staged spec (%d cells of %s, %d planned belt(s)), destroying %d preview children; construct message will be O(1)."),
-							Spec.CellCount(), *GetNameSafe(*Spec.BuildClass), Spec.BeltPlan.Num(), GridChildCount);
+							TEXT("[MP-SPEC] Client fire: staged spec (%d cells of %s, %d planned conduit(s)), destroying %d preview children; construct message will be O(1)."),
+							Spec.CellCount(), *GetNameSafe(*Spec.BuildClass), Spec.ConduitPlan.Num(), GridChildCount);
 
 						// Destroy the preview grid through the helper's own cleanup (tracking stays
 						// consistent; the sticky counters regenerate the grid on the next hologram).
@@ -738,7 +738,7 @@ void USFGameInstanceModule::RegisterSpecConstructionHooks()
 			// [MP-334] Charge the staged auto-connect belts too: exact vanilla length-based
 			// preview costs, summed client-side at capture. Without this the server-built plan
 			// belts would be free (they join mChildren only inside Construct, after costing).
-			for (const FItemAmount& BeltItem : Spec.BeltPlanCost)
+			for (const FItemAmount& BeltItem : Spec.ConduitPlanCost)
 			{
 				bool bMerged = false;
 				for (FItemAmount& Item : Cost)
@@ -793,7 +793,7 @@ void USFGameInstanceModule::RegisterSpecConstructionHooks()
 			// are appended AFTER the grid children, so the vanilla child-construct loop below
 			// builds the distributors first and each belt's SF_BeltAutoConnectChild Construct path
 			// wires it geometrically against BUILT actors - the same mechanism SP uses.
-			SFScalingSpecExpansion::SpawnBeltPlanChildren(self, Spec);
+			SFScalingSpecExpansion::SpawnConduitPlanChildren(self, Spec);
 
 			// Spawn the group proxy BEFORE construction and expose it for the window of this
 			// construct: the ConfigureActor hook below assigns it to every buildable configured

--- a/Source/SmartFoundations/Private/Module/SFGameInstanceModule.cpp
+++ b/Source/SmartFoundations/Private/Module/SFGameInstanceModule.cpp
@@ -747,23 +747,51 @@ void USFGameInstanceModule::RegisterSpecConstructionHooks()
 							}
 						}
 
-						FSFReservedInputsMap ReservedInputs;
+						// PRIMARY PATH: re-attach the server's own AIM-TIME previews. The server's
+						// mirror pipeline already derived the wiring plan for the parent (fully
+						// routed belt holograms with snapped connectors, stored in the service map,
+						// proven alive at this moment by the gate diagnostics) - the construct-
+						// message deserialization merely knocked them out of mChildren. Re-derive
+						// via ProcessSingleDistributor returned 0 here for every distributor even
+						// with 20+ nearby buildings found (live rounds 1-2), so reuse beats
+						// re-derivation for the parent.
 						int32 BeltPreviews = 0;
-
-						TArray<AFGHologram*> AllDistributors;
-						AllDistributors.Add(self);
-						AllDistributors.Append(DistributorChildren);
-						for (AFGHologram* Distributor : AllDistributors)
+						if (TArray<TSharedPtr<FBeltPreviewHelper>>* StoredPreviews = AutoConnect->GetBeltPreviews(self))
 						{
-							// [MP-334] TEMP diagnostic: the first live round returned 0 previews for
-							// every distributor while the aim-time pipeline succeeds on the same
-							// hologram - log the raw inputs of the decision at this exact moment.
+							for (const TSharedPtr<FBeltPreviewHelper>& Helper : *StoredPreviews)
+							{
+								if (!Helper.IsValid())
+								{
+									continue;
+								}
+								AFGSplineHologram* BeltHolo = Helper->GetHologram();
+								if (!IsValid(BeltHolo))
+								{
+									continue;
+								}
+								if (!self->GetHologramChildren().Contains(BeltHolo))
+								{
+									self->AddChild(BeltHolo, BeltHolo->GetFName());
+								}
+								++BeltPreviews;
+							}
+						}
+						UE_LOG(LogSmartFoundations, Display,
+							TEXT("[MP-334]   parent %s: re-attached %d stored aim-time belt previews."),
+							*self->GetName(), BeltPreviews);
+
+						// Grid children have no aim-time previews (they exist only at construct);
+						// re-derivation is still the plan for them, but it currently yields 0 -
+						// keep the diagnostic to debug with the parent as a working comparison.
+						FSFReservedInputsMap ReservedInputs;
+						for (AFGHologram* Distributor : DistributorChildren)
+						{
 							const FVector DistLoc = Distributor->GetActorLocation();
 							const int32 NearbyCount = SS->FindNearbyBuildings(DistLoc, 2500.0f).Num();
 							const int32 Made = AutoConnect->ProcessSingleDistributor(Distributor, &ReservedInputs).Num();
 							BeltPreviews += Made;
 							UE_LOG(LogSmartFoundations, Display,
-								TEXT("[MP-334]   distributor %s at %s: nearbyBuildings=%d -> beltPreviews=%d"),
+								TEXT("[MP-334]   grid child %s at %s: nearbyBuildings=%d -> beltPreviews=%d"),
 								*Distributor->GetName(), *DistLoc.ToCompactString(), NearbyCount, Made);
 						}
 

--- a/Source/SmartFoundations/Private/Module/SFGameInstanceModule.cpp
+++ b/Source/SmartFoundations/Private/Module/SFGameInstanceModule.cpp
@@ -500,6 +500,31 @@ void USFGameInstanceModule::RegisterClientGridChunkFireHook()
 				return;
 			}
 
+			// [EXTEND-MP] INTERIM GUARD until the Extend commit is ported (slice 2): a client
+			// fire with Extend clone children serializes them into the construct message, and the
+			// recipe-less belt/lift clones assert the CLIENT in SerializeConstructMessage (live
+			// crash 2026-06-10: "Assertion failed: hologramRecipe" via the pending-ghost path in
+			// SetupPendingConstructionHologram). Refuse the fire; the preview stays live.
+			{
+				static const FName ExtendChildTag(TEXT("SF_ExtendChild"));
+				for (AFGHologram* Child : Holo->GetHologramChildren())
+				{
+					if (Child && Child->Tags.Contains(ExtendChildTag))
+					{
+						UE_LOG(LogSmartFoundations, Display,
+							TEXT("[EXTEND-MP] Refused client Extend fire on %s: the Extend commit is not ported to multiplayer yet (slice 2)."),
+							*Holo->GetName());
+						if (GEngine)
+						{
+							GEngine->AddOnScreenDebugMessage(-1, 6.0f, FColor::Orange,
+								TEXT("Smart!: Extend building in multiplayer is not supported yet."));
+						}
+						scope.Cancel();
+						return;
+					}
+				}
+			}
+
 			const bool bSpecEnabled = SFScalingSpecExpansion::IsSpecConstructionEnabled();
 
 			// [MP-SPEC] Capture the spec AND the auto-connect belt plan (#334) BEFORE the strip

--- a/Source/SmartFoundations/Private/Module/SFGameInstanceModule.cpp
+++ b/Source/SmartFoundations/Private/Module/SFGameInstanceModule.cpp
@@ -812,6 +812,35 @@ void USFGameInstanceModule::RegisterSpecConstructionHooks()
 			AActor* BuiltParent = scope(self, out_children, constructionID);
 
 			GSFActiveSpecGroupProxy.Reset();
+
+			// [MP-334] Post-construct sweep: spline buildables (the plan belts) never reach the
+			// AFGBuildableHologram::ConfigureActor BASE body our pre-BeginPlay hook patches (the
+			// vanilla spline-hologram chain configures them elsewhere - live finding 2026-06-09:
+			// proxy registered the 4 mergers but none of the 7 belts). Registering them HERE is
+			// safe because conveyors are real actors, never lightweight - the pre-BeginPlay window
+			// only matters for lightweight conversion (foundations). The GetBlueprintProxy() guard
+			// skips everything Hook C already registered.
+			if (GroupProxy)
+			{
+				for (AActor* Child : out_children)
+				{
+					AFGBuildable* ChildBuildable = Cast<AFGBuildable>(Child);
+					if (ChildBuildable && !ChildBuildable->GetBlueprintProxy())
+					{
+						ChildBuildable->SetBlueprintProxy(GroupProxy);
+						GroupProxy->RegisterBuildable(ChildBuildable);
+					}
+				}
+				if (AFGBuildable* ParentBuildable = Cast<AFGBuildable>(BuiltParent))
+				{
+					if (!ParentBuildable->GetBlueprintProxy())
+					{
+						ParentBuildable->SetBlueprintProxy(GroupProxy);
+						GroupProxy->RegisterBuildable(ParentBuildable);
+					}
+				}
+			}
+
 			if (GroupProxy)
 			{
 				UE_LOG(LogSmartFoundations, Display,

--- a/Source/SmartFoundations/Private/Module/SFGameInstanceModule.cpp
+++ b/Source/SmartFoundations/Private/Module/SFGameInstanceModule.cpp
@@ -845,6 +845,13 @@ void USFGameInstanceModule::RegisterSpecConstructionHooks()
 	// corrupt entry appears in mFactoryBuildings by some path none of the chokepoint guards see.
 	// Validate the arrays IMMEDIATELY before vanilla's ParallelFor walks them: the corrupt entry
 	// is removed (server survives) and the log pinpoints its index + valid neighbors.
+	// bInsideFactoryTick: the 8th repro proved the corruption happens MID-tick (the pre-tick
+	// scrub found every entry valid on the very tick that crashed). Leading theory: something
+	// REGISTERS a buildable while the ParallelFor walks mFactoryBuildings -> TArray realloc ->
+	// workers read the freed old buffer (garbage entries, exactly the dump signature). The flag
+	// + the AddBuildable hook below convict the registrant by name.
+	static bool bInsideFactoryTick = false;
+
 	SUBSCRIBE_METHOD(
 		AFGBuildableSubsystem::TickFactory,
 		[](auto& scope, AFGBuildableSubsystem* self, float dt, ELevelTick TickType)
@@ -858,6 +865,23 @@ void USFGameInstanceModule::RegisterSpecConstructionHooks()
 						ChainSvc->ScrubFactoryTickArrays();
 					}
 				}
+			}
+			bInsideFactoryTick = true;
+			scope(self, dt, TickType);
+			bInsideFactoryTick = false;
+		});
+
+	SUBSCRIBE_METHOD(
+		AFGBuildableSubsystem::AddBuildable,
+		[](auto& scope, AFGBuildableSubsystem* self, AFGBuildable* buildable)
+		{
+			if (bInsideFactoryTick)
+			{
+				UE_LOG(LogSmartFoundations, Error,
+					TEXT("[CHAIN-DIAG] AddBuildable(%s / %s) DURING TickFactory! mFactoryBuildings can realloc under the ParallelFor - THE freed-buffer tick AV. Callstack follows."),
+					buildable ? *buildable->GetName() : TEXT("null"),
+					buildable ? *GetNameSafe(buildable->GetClass()) : TEXT("null"));
+				FDebug::DumpStackTraceToLog(ELogVerbosity::Error);
 			}
 		});
 

--- a/Source/SmartFoundations/Private/Module/SFGameInstanceModule.cpp
+++ b/Source/SmartFoundations/Private/Module/SFGameInstanceModule.cpp
@@ -577,7 +577,7 @@ void USFGameInstanceModule::RegisterClientGridChunkFireHook()
 								Holo->mChildren.Remove(Child);
 								Child->Destroy();
 							}
-							UE_LOG(LogSmartFoundations, Display,
+							UE_LOG(LogSmartFoundations, Verbose,
 								TEXT("[EXTEND-MP] Client fire: staged Extend commit (offset %s, %d scaled clone(s)), destroyed %d previews; construct message will be O(1)."),
 								*ExtendSpec.ParentOffset.ToCompactString(), ExtendSpec.ScaledClones.Num(), ToDestroy.Num());
 							return; // fire proceeds with the childless parent
@@ -586,7 +586,7 @@ void USFGameInstanceModule::RegisterClientGridChunkFireHook()
 
 					// Could not stage (spec disabled / no topology / RCO unreachable): refuse the
 					// fire - serializing the clone children would assert this client.
-					UE_LOG(LogSmartFoundations, Display,
+					UE_LOG(LogSmartFoundations, Verbose,
 						TEXT("[EXTEND-MP] Refused client Extend fire on %s: could not stage the Extend commit."),
 						*Holo->GetName());
 					if (GEngine)
@@ -631,7 +631,7 @@ void USFGameInstanceModule::RegisterClientGridChunkFireHook()
 					}
 					if (PlanBytesEstimate > 45000)
 					{
-						UE_LOG(LogSmartFoundations, Display,
+						UE_LOG(LogSmartFoundations, Verbose,
 							TEXT("[MP-334] Refused client fire: conduit plan too large to stage reliably (%d conduits, ~%d bytes). Build in smaller sections."),
 							Spec.ConduitPlan.Num(), PlanBytesEstimate);
 						if (GEngine)
@@ -680,7 +680,7 @@ void USFGameInstanceModule::RegisterClientGridChunkFireHook()
 						Holo->mChildren.Remove(Child);
 						Child->Destroy();
 					}
-					UE_LOG(LogSmartFoundations, Display,
+					UE_LOG(LogSmartFoundations, Verbose,
 						TEXT("[MP-SPEC] Stripped %d auto-connect preview children before the fire ")
 						TEXT("(server-side wiring pending, #334)."),
 						AutoConnectToStrip.Num());
@@ -738,7 +738,7 @@ void USFGameInstanceModule::RegisterClientGridChunkFireHook()
 
 					if (Spec.bValid && bStaged)
 					{
-						UE_LOG(LogSmartFoundations, Display,
+						UE_LOG(LogSmartFoundations, Verbose,
 							TEXT("[MP-SPEC] Client fire: staged spec (%d cells of %s, %d planned conduit(s)), destroying %d preview children; construct message will be O(1)."),
 							Spec.CellCount(), *GetNameSafe(*Spec.BuildClass), Spec.ConduitPlan.Num(), GridChildCount);
 
@@ -840,18 +840,11 @@ void USFGameInstanceModule::RegisterSpecConstructionHooks()
 			}
 		});
 
-	// [CHAIN-FIX] Pre-tick integrity scrub. 7 freed-pointer tick AV repros with three falsified
-	// theories (RemoveConveyor skip, conveyor EndPlay skip, buildable EndPlay skip, arrows) - the
-	// corrupt entry appears in mFactoryBuildings by some path none of the chokepoint guards see.
-	// Validate the arrays IMMEDIATELY before vanilla's ParallelFor walks them: the corrupt entry
-	// is removed (server survives) and the log pinpoints its index + valid neighbors.
-	// bInsideFactoryTick: the 8th repro proved the corruption happens MID-tick (the pre-tick
-	// scrub found every entry valid on the very tick that crashed). Leading theory: something
-	// REGISTERS a buildable while the ParallelFor walks mFactoryBuildings -> TArray realloc ->
-	// workers read the freed old buffer (garbage entries, exactly the dump signature). The flag
-	// + the AddBuildable hook below convict the registrant by name.
-	static bool bInsideFactoryTick = false;
-
+	// [CHAIN-FIX] Pre-tick integrity scrub (permanent safety net, ~2us for ~2k entries): validate
+	// mFactoryBuildings (+ groups) immediately before vanilla's ParallelFor walks them. A corrupt
+	// entry is removed (the server survives the tick) and logged with its index + valid neighbors.
+	// Kept after the 2026-06-10 wild-free incident (GetCost hook Override-without-invoke, fixed):
+	// this class of bug otherwise kills dedicated servers minutes after the corrupting write.
 	SUBSCRIBE_METHOD(
 		AFGBuildableSubsystem::TickFactory,
 		[](auto& scope, AFGBuildableSubsystem* self, float dt, ELevelTick TickType)
@@ -865,60 +858,6 @@ void USFGameInstanceModule::RegisterSpecConstructionHooks()
 						ChainSvc->ScrubFactoryTickArrays();
 					}
 				}
-			}
-			bInsideFactoryTick = true;
-			scope(self, dt, TickType);
-			bInsideFactoryTick = false;
-		});
-
-	SUBSCRIBE_METHOD(
-		AFGBuildableSubsystem::AddBuildable,
-		[](auto& scope, AFGBuildableSubsystem* self, AFGBuildable* buildable)
-		{
-			if (bInsideFactoryTick)
-			{
-				UE_LOG(LogSmartFoundations, Error,
-					TEXT("[CHAIN-DIAG] AddBuildable(%s / %s) DURING TickFactory! mFactoryBuildings can realloc under the ParallelFor - THE freed-buffer tick AV. Callstack follows."),
-					buildable ? *buildable->GetName() : TEXT("null"),
-					buildable ? *GetNameSafe(buildable->GetClass()) : TEXT("null"));
-				FDebug::DumpStackTraceToLog(ELogVerbosity::Error);
-			}
-		});
-
-	// [CHAIN-DIAG] Mid-tick SPAWN detector. Live forensics (repro 12) proved: Num grew 1843->1844
-	// DURING the crashing tick (the AddBuildable hook missed it - inlined call site), and the
-	// corrupt entry was a real actor whose first 16 bytes held an allocator freelist link with
-	// the rest of the actor (PrimaryActorTick vftable at +0x30) intact - i.e. a buildable is
-	// spawned, registered, destroyed, AND freed by the concurrent purge ALL WITHIN ONE FACTORY
-	// TICK. BeginPlay is virtual - it cannot be inlined away from this hook - so this names the
-	// short-lived buildable and its spawn callstack.
-	AFGBuildable* BuildableBeginPlayCDO = GetMutableDefault<AFGBuildable>();
-	SUBSCRIBE_METHOD_VIRTUAL(AFGBuildable::BeginPlay, BuildableBeginPlayCDO,
-		[](auto& scope, AFGBuildable* self)
-		{
-			if (bInsideFactoryTick && self && self->HasAuthority())
-			{
-				UE_LOG(LogSmartFoundations, Error,
-					TEXT("[CHAIN-DIAG] AFGBuildable::BeginPlay(%s / %s) DURING TickFactory - the mid-tick registration. Callstack follows."),
-					*self->GetName(), *GetNameSafe(self->GetClass()));
-				FDebug::DumpStackTraceToLog(ELogVerbosity::Error);
-			}
-		});
-
-	// Symmetric detector: a REMOVAL mid-tick can shrink-reallocate mFactoryBuildings, freeing the
-	// buffer under the ParallelFor workers just like a growth realloc (9th repro: Add detector
-	// silent, pre-tick scrub valid -> the mutation, whatever it is, happens DURING the tick).
-	SUBSCRIBE_METHOD(
-		AFGBuildableSubsystem::RemoveBuildable,
-		[](auto& scope, AFGBuildableSubsystem* self, AFGBuildable* buildable)
-		{
-			if (bInsideFactoryTick)
-			{
-				UE_LOG(LogSmartFoundations, Error,
-					TEXT("[CHAIN-DIAG] RemoveBuildable(%s / %s) DURING TickFactory! A shrink-realloc frees the buffer under the ParallelFor - THE freed-buffer tick AV. Callstack follows."),
-					buildable ? *buildable->GetName() : TEXT("null"),
-					buildable ? *GetNameSafe(buildable->GetClass()) : TEXT("null"));
-				FDebug::DumpStackTraceToLog(ELogVerbosity::Error);
 			}
 		});
 
@@ -956,7 +895,7 @@ void USFGameInstanceModule::RegisterSpecConstructionHooks()
 			}
 			if (Removed > 0)
 			{
-				UE_LOG(LogSmartFoundations, Display,
+				UE_LOG(LogSmartFoundations, Warning,
 					TEXT("[CHAIN-DIAG] EndPlay guard: %s (%s) died (reason=%d) while STILL in %d factory-tick entr%s - leak path identified, freed-pointer tick AV prevented."),
 					*self->GetName(), *GetNameSafe(self->GetClass()), static_cast<int32>(endPlayReason),
 					Removed, Removed == 1 ? TEXT("y") : TEXT("ies"));
@@ -1236,7 +1175,7 @@ void USFGameInstanceModule::RegisterSpecConstructionHooks()
 								++RegisteredAnchors;
 							}
 						}
-						UE_LOG(LogSmartFoundations, Display,
+						UE_LOG(LogSmartFoundations, Verbose,
 							TEXT("[EXTEND-MP] Registered %d clone-id wiring anchor(s) post-construct for %s."),
 							RegisteredAnchors, *GetNameSafe(BuiltParent));
 
@@ -1252,7 +1191,7 @@ void USFGameInstanceModule::RegisterSpecConstructionHooks()
 						// chain registration proves safe.
 						if (AFGBuildableFactory* BuiltFactory = Cast<AFGBuildableFactory>(BuiltParent))
 						{
-							UE_LOG(LogSmartFoundations, Display,
+							UE_LOG(LogSmartFoundations, Verbose,
 								TEXT("[EXTEND-MP] Commit wiring pass executing for %s."),
 								*BuiltFactory->GetName());
 							Extend->ConnectAllChainElements(BuiltFactory);
@@ -1302,7 +1241,7 @@ void USFGameInstanceModule::RegisterSpecConstructionHooks()
 
 			if (GroupProxy)
 			{
-				UE_LOG(LogSmartFoundations, Display,
+				UE_LOG(LogSmartFoundations, Verbose,
 					TEXT("[MP-SPEC] Spec group proxy %s: %d actor buildables registered (+ lightweight instances tracked by index); built parent=%s, out_children=%d."),
 					*GroupProxy->GetName(), GroupProxy->GetBuildables().Num(),
 					*GetNameSafe(BuiltParent), out_children.Num());

--- a/Source/SmartFoundations/Private/Module/SFGameInstanceModule.cpp
+++ b/Source/SmartFoundations/Private/Module/SFGameInstanceModule.cpp
@@ -321,6 +321,15 @@ void USFGameInstanceModule::RegisterBeltSupportConstructHook()
 static constexpr int32 SF_MP_CONSTRUCT_MAX_BYTES = 60000; // cancel a Smart-grid construct above this
 static constexpr int32 SF_MP_CONSTRUCT_LOG_BYTES = 20000; // log any Smart-grid construct above this (capture real sizes)
 
+// Hand-serialization (full-auto) state. Declared before the guard hook because the guard hook captures
+// chunk 0's NetConstructionID into these. Chunk 0 is the player's natural fire; we capture the valid
+// FNetConstructionID vanilla minted for it, then derive subsequent chunk IDs (Client_ID + n) and hand-build
+// + send each remaining chunk's Server_ConstructHologram ourselves (the build gun only constructs on real
+// input). The biggest unknown is whether the server accepts the derived IDs.
+static FNetConstructionID GSFBaseConstructID;
+static bool GSFExpectingChunk0ID = false;
+static int32 GSFChunkSeq = 0;
+
 void USFGameInstanceModule::RegisterClientConstructChunkGuardHook()
 {
 	SUBSCRIBE_METHOD(
@@ -430,14 +439,6 @@ static TArray<FSFPendingChunk> GSFPendingChunks;
 static TWeakObjectPtr<UFGBuildGunStateBuild> GSFPendingGun;
 static int32 GSFChunkWait = 0;
 static FTSTicker::FDelegateHandle GSFChunkTicker;
-
-// Hand-serialization (full-auto) state. Chunk 0 is the player's natural fire; we capture the valid
-// FNetConstructionID vanilla minted for it, then derive subsequent chunk IDs (Client_ID + n) and hand-build
-// + send each remaining chunk's Server_ConstructHologram ourselves (bypassing the build gun, which only
-// constructs on real input). The biggest unknown is whether the server accepts the derived IDs.
-static FNetConstructionID GSFBaseConstructID;
-static bool GSFExpectingChunk0ID = false;
-static int32 GSFChunkSeq = 0;
 
 bool USFGameInstanceModule::TickPendingGridChunks(float /*Dt*/)
 {

--- a/Source/SmartFoundations/Private/Module/SFGameInstanceModule.cpp
+++ b/Source/SmartFoundations/Private/Module/SFGameInstanceModule.cpp
@@ -27,10 +27,11 @@
 #include "Core/Helpers/SFNetworkHelper.h"     // FSFNetworkHelper::IsClient
 #include "Engine/Engine.h"                     // GEngine on-screen message
 
-// MP spec-based construction: guard bypass for spec-capable parents
-#include "Holograms/Core/SFFactoryHologram.h"
-#include "Holograms/Core/SFFoundationHologram.h"
+// MP spec-based construction: class-agnostic hooks + guard bypass
 #include "Holograms/Core/SFScalingSpecExpansion.h"
+#include "Data/SFBuildableSizeRegistry.h"
+#include "Data/SFHologramDataRegistry.h"
+#include "Subsystem/SFHologramDataService.h"
 
 // For chain actor rebuilding
 #include "Buildables/FGBuildableConveyorBase.h"
@@ -93,6 +94,10 @@ void USFGameInstanceModule::DispatchLifecycleEvent(ELifecyclePhase Phase)
 		// MP Slice 0 chunking: shrink an oversized client grid to a fit-in-one-RPC chunk at the fire handler,
 		// before vanilla serializes (Increment 1 = single-chunk proof). See the method comment.
 		RegisterClientGridChunkFireHook();
+
+		// MP spec-based scaling construction (class-agnostic hook path - covers ALL scalable
+		// buildables including BP hologram wrappers, no hologram swap). See the method comment.
+		RegisterSpecConstructionHooks();
 
 	}
 }
@@ -433,18 +438,20 @@ void USFGameInstanceModule::RegisterClientGridChunkFireHook()
 				return;
 			}
 
-			// [MP-SPEC] When spec-based construction is enabled AND the active hologram is one of the
-			// spec-capable parents (swapped at registration), the grid children are stripped from the
-			// wire in PreConstructMessageSerialization and the message is O(1) - the oversized refusal
-			// must NOT fire. Legacy holograms (e.g. ramp subclasses not yet covered by the swap) still
-			// serialize all children, so for them the guard stays authoritative.
-			if (SFScalingSpecExpansion::IsSpecConstructionEnabled()
-				&& (Holo->IsA(ASFFactoryHologram::StaticClass()) || Holo->IsA(ASFFoundationHologram::StaticClass())))
+			// [MP-SPEC] When spec-based construction is enabled and the buildable is Smart-scalable
+			// (size registry), the SerializeConstructMessage hook strips the grid children and the
+			// message is O(1) - the oversized refusal must NOT fire. Non-scalable grids (none today)
+			// keep the guard; with the CVar off the guard stays fully authoritative.
+			if (SFScalingSpecExpansion::IsSpecConstructionEnabled())
 			{
-				UE_LOG(LogSmartFoundations, Display,
-					TEXT("[MP-SPEC] Oversized guard bypassed: %s commits via the compact spec path."),
-					*Holo->GetName());
-				return;
+				USFBuildableSizeRegistry::Initialize();
+				if (USFBuildableSizeRegistry::GetProfile(Holo->GetBuildClass()).bSupportsScaling)
+				{
+					UE_LOG(LogSmartFoundations, Display,
+						TEXT("[MP-SPEC] Oversized guard bypassed: %s commits via the compact spec path."),
+						*Holo->GetName());
+					return;
+				}
 			}
 
 			// Count Smart grid child holograms (tagged SF_GridChild). +1 for the parent/origin cell.
@@ -487,4 +494,168 @@ void USFGameInstanceModule::RegisterClientGridChunkFireHook()
 	);
 
 	UE_LOG(LogSmartFoundations, Verbose, TEXT("✅ Client grid oversized-guard fire-hook registered (MP Slice 0 safety, InternalExecuteDuBuildStepInput)"));
+}
+
+void USFGameInstanceModule::RegisterSpecConstructionHooks()
+{
+	static const FName GridChildTag(TEXT("SF_GridChild"));
+
+	// Count the Smart grid children currently attached to a hologram (the strip/expand targets).
+	auto CountGridChildren = [](AFGHologram* Holo) -> int32
+	{
+		int32 Count = 0;
+		for (AFGHologram* Child : Holo->mChildren)
+		{
+			if (Child && Child->Tags.Contains(GridChildTag))
+			{
+				++Count;
+			}
+		}
+		return Count;
+	};
+
+	// CDOs for virtual-method body resolution. SUBSCRIBE_METHOD on a virtual resolves to a vcall
+	// thunk and SML's hook install CRASHES at startup (live finding 2026-06-09: FatalError in
+	// FNativeHookManagerInternal::RegisterHookFunction). SUBSCRIBE_METHOD_VIRTUAL resolves the
+	// actual body from the CDO's vtable - and hooking the BASE body fires for the entire Super
+	// chain (same mechanism the belt-support Construct hook above relies on).
+	AFGHologram* HologramCDO = GetMutableDefault<AFGHologram>();
+	AFGBuildableHologram* BuildableHologramCDO = GetMutableDefault<AFGBuildableHologram>();
+
+	// ── Hook 1: the construct message. AFGHologram::SerializeConstructMessage is the base body of
+	// the Super chain for every hologram class (BP wrappers cannot override C++ virtuals), and it
+	// is where the child tree is serialized. Wrap it symmetrically on both sides.
+	SUBSCRIBE_METHOD_VIRTUAL(AFGHologram::SerializeConstructMessage, HologramCDO,
+		[CountGridChildren](auto& scope, AFGHologram* self, FArchive& ar, FNetConstructionID id)
+		{
+			if (!self || !SFScalingSpecExpansion::IsSpecConstructionEnabled())
+			{
+				return; // original runs untouched; no spec byte is written/read (symmetric: CVar
+				        // matches across client+server because both run this same module).
+			}
+
+			if (ar.IsSaving())
+			{
+				// CLIENT (fire): capture the grid into a compact spec and strip the grid children
+				// so the original writes an O(1) message; append the spec; restore the children so
+				// the post-fire teardown destroys the previews normally.
+				FSFScalingSpec Spec;
+				TArray<AFGHologram*> Stash;
+
+				const int32 TaggedChildren = CountGridChildren(self);
+				bool bHasSpec = false;
+				if (TaggedChildren > 0)
+				{
+					USFBuildableSizeRegistry::Initialize();
+					if (USFBuildableSizeRegistry::GetProfile(self->GetBuildClass()).bSupportsScaling
+						&& SFScalingSpecExpansion::CaptureScalingSpec(self, Spec))
+					{
+						bHasSpec = true;
+						for (int32 i = self->mChildren.Num() - 1; i >= 0; --i)
+						{
+							AFGHologram* Child = self->mChildren[i];
+							if (Child && Child->Tags.Contains(GridChildTag))
+							{
+								Stash.Add(Child);
+								self->mChildren.RemoveAt(i);
+							}
+						}
+					}
+				}
+
+				scope(self, ar, id); // original writes the (possibly childless) hologram
+
+				ar << bHasSpec;
+				if (bHasSpec)
+				{
+					FSFScalingSpec::StaticStruct()->SerializeBin(ar, &Spec);
+					UE_LOG(LogSmartFoundations, Display,
+						TEXT("[MP-SPEC] SerializeConstructMessage(%s): captured spec (%d cells), stripped %d grid children, message is O(1)."),
+						*self->GetClass()->GetName(), Spec.CellCount(), Stash.Num());
+				}
+
+				for (AFGHologram* Child : Stash)
+				{
+					self->mChildren.Add(Child);
+				}
+			}
+			else
+			{
+				// SERVER (receive): original reads the childless hologram, then read the spec into
+				// the per-hologram data registry. Expansion happens later, inside Construct
+				// (post-validation - fresh holograms cannot pass vanilla placement validation).
+				scope(self, ar, id);
+
+				bool bHasSpec = false;
+				ar << bHasSpec;
+				if (bHasSpec)
+				{
+					FSFScalingSpec Spec;
+					FSFScalingSpec::StaticStruct()->SerializeBin(ar, &Spec);
+					if (FSFHologramData* Data = USFHologramDataService::GetOrCreateData(self))
+					{
+						Data->ScalingSpec = Spec;
+					}
+					UE_LOG(LogSmartFoundations, Display,
+						TEXT("[MP-SPEC] SerializeConstructMessage(%s): server received spec (%d cells)."),
+						*self->GetClass()->GetName(), Spec.CellCount());
+				}
+			}
+		});
+
+	// ── Hook 2: cost. Charged server-side BEFORE Construct, when the grid children do not exist
+	// yet - scale the uniform per-cell cost by the cell count. Fires at the AFGHologram::GetCost
+	// base body (the scalable parents' classes do not override GetCost; spline types that do never
+	// carry a spec).
+	SUBSCRIBE_METHOD_VIRTUAL(AFGHologram::GetCost, HologramCDO,
+		[CountGridChildren](auto& scope, const AFGHologram* self, bool includeChildren)
+		{
+			if (!self || !includeChildren || !SFScalingSpecExpansion::IsSpecConstructionEnabled())
+			{
+				return;
+			}
+			AFGHologram* MutableSelf = const_cast<AFGHologram*>(self);
+			if (!MutableSelf->HasAuthority())
+			{
+				return; // client cost comes from its real preview children via vanilla aggregation
+			}
+			FSFHologramData* Data = USFHologramDataRegistry::GetData(MutableSelf);
+			if (!Data || !Data->ScalingSpec.bValid || CountGridChildren(MutableSelf) > 0)
+			{
+				return; // no pending spec (or already expanded) -> vanilla cost
+			}
+
+			TArray<FItemAmount> Cost = scope(self, includeChildren);
+			const int32 Cells = Data->ScalingSpec.CellCount();
+			for (FItemAmount& Item : Cost)
+			{
+				Item.Amount *= Cells;
+			}
+			scope.Override(Cost);
+		});
+
+	// ── Hook 3: expansion. Fires at the AFGBuildableHologram::Construct body - inside the Super
+	// chain of every buildable hologram, before the base child-construct loop - on the server,
+	// after Server_ConstructHologram validation has already passed on the childless parent.
+	SUBSCRIBE_METHOD_VIRTUAL(AFGBuildableHologram::Construct, BuildableHologramCDO,
+		[CountGridChildren](auto& scope, AFGBuildableHologram* self, TArray<AActor*>& out_children, FNetConstructionID constructionID)
+		{
+			if (!self || !self->HasAuthority() || !SFScalingSpecExpansion::IsSpecConstructionEnabled())
+			{
+				return;
+			}
+			FSFHologramData* Data = USFHologramDataRegistry::GetData(self);
+			if (!Data || !Data->ScalingSpec.bValid)
+			{
+				return; // not a spec parent (e.g. one of the children constructing in the loop)
+			}
+			if (CountGridChildren(self) == 0)
+			{
+				SFScalingSpecExpansion::ExpandScalingSpecIntoChildren(self, Data->ScalingSpec, self->GetRecipe());
+			}
+			Data->ScalingSpec.bValid = false; // one-shot
+			// original runs after return and constructs parent + expanded children
+		});
+
+	UE_LOG(LogSmartFoundations, Verbose, TEXT("✅ Spec-construction hooks registered (SerializeConstructMessage / GetCost / Construct - class-agnostic)"));
 }

--- a/Source/SmartFoundations/Private/Module/SFGameInstanceModule.cpp
+++ b/Source/SmartFoundations/Private/Module/SFGameInstanceModule.cpp
@@ -840,35 +840,44 @@ void USFGameInstanceModule::RegisterSpecConstructionHooks()
 			}
 		});
 
-	// [CHAIN-FIX] Destruction chokepoint guard. The 4th freed-pointer tick AV reproduced with NO
-	// dismantle and NO build (hover extend -> look away -> re-aim), with the RemoveConveyor guard
-	// silent - so some conveyor destruction path never calls RemoveConveyor at all and leaves the
-	// belt in a tick-group array. EndPlay fires for EVERY destruction path; the before-hook sweeps
-	// the tick groups while the object is still alive and logs WHICH belt + WHY it died, naming
-	// the leaking path. AFGBuildableConveyorBase overrides EndPlay (primary-class virtual), so the
-	// CDO resolves the conveyor-specific body - the hook fires only for conveyors.
-	AFGBuildableConveyorBase* ConveyorBaseCDO = GetMutableDefault<AFGBuildableConveyorBase>();
-	SUBSCRIBE_METHOD_VIRTUAL(AFGBuildableConveyorBase::EndPlay, ConveyorBaseCDO,
-		[](auto& scope, AFGBuildableConveyorBase* self, const EEndPlayReason::Type endPlayReason)
+	// [CHAIN-FIX] Destruction chokepoint guard, ALL buildables. cdb on the 5th freed-pointer tick
+	// AV (2026-06-10) identified the crashing loop: TickFactoryActors' lambda walks
+	// mFactoryBuildings (subsystem +0x3C0, confirmed via PDB) and virtual-calls each entry - the
+	// freed entry sat at the array END (= most recently registered), and the conveyor-only guards
+	// stayed silent, so a NON-conveyor factory buildable is destroyed by some path that skips
+	// vanilla RemoveBuildable. EndPlay fires for every destruction path; running AFTER the
+	// original (scope first) means vanilla's own cleanup has happened - anything still left in
+	// mFactoryBuildings/groups or the conveyor tick groups is a true leak: force-removed and
+	// logged with name + reason, naming the leaking path on the next repro. AFGBuildable
+	// overrides EndPlay (primary-class virtual): hooking its body via the CDO fires for the
+	// whole Super chain - every buildable, conveyors included.
+	AFGBuildable* BuildableCDO = GetMutableDefault<AFGBuildable>();
+	SUBSCRIBE_METHOD_VIRTUAL(AFGBuildable::EndPlay, BuildableCDO,
+		[](auto& scope, AFGBuildable* self, const EEndPlayReason::Type endPlayReason)
 		{
-			if (self && self->HasAuthority())
+			scope(self, endPlayReason);
+			if (!self || !self->HasAuthority())
 			{
-				if (UWorld* World = self->GetWorld())
-				{
-					if (USFSubsystem* SS = USFSubsystem::Get(World))
-					{
-						if (USFChainActorService* ChainSvc = SS->GetChainActorService())
-						{
-							const int32 Removed = ChainSvc->RemoveConveyorFromAllTickGroups(self);
-							if (Removed > 0)
-							{
-								UE_LOG(LogSmartFoundations, Display,
-									TEXT("[CHAIN-DIAG] EndPlay guard: %s died (reason=%d) while STILL in %d tick group(s) - leak path identified, freed-pointer tick AV prevented."),
-									*self->GetName(), static_cast<int32>(endPlayReason), Removed);
-							}
-						}
-					}
-				}
+				return;
+			}
+			UWorld* World = self->GetWorld();
+			USFSubsystem* SS = World ? USFSubsystem::Get(World) : nullptr;
+			USFChainActorService* ChainSvc = SS ? SS->GetChainActorService() : nullptr;
+			if (!ChainSvc)
+			{
+				return;
+			}
+			int32 Removed = ChainSvc->RemoveBuildableFromFactoryTickArrays(self);
+			if (AFGBuildableConveyorBase* Conveyor = Cast<AFGBuildableConveyorBase>(self))
+			{
+				Removed += ChainSvc->RemoveConveyorFromAllTickGroups(Conveyor);
+			}
+			if (Removed > 0)
+			{
+				UE_LOG(LogSmartFoundations, Display,
+					TEXT("[CHAIN-DIAG] EndPlay guard: %s (%s) died (reason=%d) while STILL in %d factory-tick entr%s - leak path identified, freed-pointer tick AV prevented."),
+					*self->GetName(), *GetNameSafe(self->GetClass()), static_cast<int32>(endPlayReason),
+					Removed, Removed == 1 ? TEXT("y") : TEXT("ies"));
 			}
 		});
 

--- a/Source/SmartFoundations/Private/Module/SFGameInstanceModule.cpp
+++ b/Source/SmartFoundations/Private/Module/SFGameInstanceModule.cpp
@@ -33,6 +33,7 @@
 #include "Subsystem/SFHologramHelperService.h"
 #include "SFRCO.h"
 #include "FGPlayerController.h"
+#include "FGBlueprintProxy.h"   // server-side Smart Dismantle group for spec-built grids
 
 // For chain actor rebuilding
 #include "Buildables/FGBuildableConveyorBase.h"
@@ -628,10 +629,15 @@ void USFGameInstanceModule::RegisterSpecConstructionHooks()
 			scope.Override(Cost);
 		});
 
-	// ── Hook B: expansion. Fires at the AFGBuildableHologram::Construct body (primary virtual) -
-	// inside the Super chain of every buildable hologram, before the base child-construct loop -
-	// on the server, after Server_ConstructHologram validation has already passed on the childless
-	// parent. Consumes the staged spec (matched by instigator + build class).
+	// ── Hook B: expansion + group bookkeeping. Fires at the AFGBuildableHologram::Construct body
+	// (primary virtual) - inside the Super chain of every buildable hologram, before the base
+	// child-construct loop - on the server, after Server_ConstructHologram validation has already
+	// passed on the childless parent. Consumes the staged spec (matched by instigator + build
+	// class), expands, runs the original, then registers ALL built actors into one
+	// AFGBlueprintProxy so Smart Dismantle group-dismantle works on spec-built grids. The proxy is
+	// created SERVER-side (its mBuildables array is replicated, so the client group UI sees it and
+	// dismantle is server-authoritative - the legacy client-side proxy from OnActorSpawned cannot
+	// cover server-built actors).
 	SUBSCRIBE_METHOD_VIRTUAL(AFGBuildableHologram::Construct, BuildableHologramCDO,
 		[=](auto& scope, AFGBuildableHologram* self, TArray<AActor*>& out_children, FNetConstructionID constructionID)
 		{
@@ -648,7 +654,58 @@ void USFGameInstanceModule::RegisterSpecConstructionHooks()
 			{
 				SFScalingSpecExpansion::ExpandScalingSpecIntoChildren(self, Spec, self->GetRecipe());
 			}
-			// original runs after return and constructs parent + expanded children
+
+			// Run the original construct now (parent + expanded children) so we can group the
+			// resulting actors. out_children is filled by the vanilla child-construct loop.
+			AActor* BuiltParent = scope(self, out_children, constructionID);
+
+			// Group everything that was built into one blueprint proxy (Smart Dismantle group).
+			TArray<AFGBuildable*> BuiltBuildables;
+			if (AFGBuildable* ParentBuildable = Cast<AFGBuildable>(BuiltParent))
+			{
+				BuiltBuildables.Add(ParentBuildable);
+			}
+			for (AActor* ChildActor : out_children)
+			{
+				if (AFGBuildable* ChildBuildable = Cast<AFGBuildable>(ChildActor))
+				{
+					BuiltBuildables.AddUnique(ChildBuildable);
+				}
+			}
+
+			if (BuiltBuildables.Num() > 1)
+			{
+				UWorld* World = self->GetWorld();
+				FActorSpawnParameters ProxyParams;
+				ProxyParams.SpawnCollisionHandlingOverride = ESpawnActorCollisionHandlingMethod::AlwaysSpawn;
+				AFGBlueprintProxy* GroupProxy = World ? World->SpawnActor<AFGBlueprintProxy>(
+					AFGBlueprintProxy::StaticClass(),
+					BuiltBuildables[0]->GetActorTransform(),
+					ProxyParams) : nullptr;
+
+				if (GroupProxy)
+				{
+					for (AFGBuildable* Buildable : BuiltBuildables)
+					{
+						if (!Buildable->GetBlueprintProxy())
+						{
+							Buildable->SetBlueprintProxy(GroupProxy);
+							GroupProxy->RegisterBuildable(Buildable);
+						}
+					}
+					UE_LOG(LogSmartFoundations, Display,
+						TEXT("[MP-SPEC] Grouped %d spec-built buildables into blueprint proxy %s (Smart Dismantle group)."),
+						BuiltBuildables.Num(), *GroupProxy->GetName());
+				}
+				else
+				{
+					UE_LOG(LogSmartFoundations, Warning,
+						TEXT("[MP-SPEC] Could not spawn blueprint proxy for spec-built group (%d buildables)."),
+						BuiltBuildables.Num());
+				}
+			}
+
+			scope.Override(BuiltParent);
 		});
 
 	UE_LOG(LogSmartFoundations, Verbose, TEXT("✅ Spec-construction hooks registered (GetCost / Construct - class-agnostic; spec staged via USFRCO)"));

--- a/Source/SmartFoundations/Private/Module/SFGameInstanceModule.cpp
+++ b/Source/SmartFoundations/Private/Module/SFGameInstanceModule.cpp
@@ -33,6 +33,7 @@
 // MP spec-based construction: class-agnostic hooks + RCO spec staging
 #include "Holograms/Core/SFScalingSpecExpansion.h"
 #include "Data/SFBuildableSizeRegistry.h"
+#include "Data/SFHologramDataRegistry.h"   // [EXTEND-MP] JsonCloneId wiring anchors post-construct
 #include "Subsystem/SFHologramHelperService.h"
 #include "SFRCO.h"
 #include "FGPlayerController.h"
@@ -534,21 +535,9 @@ void USFGameInstanceModule::RegisterClientGridChunkFireHook()
 						USFExtendService* Extend = SS ? SS->GetExtendService() : nullptr;
 						if (Extend)
 						{
-							const FSFExtendTopology& Topo = Extend->GetLastExtendTopology();
-							if (Topo.bIsValid && Topo.SourceBuilding.IsValid())
-							{
-								const FVector FinalOffset =
-									Holo->GetActorLocation() - Topo.SourceBuilding->GetActorLocation();
-								const FSFSourceTopology Source = FSFSourceTopology::CaptureFromTopology(Topo);
-								ExtendSpec.Clone = FSFCloneTopology::FromSource(Source, FinalOffset);
-								ExtendSpec.Cost = Holo->GetCost(true); // parent + preview children
-								ExtendSpec.BuildClass = Holo->GetBuildClass();
-								ExtendSpec.SourceBuilding = Topo.SourceBuilding.Get();
-								// Scaled Extend: ship the per-clone PARAMETERS; the server re-runs
-								// the same spawn pipeline against its own authoritative walk.
-								Extend->GetScaledClonePlanForCommit(ExtendSpec.ScaledClones);
-								ExtendSpec.bValid = ExtendSpec.Clone.ChildHolograms.Num() > 0;
-							}
+							// Fresh clone topology at the FINAL fire position + cost + scaled
+							// clone parameters (the same capture the throttled pre-stage uses).
+							Extend->BuildCommitSpecForMP(Holo, ExtendSpec);
 						}
 
 						if (ExtendSpec.bValid)
@@ -728,6 +717,8 @@ void USFGameInstanceModule::RegisterClientGridChunkFireHook()
 					// grid does.
 
 					// Stage (or clear) the spec server-side BEFORE the construct RPC goes out.
+					// Also stage an Extend-commit CLEAR: a pre-staged commit from an earlier
+					// (cancelled) Extend session must never be consumed by this plain fire.
 					bool bStaged = false;
 					if (APawn* InstigatorPawn = Holo->GetConstructionInstigator())
 					{
@@ -736,6 +727,7 @@ void USFGameInstanceModule::RegisterClientGridChunkFireHook()
 							if (USFRCO* RCO = PC->GetRemoteCallObjectOfClass<USFRCO>())
 							{
 								RCO->Server_StageScalingSpec(Spec);
+								RCO->Server_StageExtendCommit(FSFExtendCommitSpec());
 								bStaged = true;
 							}
 						}
@@ -1036,6 +1028,65 @@ void USFGameInstanceModule::RegisterSpecConstructionHooks()
 			AActor* BuiltParent = scope(self, out_children, constructionID);
 
 			GSFActiveSpecGroupProxy.Reset();
+
+			// [EXTEND-MP] Register the clone-id -> built-actor anchors for the wiring pass. In SP
+			// this lives in ASFFactoryHologram::Construct (the swapped parent): it position-matches
+			// every child hologram carrying a JsonCloneId (the scaled clone FACTORIES,
+			// "sc{i}_factory" - vanilla holograms whose own Construct knows nothing of clone ids)
+			// to its built actor. The server constructs through the VANILLA hologram, so those
+			// anchors never registered and the deferred wiring resolved NOTHING - a scaled run
+			// built geometrically perfect but fully unwired (live 2026-06-10). Same seam, same
+			// position-match, with the self-registered skip (#288).
+			if (bHasExtend)
+			{
+				if (USFSubsystem* SS = USFSubsystem::Get(self->GetWorld()))
+				{
+					if (USFExtendService* Extend = SS->GetExtendService())
+					{
+						int32 RegisteredAnchors = 0;
+						for (AFGHologram* ChildHolo : self->mChildren)
+						{
+							if (!ChildHolo)
+							{
+								continue;
+							}
+							FSFHologramData* ChildData = USFHologramDataRegistry::GetData(ChildHolo);
+							if (!ChildData || ChildData->JsonCloneId.IsEmpty())
+							{
+								continue;
+							}
+							if (Extend->GetBuiltActorByCloneId(ChildData->JsonCloneId) != nullptr)
+							{
+								continue; // self-registered during its own Construct (exact match)
+							}
+							const FVector ChildPos = ChildHolo->GetActorLocation();
+							AActor* BestMatch = nullptr;
+							float BestDist = 200.0f;
+							for (AActor* ChildActor : out_children)
+							{
+								if (!ChildActor)
+								{
+									continue;
+								}
+								const float Dist = FVector::Dist(ChildActor->GetActorLocation(), ChildPos);
+								if (Dist < BestDist)
+								{
+									BestDist = Dist;
+									BestMatch = ChildActor;
+								}
+							}
+							if (BestMatch)
+							{
+								Extend->RegisterJsonBuiltActor(ChildData->JsonCloneId, BestMatch);
+								++RegisteredAnchors;
+							}
+						}
+						UE_LOG(LogSmartFoundations, Display,
+							TEXT("[EXTEND-MP] Registered %d clone-id wiring anchor(s) post-construct for %s."),
+							RegisteredAnchors, *GetNameSafe(BuiltParent));
+					}
+				}
+			}
 
 			// [MP-334] Post-construct sweep: spline buildables (the plan belts) never reach the
 			// AFGBuildableHologram::ConfigureActor BASE body our pre-BeginPlay hook patches (the

--- a/Source/SmartFoundations/Private/Module/SFGameInstanceModule.cpp
+++ b/Source/SmartFoundations/Private/Module/SFGameInstanceModule.cpp
@@ -1045,31 +1045,6 @@ void USFGameInstanceModule::RegisterSpecConstructionHooks()
 				{
 					if (USFExtendService* Extend = SS->GetExtendService())
 					{
-						// [EXTEND-MP] Schedule the post-build wiring pass OURSELVES, next tick,
-						// with the BUILT PARENT as the factory anchor. The legacy OnActorSpawned
-						// trigger queues per factory spawn and proved unreliable at the commit
-						// seam (live 2026-06-10: only the LAST junction's lambda ran, so
-						// "parent"/"Factory" targets resolved against a junction and every
-						// factory-end connection failed). Our pass runs first; the legacy lambdas
-						// no-op afterwards via their HasPendingPostBuildWiring re-check.
-						if (AFGBuildableFactory* BuiltFactory = Cast<AFGBuildableFactory>(BuiltParent))
-						{
-							TWeakObjectPtr<AFGBuildableFactory> WeakFactory = BuiltFactory;
-							TWeakObjectPtr<USFExtendService> WeakExtend = Extend;
-							self->GetWorld()->GetTimerManager().SetTimerForNextTick([=]()
-							{
-								if (WeakFactory.IsValid() && WeakExtend.IsValid()
-									&& WeakExtend->HasPendingPostBuildWiring())
-								{
-									UE_LOG(LogSmartFoundations, Display,
-										TEXT("[EXTEND-MP] Commit wiring pass executing for %s."),
-										*WeakFactory->GetName());
-									WeakExtend->ConnectAllChainElements(WeakFactory.Get());
-									WeakExtend->WireBuiltChildConnections(WeakFactory.Get());
-								}
-							});
-						}
-
 						int32 RegisteredAnchors = 0;
 						for (AFGHologram* ChildHolo : self->mChildren)
 						{
@@ -1111,6 +1086,25 @@ void USFGameInstanceModule::RegisterSpecConstructionHooks()
 						UE_LOG(LogSmartFoundations, Display,
 							TEXT("[EXTEND-MP] Registered %d clone-id wiring anchor(s) post-construct for %s."),
 							RegisteredAnchors, *GetNameSafe(BuiltParent));
+
+						// [EXTEND-MP] Run the post-build wiring pass SYNCHRONOUSLY, here, with the
+						// BUILT PARENT as the factory anchor. Deferral is structurally unreliable
+						// at the commit seam: the legacy per-factory-spawn lambdas resolved
+						// "parent"/"Factory" against whichever factory their trigger captured
+						// (live: a junction -> every factory-end connection failed), and BOTH the
+						// legacy and a next-tick pass race the post-construct hologram
+						// re-registration cleanup that clears the pending-wiring state (live:
+						// everything no-opped). This point is POST-construct - all children built,
+						// configured, and registered - the same in-frame pre-tick timing the #341
+						// chain registration proves safe.
+						if (AFGBuildableFactory* BuiltFactory = Cast<AFGBuildableFactory>(BuiltParent))
+						{
+							UE_LOG(LogSmartFoundations, Display,
+								TEXT("[EXTEND-MP] Commit wiring pass executing for %s."),
+								*BuiltFactory->GetName());
+							Extend->ConnectAllChainElements(BuiltFactory);
+							Extend->WireBuiltChildConnections(BuiltFactory);
+						}
 					}
 				}
 			}

--- a/Source/SmartFoundations/Private/SFRCO.cpp
+++ b/Source/SmartFoundations/Private/SFRCO.cpp
@@ -503,6 +503,18 @@ void USFRCO::Client_ReceiveTraversalResult_Implementation(FSFTraversalResult Res
 	USFUpgradeTraversalService::InjectTraversalResult(Result);
 }
 
+void USFRCO::Client_ReceiveServerCloneTopology_Implementation(FSFCloneTopology Topology)
+{
+	USFSubsystem* Subsystem = USFSubsystem::Get(this);
+	if (IsValid(Subsystem))
+	{
+		if (USFExtendService* ExtendService = Subsystem->GetExtendService())
+		{
+			ExtendService->ReceiveServerCloneTopology(Topology);
+		}
+	}
+}
+
 void USFRCO::Client_ReceiveAuditResult_Implementation(FSFUpgradeAuditResult Result)
 {
 	UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("[SFRCO] Client_ReceiveAuditResult: Success=%d, TotalScanned=%d"), Result.bSuccess, Result.TotalScanned);

--- a/Source/SmartFoundations/Private/SFRCO.cpp
+++ b/Source/SmartFoundations/Private/SFRCO.cpp
@@ -327,17 +327,41 @@ void USFRCO::Server_StageExtendCommit_Implementation(FSFExtendCommitSpec Spec)
 	if (Spec.bValid)
 	{
 		UE_LOG(LogSmartFoundations, Display,
-			TEXT("[EXTEND-MP] Server staged Extend commit for %s: offset %s, %d scaled clone(s) of %s, %d cost item type(s)."),
+			TEXT("[EXTEND-MP] Server staged %s commit for %s: offset %s, %d scaled clone(s) of %s, %d cost item type(s)%s."),
+			Spec.bIsRestore ? TEXT("RESTORE") : TEXT("Extend"),
 			*GetNameSafe(OwnerPC), *Spec.ParentOffset.ToCompactString(), Spec.ScaledClones.Num(),
-			*GetNameSafe(*Spec.BuildClass), Spec.Cost.Num());
+			*GetNameSafe(*Spec.BuildClass), Spec.Cost.Num(),
+			Spec.bIsRestore
+				? *FString::Printf(TEXT(", restore template children=%d"), Spec.RestoreTemplate.ChildHolograms.Num())
+				: TEXT(""));
 	}
 }
 
 bool USFRCO::Server_StageExtendCommit_Validate(FSFExtendCommitSpec Spec)
 {
 	// Sanity-bound the commit parameters (a forged/buggy commit cannot demand absurd spawning).
-	// The clone topology itself is derived SERVER-side from these, never shipped.
-	return Spec.ScaledClones.Num() <= 1024 && Spec.ParentOffset.Size() <= 1.0e7;
+	// For an EXTEND commit the clone topology is derived SERVER-side from these, never shipped.
+	if (Spec.ScaledClones.Num() > 1024 || Spec.ParentOffset.Size() > 1.0e7)
+	{
+		return false;
+	}
+	// A RESTORE commit ships the preset's value-only TEMPLATE topology (no source building exists
+	// to walk). Bound it like the conduit plan: child and per-spline-point caps.
+	if (Spec.bIsRestore)
+	{
+		if (Spec.RestoreTemplate.ChildHolograms.Num() > 4096)
+		{
+			return false;
+		}
+		for (const FSFCloneHologram& Holo : Spec.RestoreTemplate.ChildHolograms)
+		{
+			if (Holo.SplineData.Points.Num() > 64)
+			{
+				return false;
+			}
+		}
+	}
+	return true;
 }
 
 // ========================================

--- a/Source/SmartFoundations/Private/SFRCO.cpp
+++ b/Source/SmartFoundations/Private/SFRCO.cpp
@@ -327,27 +327,17 @@ void USFRCO::Server_StageExtendCommit_Implementation(FSFExtendCommitSpec Spec)
 	if (Spec.bValid)
 	{
 		UE_LOG(LogSmartFoundations, Display,
-			TEXT("[EXTEND-MP] Server staged Extend commit for %s: %d clone children of %s, %d cost item type(s)."),
-			*GetNameSafe(OwnerPC), Spec.Clone.ChildHolograms.Num(),
+			TEXT("[EXTEND-MP] Server staged Extend commit for %s: offset %s, %d scaled clone(s) of %s, %d cost item type(s)."),
+			*GetNameSafe(OwnerPC), *Spec.ParentOffset.ToCompactString(), Spec.ScaledClones.Num(),
 			*GetNameSafe(*Spec.BuildClass), Spec.Cost.Num());
 	}
 }
 
 bool USFRCO::Server_StageExtendCommit_Validate(FSFExtendCommitSpec Spec)
 {
-	// Sanity-bound the clone description (a forged/buggy commit cannot demand absurd spawning).
-	if (Spec.Clone.ChildHolograms.Num() > 4096 || Spec.ScaledClones.Num() > 1024)
-	{
-		return false;
-	}
-	for (const FSFCloneHologram& Child : Spec.Clone.ChildHolograms)
-	{
-		if (Child.SplineData.Points.Num() > 256)
-		{
-			return false;
-		}
-	}
-	return true;
+	// Sanity-bound the commit parameters (a forged/buggy commit cannot demand absurd spawning).
+	// The clone topology itself is derived SERVER-side from these, never shipped.
+	return Spec.ScaledClones.Num() <= 1024 && Spec.ParentOffset.Size() <= 1.0e7;
 }
 
 // ========================================

--- a/Source/SmartFoundations/Private/SFRCO.cpp
+++ b/Source/SmartFoundations/Private/SFRCO.cpp
@@ -418,6 +418,91 @@ bool USFRCO::Server_CancelUpgradeAudit_Validate()
 	return true;
 }
 
+// ========================================
+// Upgrade Execution + Traversal RPCs ([UPGRADE-MP])
+// ========================================
+
+void USFRCO::Server_StartUpgrade_Implementation(FSFUpgradeExecutionParams Params)
+{
+	USFSubsystem* Subsystem = USFSubsystem::Get(this);
+	AFGPlayerController* OwnerPC = Cast<AFGPlayerController>(GetOuter());
+	if (!IsValid(Subsystem) || !OwnerPC)
+	{
+		UE_LOG(LogSmartFoundations, Warning,
+			TEXT("[UPGRADE-MP] Server_StartUpgrade: missing subsystem (%d) or owner PC (%d)"),
+			IsValid(Subsystem) ? 1 : 0, OwnerPC ? 1 : 0);
+		return;
+	}
+
+	USFUpgradeExecutionService* ExecutionService = Subsystem->GetUpgradeExecutionService();
+	if (!IsValid(ExecutionService))
+	{
+		UE_LOG(LogSmartFoundations, Error, TEXT("[UPGRADE-MP] Server_StartUpgrade: no execution service"));
+		return;
+	}
+
+	// Authoritative requester: cost deduction, build-gun hologram instigation, and the result
+	// echo all key off this - never the client-supplied field.
+	Params.PlayerController = OwnerPC;
+
+	UE_LOG(LogSmartFoundations, Display,
+		TEXT("[UPGRADE-MP] Server starting upgrade for %s: family=%d %d->%d radius=%.0fcm specific=%d"),
+		*GetNameSafe(OwnerPC), static_cast<int32>(Params.Family), Params.SourceTier, Params.TargetTier,
+		Params.Radius, Params.SpecificBuildables.Num());
+	ExecutionService->StartUpgrade(Params);
+}
+
+bool USFRCO::Server_StartUpgrade_Validate(FSFUpgradeExecutionParams Params)
+{
+	return Params.SourceTier >= 0 && Params.SourceTier <= 6
+		&& Params.TargetTier >= 0 && Params.TargetTier <= 6
+		&& Params.Radius >= 0.0f
+		&& Params.SpecificBuildables.Num() <= 50000;
+}
+
+void USFRCO::Client_ReceiveUpgradeResult_Implementation(FSFUpgradeExecutionResult Result)
+{
+	USFSubsystem* Subsystem = USFSubsystem::Get(this);
+	if (IsValid(Subsystem))
+	{
+		if (USFUpgradeExecutionService* ExecutionService = Subsystem->GetUpgradeExecutionService())
+		{
+			ExecutionService->InjectUpgradeResult(Result);
+		}
+	}
+}
+
+void USFRCO::Server_StartUpgradeTraversal_Implementation(AFGBuildable* AnchorBuildable, FSFTraversalConfig Config)
+{
+	AFGPlayerController* OwnerPC = Cast<AFGPlayerController>(GetOuter());
+	if (!OwnerPC || !AnchorBuildable)
+	{
+		UE_LOG(LogSmartFoundations, Warning,
+			TEXT("[UPGRADE-MP] Server_StartUpgradeTraversal: missing owner PC (%d) or anchor (%d)"),
+			OwnerPC ? 1 : 0, AnchorBuildable ? 1 : 0);
+		return;
+	}
+
+	// The walk is synchronous; a throwaway service matches the SP panel's usage.
+	USFUpgradeTraversalService* TraversalService = NewObject<USFUpgradeTraversalService>();
+	const FSFTraversalResult Result = TraversalService->TraverseNetwork(AnchorBuildable, Config, OwnerPC);
+	UE_LOG(LogSmartFoundations, Display,
+		TEXT("[UPGRADE-MP] Server traversal for %s from %s: family=%d entries=%d upgradeable=%d"),
+		*GetNameSafe(OwnerPC), *GetNameSafe(AnchorBuildable), static_cast<int32>(Result.Family),
+		Result.Entries.Num(), Result.UpgradeableCount);
+	Client_ReceiveTraversalResult(Result);
+}
+
+bool USFRCO::Server_StartUpgradeTraversal_Validate(AFGBuildable* AnchorBuildable, FSFTraversalConfig Config)
+{
+	return Config.MaxTraversalCount >= 0 && Config.MaxTraversalCount <= 100000;
+}
+
+void USFRCO::Client_ReceiveTraversalResult_Implementation(FSFTraversalResult Result)
+{
+	USFUpgradeTraversalService::InjectTraversalResult(Result);
+}
+
 void USFRCO::Client_ReceiveAuditResult_Implementation(FSFUpgradeAuditResult Result)
 {
 	UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("[SFRCO] Client_ReceiveAuditResult: Success=%d, TotalScanned=%d"), Result.bSuccess, Result.TotalScanned);

--- a/Source/SmartFoundations/Private/SFRCO.cpp
+++ b/Source/SmartFoundations/Private/SFRCO.cpp
@@ -201,6 +201,43 @@ bool USFRCO::Server_ToggleArrows_Validate(bool bVisible)
 }
 
 // ========================================
+// MP spec-based scaling construction
+// ========================================
+
+void USFRCO::Server_StageScalingSpec_Implementation(FSFScalingSpec Spec)
+{
+	USFSubsystem* Subsystem = USFSubsystem::Get(this);
+	AFGPlayerController* OwnerPC = Cast<AFGPlayerController>(GetOuter());
+	if (!IsValid(Subsystem) || !OwnerPC)
+	{
+		UE_LOG(LogSmartFoundations, Warning,
+			TEXT("[SFRCO] Server_StageScalingSpec: missing subsystem (%d) or owner PC (%d)"),
+			IsValid(Subsystem) ? 1 : 0, OwnerPC ? 1 : 0);
+		return;
+	}
+
+	Subsystem->StageScalingSpecForPlayer(OwnerPC, Spec);
+
+	if (Spec.bValid)
+	{
+		UE_LOG(LogSmartFoundations, Display,
+			TEXT("[MP-SPEC] Server staged scaling spec for %s: %d cells of %s."),
+			*GetNameSafe(OwnerPC), Spec.CellCount(), *GetNameSafe(*Spec.BuildClass));
+	}
+}
+
+bool USFRCO::Server_StageScalingSpec_Validate(FSFScalingSpec Spec)
+{
+	// Sanity-bound the grid (a forged/buggy spec cannot demand absurd expansion).
+	const FIntVector& G = Spec.Counters.GridCounters;
+	const int64 Cells = (int64)FMath::Max(1, FMath::Abs(G.X))
+		* FMath::Max(1, FMath::Abs(G.Y))
+		* FMath::Max(1, FMath::Abs(G.Z));
+	return FMath::Abs(G.X) <= 2000 && FMath::Abs(G.Y) <= 2000 && FMath::Abs(G.Z) <= 2000
+		&& Cells <= 100000;
+}
+
+// ========================================
 // Upgrade Audit RPCs
 // ========================================
 

--- a/Source/SmartFoundations/Private/SFRCO.cpp
+++ b/Source/SmartFoundations/Private/SFRCO.cpp
@@ -4,6 +4,7 @@
 #include "SmartFoundations.h"
 #include "Hologram/FGHologram.h"
 #include "Subsystem/SFSubsystem.h"
+#include "Features/Extend/SFExtendService.h"   // [EXTEND-MP] topology walk RPCs
 #include "FGPlayerController.h"  // AFGPlayerController (don't rely on transitive unity-build includes)
 #include "Net/UnrealNetwork.h"
 
@@ -254,6 +255,59 @@ bool USFRCO::Server_StageScalingSpec_Validate(FSFScalingSpec Spec)
 		}
 	}
 	return true;
+}
+
+// ========================================
+// Extend MP: server-side topology walk
+// ========================================
+
+void USFRCO::Server_RequestExtendTopology_Implementation(AFGBuildable* SourceBuilding)
+{
+	USFSubsystem* Subsystem = USFSubsystem::Get(this);
+	USFExtendService* Extend = IsValid(Subsystem) ? Subsystem->GetExtendService() : nullptr;
+	if (!Extend || !IsValid(SourceBuilding))
+	{
+		UE_LOG(LogSmartFoundations, Warning,
+			TEXT("[EXTEND-MP] Server_RequestExtendTopology: missing extend service (%d) or building (%d)"),
+			Extend ? 1 : 0, IsValid(SourceBuilding) ? 1 : 0);
+		return;
+	}
+
+	FSFExtendTopology Reply;
+	if (Extend->WalkTopology(SourceBuilding))
+	{
+		Reply = Extend->GetCurrentTopology();
+	}
+	else
+	{
+		// Negative reply: tag the building so the client caches "nothing to extend here" briefly
+		// instead of re-requesting every tick while aiming.
+		Reply.Reset();
+		Reply.SourceBuilding = SourceBuilding;
+		Reply.bIsValid = false;
+	}
+
+	UE_LOG(LogSmartFoundations, Display,
+		TEXT("[EXTEND-MP] Server walked topology for %s: valid=%d (beltIn=%d beltOut=%d pipeIn=%d pipeOut=%d power=%d)"),
+		*GetNameSafe(SourceBuilding), Reply.bIsValid ? 1 : 0,
+		Reply.InputChains.Num(), Reply.OutputChains.Num(),
+		Reply.PipeInputChains.Num(), Reply.PipeOutputChains.Num(), Reply.PowerPoles.Num());
+
+	Client_ReceiveExtendTopology(Reply);
+}
+
+bool USFRCO::Server_RequestExtendTopology_Validate(AFGBuildable* SourceBuilding)
+{
+	return true; // null-checked in the implementation; no client-supplied geometry to bound
+}
+
+void USFRCO::Client_ReceiveExtendTopology_Implementation(FSFExtendTopology Topology)
+{
+	USFSubsystem* Subsystem = USFSubsystem::Get(this);
+	if (USFExtendService* Extend = IsValid(Subsystem) ? Subsystem->GetExtendService() : nullptr)
+	{
+		Extend->ReceiveServerTopology(Topology);
+	}
 }
 
 // ========================================

--- a/Source/SmartFoundations/Private/SFRCO.cpp
+++ b/Source/SmartFoundations/Private/SFRCO.cpp
@@ -336,7 +336,7 @@ void USFRCO::Server_StageExtendCommit_Implementation(FSFExtendCommitSpec Spec)
 bool USFRCO::Server_StageExtendCommit_Validate(FSFExtendCommitSpec Spec)
 {
 	// Sanity-bound the clone description (a forged/buggy commit cannot demand absurd spawning).
-	if (Spec.Clone.ChildHolograms.Num() > 4096)
+	if (Spec.Clone.ChildHolograms.Num() > 4096 || Spec.ScaledClones.Num() > 1024)
 	{
 		return false;
 	}

--- a/Source/SmartFoundations/Private/SFRCO.cpp
+++ b/Source/SmartFoundations/Private/SFRCO.cpp
@@ -221,8 +221,8 @@ void USFRCO::Server_StageScalingSpec_Implementation(FSFScalingSpec Spec)
 	if (Spec.bValid)
 	{
 		UE_LOG(LogSmartFoundations, Display,
-			TEXT("[MP-SPEC] Server staged scaling spec for %s: %d cells of %s, %d planned belt(s)."),
-			*GetNameSafe(OwnerPC), Spec.CellCount(), *GetNameSafe(*Spec.BuildClass), Spec.BeltPlan.Num());
+			TEXT("[MP-SPEC] Server staged scaling spec for %s: %d cells of %s, %d planned conduit(s)."),
+			*GetNameSafe(OwnerPC), Spec.CellCount(), *GetNameSafe(*Spec.BuildClass), Spec.ConduitPlan.Num());
 	}
 }
 
@@ -239,14 +239,14 @@ bool USFRCO::Server_StageScalingSpec_Validate(FSFScalingSpec Spec)
 		return false;
 	}
 
-	// Sanity-bound the belt plan (#334): at most ~3 belts per distributor cell in practice; allow
+	// Sanity-bound the conduit plan (#334): at most a few conduits per grid cell in practice; allow
 	// generous headroom. Spline previews route with a handful of points; 64 is far beyond any real
 	// auto-connect belt.
-	if (Spec.BeltPlan.Num() > 4096)
+	if (Spec.ConduitPlan.Num() > 4096)
 	{
 		return false;
 	}
-	for (const FSFBeltPlanEntry& Entry : Spec.BeltPlan)
+	for (const FSFConduitPlanEntry& Entry : Spec.ConduitPlan)
 	{
 		if (Entry.SplinePoints.Num() > 64)
 		{

--- a/Source/SmartFoundations/Private/SFRCO.cpp
+++ b/Source/SmartFoundations/Private/SFRCO.cpp
@@ -221,7 +221,7 @@ void USFRCO::Server_StageScalingSpec_Implementation(FSFScalingSpec Spec)
 
 	if (Spec.bValid)
 	{
-		UE_LOG(LogSmartFoundations, Display,
+		UE_LOG(LogSmartFoundations, Verbose,
 			TEXT("[MP-SPEC] Server staged scaling spec for %s: %d cells of %s, %d planned conduit(s)."),
 			*GetNameSafe(OwnerPC), Spec.CellCount(), *GetNameSafe(*Spec.BuildClass), Spec.ConduitPlan.Num());
 	}
@@ -287,7 +287,7 @@ void USFRCO::Server_RequestExtendTopology_Implementation(AFGBuildable* SourceBui
 		Reply.bIsValid = false;
 	}
 
-	UE_LOG(LogSmartFoundations, Display,
+	UE_LOG(LogSmartFoundations, Verbose,
 		TEXT("[EXTEND-MP] Server walked topology for %s: valid=%d (beltIn=%d beltOut=%d pipeIn=%d pipeOut=%d power=%d)"),
 		*GetNameSafe(SourceBuilding), Reply.bIsValid ? 1 : 0,
 		Reply.InputChains.Num(), Reply.OutputChains.Num(),
@@ -326,7 +326,7 @@ void USFRCO::Server_StageExtendCommit_Implementation(FSFExtendCommitSpec Spec)
 
 	if (Spec.bValid)
 	{
-		UE_LOG(LogSmartFoundations, Display,
+		UE_LOG(LogSmartFoundations, Verbose,
 			TEXT("[EXTEND-MP] Server staged %s commit for %s: offset %s, %d scaled clone(s) of %s, %d cost item type(s)%s."),
 			Spec.bIsRestore ? TEXT("RESTORE") : TEXT("Extend"),
 			*GetNameSafe(OwnerPC), *Spec.ParentOffset.ToCompactString(), Spec.ScaledClones.Num(),
@@ -445,7 +445,7 @@ void USFRCO::Server_StartUpgrade_Implementation(FSFUpgradeExecutionParams Params
 	// echo all key off this - never the client-supplied field.
 	Params.PlayerController = OwnerPC;
 
-	UE_LOG(LogSmartFoundations, Display,
+	UE_LOG(LogSmartFoundations, Verbose,
 		TEXT("[UPGRADE-MP] Server starting upgrade for %s: family=%d %d->%d radius=%.0fcm specific=%d"),
 		*GetNameSafe(OwnerPC), static_cast<int32>(Params.Family), Params.SourceTier, Params.TargetTier,
 		Params.Radius, Params.SpecificBuildables.Num());
@@ -486,7 +486,7 @@ void USFRCO::Server_StartUpgradeTraversal_Implementation(AFGBuildable* AnchorBui
 	// The walk is synchronous; a throwaway service matches the SP panel's usage.
 	USFUpgradeTraversalService* TraversalService = NewObject<USFUpgradeTraversalService>();
 	const FSFTraversalResult Result = TraversalService->TraverseNetwork(AnchorBuildable, Config, OwnerPC);
-	UE_LOG(LogSmartFoundations, Display,
+	UE_LOG(LogSmartFoundations, Verbose,
 		TEXT("[UPGRADE-MP] Server traversal for %s from %s: family=%d entries=%d upgradeable=%d"),
 		*GetNameSafe(OwnerPC), *GetNameSafe(AnchorBuildable), static_cast<int32>(Result.Family),
 		Result.Entries.Num(), Result.UpgradeableCount);

--- a/Source/SmartFoundations/Private/SFRCO.cpp
+++ b/Source/SmartFoundations/Private/SFRCO.cpp
@@ -17,6 +17,14 @@ bool USFRCO::ShouldRegisterRemoteCallObject(const AFGGameMode* GameMode) const
 	return true;
 }
 
+void USFRCO::GetLifetimeReplicatedProps(TArray<FLifetimeProperty>& OutLifetimeProps) const
+{
+	Super::GetLifetimeReplicatedProps(OutLifetimeProps);
+
+	// Required for the RCO to replicate at all (SML rule): register at least one replicated property.
+	DOREPLIFETIME(USFRCO, bDummyReplicated);
+}
+
 // ========================================
 // Scaling RPCs
 // ========================================

--- a/Source/SmartFoundations/Private/SFRCO.cpp
+++ b/Source/SmartFoundations/Private/SFRCO.cpp
@@ -221,8 +221,8 @@ void USFRCO::Server_StageScalingSpec_Implementation(FSFScalingSpec Spec)
 	if (Spec.bValid)
 	{
 		UE_LOG(LogSmartFoundations, Display,
-			TEXT("[MP-SPEC] Server staged scaling spec for %s: %d cells of %s."),
-			*GetNameSafe(OwnerPC), Spec.CellCount(), *GetNameSafe(*Spec.BuildClass));
+			TEXT("[MP-SPEC] Server staged scaling spec for %s: %d cells of %s, %d planned belt(s)."),
+			*GetNameSafe(OwnerPC), Spec.CellCount(), *GetNameSafe(*Spec.BuildClass), Spec.BeltPlan.Num());
 	}
 }
 
@@ -233,8 +233,27 @@ bool USFRCO::Server_StageScalingSpec_Validate(FSFScalingSpec Spec)
 	const int64 Cells = (int64)FMath::Max(1, FMath::Abs(G.X))
 		* FMath::Max(1, FMath::Abs(G.Y))
 		* FMath::Max(1, FMath::Abs(G.Z));
-	return FMath::Abs(G.X) <= 2000 && FMath::Abs(G.Y) <= 2000 && FMath::Abs(G.Z) <= 2000
-		&& Cells <= 100000;
+	if (FMath::Abs(G.X) > 2000 || FMath::Abs(G.Y) > 2000 || FMath::Abs(G.Z) > 2000
+		|| Cells > 100000)
+	{
+		return false;
+	}
+
+	// Sanity-bound the belt plan (#334): at most ~3 belts per distributor cell in practice; allow
+	// generous headroom. Spline previews route with a handful of points; 64 is far beyond any real
+	// auto-connect belt.
+	if (Spec.BeltPlan.Num() > 4096)
+	{
+		return false;
+	}
+	for (const FSFBeltPlanEntry& Entry : Spec.BeltPlan)
+	{
+		if (Entry.SplinePoints.Num() > 64)
+		{
+			return false;
+		}
+	}
+	return true;
 }
 
 // ========================================

--- a/Source/SmartFoundations/Private/SFRCO.cpp
+++ b/Source/SmartFoundations/Private/SFRCO.cpp
@@ -310,6 +310,46 @@ void USFRCO::Client_ReceiveExtendTopology_Implementation(FSFExtendTopology Topol
 	}
 }
 
+void USFRCO::Server_StageExtendCommit_Implementation(FSFExtendCommitSpec Spec)
+{
+	USFSubsystem* Subsystem = USFSubsystem::Get(this);
+	AFGPlayerController* OwnerPC = Cast<AFGPlayerController>(GetOuter());
+	if (!IsValid(Subsystem) || !OwnerPC)
+	{
+		UE_LOG(LogSmartFoundations, Warning,
+			TEXT("[EXTEND-MP] Server_StageExtendCommit: missing subsystem (%d) or owner PC (%d)"),
+			IsValid(Subsystem) ? 1 : 0, OwnerPC ? 1 : 0);
+		return;
+	}
+
+	Subsystem->StageExtendCommitForPlayer(OwnerPC, Spec);
+
+	if (Spec.bValid)
+	{
+		UE_LOG(LogSmartFoundations, Display,
+			TEXT("[EXTEND-MP] Server staged Extend commit for %s: %d clone children of %s, %d cost item type(s)."),
+			*GetNameSafe(OwnerPC), Spec.Clone.ChildHolograms.Num(),
+			*GetNameSafe(*Spec.BuildClass), Spec.Cost.Num());
+	}
+}
+
+bool USFRCO::Server_StageExtendCommit_Validate(FSFExtendCommitSpec Spec)
+{
+	// Sanity-bound the clone description (a forged/buggy commit cannot demand absurd spawning).
+	if (Spec.Clone.ChildHolograms.Num() > 4096)
+	{
+		return false;
+	}
+	for (const FSFCloneHologram& Child : Spec.Clone.ChildHolograms)
+	{
+		if (Child.SplineData.Points.Num() > 256)
+		{
+			return false;
+		}
+	}
+	return true;
+}
+
 // ========================================
 // Upgrade Audit RPCs
 // ========================================

--- a/Source/SmartFoundations/Private/Services/SFChainActorService.cpp
+++ b/Source/SmartFoundations/Private/Services/SFChainActorService.cpp
@@ -1780,6 +1780,20 @@ int32 USFChainActorService::RemoveConveyorFromAllTickGroups(AFGBuildableConveyor
 	return StaleRemovals;
 }
 
+int32 USFChainActorService::RemoveBuildableFromFactoryTickArrays(AFGBuildable* Buildable)
+{
+	AFGBuildableSubsystem* BuildableSub = GetBuildableSubsystem();
+	if (!BuildableSub || !Buildable) return 0;
+
+	int32 Removed = 0;
+	Removed += BuildableSub->mFactoryBuildings.Remove(Buildable);
+	for (TArray<AFGBuildable*>& Group : BuildableSub->mFactoryBuildingGroups)
+	{
+		Removed += Group.Remove(Buildable);
+	}
+	return Removed;
+}
+
 void USFChainActorService::ScheduleDeferredZombiePurge(float DelaySeconds)
 {
 	USFSubsystem* Sub = Subsystem.Get();

--- a/Source/SmartFoundations/Private/Services/SFChainActorService.cpp
+++ b/Source/SmartFoundations/Private/Services/SFChainActorService.cpp
@@ -1802,8 +1802,15 @@ int32 USFChainActorService::ScrubFactoryTickArrays()
 	auto IsEntryHealthy = [](AFGBuildable* Entry) -> bool
 	{
 		// IsValidLowLevelFast rejects freed/garbage pointers (GUObjectArray membership + vtable
-		// sanity); IsValid additionally rejects pending-kill objects.
-		return Entry && Entry->IsValidLowLevelFast(/*bRecursive*/ false) && IsValid(Entry);
+		// sanity); IsValid additionally rejects pending-kill objects. The IsA check catches the
+		// one case those CANNOT: a stale entry whose freed memory was REUSED by a different live
+		// UObject at the same address - it passes both validity checks but is not a buildable,
+		// and Factory_Tick through the wrong (smaller) vtable reads garbage past it (the
+		// 2026-06-10 tick-AV signature; repro 10 motivated this check).
+		return Entry
+			&& Entry->IsValidLowLevelFast(/*bRecursive*/ false)
+			&& IsValid(Entry)
+			&& Entry->IsA<AFGBuildable>();
 	};
 
 	int32 RemovedTotal = 0;
@@ -1817,12 +1824,21 @@ int32 USFChainActorService::ScrubFactoryTickArrays()
 			continue;
 		}
 
-		// Identify the corruption site via valid neighbors (registration order context).
+		// Identify the corruption site via valid neighbors (registration order context). If the
+		// entry is a live UObject of the WRONG class, the address was recycled - name the
+		// squatter: its class points at whatever allocates over freed buildables.
 		AFGBuildable* Prev = Buildings.IsValidIndex(Index - 1) ? Buildings[Index - 1] : nullptr;
 		AFGBuildable* Next = Buildings.IsValidIndex(Index + 1) ? Buildings[Index + 1] : nullptr;
+		FString EntryDescription = TEXT("<freed/garbage>");
+		if (Entry && Entry->IsValidLowLevelFast(false) && IsValid(Entry) && !Entry->IsA<AFGBuildable>())
+		{
+			UObject* Squatter = static_cast<UObject*>(Entry);
+			EntryDescription = FString::Printf(TEXT("LIVE NON-BUILDABLE (recycled address): %s / %s"),
+				*Squatter->GetName(), *GetNameSafe(Squatter->GetClass()));
+		}
 		UE_LOG(LogSmartUpgrade, Error,
-			TEXT("[CHAIN-DIAG] CORRUPT mFactoryBuildings entry at index %d/%d: ptr=0x%llX (prev=%s next=%s) - removed before the factory tick could call through it."),
-			Index, Buildings.Num(), reinterpret_cast<uint64>(Entry),
+			TEXT("[CHAIN-DIAG] CORRUPT mFactoryBuildings entry at index %d/%d: ptr=0x%llX [%s] (prev=%s next=%s) - removed before the factory tick could call through it."),
+			Index, Buildings.Num(), reinterpret_cast<uint64>(Entry), *EntryDescription,
 			IsEntryHealthy(Prev) ? *Prev->GetName() : TEXT("<invalid/none>"),
 			IsEntryHealthy(Next) ? *Next->GetName() : TEXT("<invalid/none>"));
 		Buildings.RemoveAt(Index);

--- a/Source/SmartFoundations/Private/Services/SFChainActorService.cpp
+++ b/Source/SmartFoundations/Private/Services/SFChainActorService.cpp
@@ -20,6 +20,21 @@
 void USFChainActorService::Initialize(USFSubsystem* InSubsystem)
 {
 	Subsystem = InSubsystem;
+
+	// Load-time repair sweep (authority only): a save written while detached-but-segmented
+	// chains existed (the pre-fix upgrade/extend rebuild left them; ShouldSave is unconditionally
+	// true) reloads with belts claimed by TWO chains — vanilla's in-tick recovery then fires
+	// ForceDestroyChainActor from a ParallelFor WORKER and randomly asserts (the 2026-06-10 boot
+	// crash). Sweeping once shortly after load force-destroys those chains from the GAME THREAD
+	// (items transfer back to belts) before the race can fire again. 15 s leaves vanilla's own
+	// load-time chain registration time to settle first.
+	if (UWorld* World = InSubsystem ? InSubsystem->GetWorld() : nullptr)
+	{
+		if (World->GetNetMode() != NM_Client)
+		{
+			ScheduleDeferredZombiePurge(15.0f);
+		}
+	}
 }
 
 void USFChainActorService::Shutdown()
@@ -760,7 +775,7 @@ int32 USFChainActorService::PurgeZombieChainActors()
 	// Factory_Tick:614 → ForceDestroyChainActor fires from a ParallelFor worker thread
 	// (assertion: GTestRegisterComponentTickFunctions == 0 fails on worker threads).
 	TArray<AFGConveyorChainActor*> Zombies;
-	int32 DetachedWithSegments = 0;
+	TArray<AFGConveyorChainActor*> DetachedWithSegments;
 	for (TActorIterator<AFGConveyorChainActor> It(World); It; ++It)
 	{
 		AFGConveyorChainActor* Chain = *It;
@@ -771,9 +786,13 @@ int32 USFChainActorService::PurgeZombieChainActors()
 		}
 		else
 		{
-			// [CHAIN-DIAG] A chain WITH segments that no tick group owns escapes this purge,
-			// saves (ShouldSave unconditionally true), and poisons the reload (belts found in
-			// two chains' segment lists -> vanilla's racy in-tick recovery -> 2026-06-10 crash).
+			// A chain WITH segments that no tick group owns is NOT inert (the old Phase 2/4
+			// assumption): it persists into saves (ShouldSave is unconditionally true) where its
+			// segment list claims belts now owned by the replacement chain — on reload vanilla's
+			// in-tick recovery fires ForceDestroyChainActor from a ParallelFor WORKER and
+			// randomly asserts in FNetworkObjectList (the 2026-06-10 boot crash). At runtime it
+			// also imprisons its in-flight items (length-0 orphan chains holding 6-12 items each,
+			// starving downstream factories — live finding, same day).
 			bool bOwned = false;
 			for (FConveyorTickGroup* TG : BuildableSub->mConveyorTickGroup)
 			{
@@ -781,24 +800,35 @@ int32 USFChainActorService::PurgeZombieChainActors()
 			}
 			if (!bOwned)
 			{
-				++DetachedWithSegments;
-				if (DetachedWithSegments <= 12)
-				{
-					UE_LOG(LogSmartUpgrade, Display,
-						TEXT("[CHAIN-DIAG] Purge SKIPPING detached-but-segmented chain %s (segments=%d) — save-poison candidate"),
-						*Chain->GetName(), Chain->GetNumChainSegments());
-				}
+				DetachedWithSegments.Add(Chain);
 			}
 		}
 	}
-	if (DetachedWithSegments > 0)
+
+	// Destroy detached-but-segmented chains via VANILLA's own cleanup. ForceDestroyChainActor
+	// removes the chain from the tick buckets AND transfers its items back onto the conveyor
+	// belts — exactly the two leaks (save poison + imprisoned items). It is only unsafe from
+	// ParallelFor workers (vanilla's own in-tick recovery crash); this timer context is the
+	// game thread in TG_PrePhysics, before TickFactoryActors dispatches — the same safety
+	// window the 0-segment Destroy() path below has used since April 2026.
+	int32 ForceDestroyedCount = 0;
+	for (AFGConveyorChainActor* Chain : DetachedWithSegments)
+	{
+		if (!IsValid(Chain)) continue;
+		UE_LOG(LogSmartUpgrade, Display,
+			TEXT("[CHAIN-DIAG] Purge force-destroying detached-but-segmented chain %s (segments=%d) — items transfer back to belts"),
+			*Chain->GetName(), Chain->GetNumChainSegments());
+		BuildableSub->ForceDestroyChainActor(Chain);
+		++ForceDestroyedCount;
+	}
+	if (ForceDestroyedCount > 0)
 	{
 		UE_LOG(LogSmartUpgrade, Display,
-			TEXT("[CHAIN-DIAG] Purge sweep: %d detached-but-segmented chain(s) NOT purged (save-poison candidates)"),
-			DetachedWithSegments);
+			TEXT("[CHAIN-DIAG] Purge sweep: %d detached-but-segmented chain(s) force-destroyed (save-poison + frozen-item fix)"),
+			ForceDestroyedCount);
 	}
 
-	if (Zombies.Num() == 0) return 0;
+	if (Zombies.Num() == 0) return ForceDestroyedCount;
 
 	int32 PurgeCount = 0;
 	for (AFGConveyorChainActor* Chain : Zombies)
@@ -829,7 +859,7 @@ int32 USFChainActorService::PurgeZombieChainActors()
 		++PurgeCount;
 	}
 
-	return PurgeCount;
+	return PurgeCount + ForceDestroyedCount;
 }
 
 int32 USFChainActorService::RepairSplitChains()

--- a/Source/SmartFoundations/Private/Services/SFChainActorService.cpp
+++ b/Source/SmartFoundations/Private/Services/SFChainActorService.cpp
@@ -1757,6 +1757,29 @@ int32 USFChainActorService::ReRegisterAndQueueVanillaRebuildForBelts(
 	return PendingGroups;
 }
 
+int32 USFChainActorService::RemoveConveyorFromAllTickGroups(AFGBuildableConveyorBase* Conveyor)
+{
+	AFGBuildableSubsystem* BuildableSub = GetBuildableSubsystem();
+	if (!BuildableSub || !Conveyor) return 0;
+
+	int32 StaleRemovals = 0;
+	for (FConveyorTickGroup* TG : BuildableSub->mConveyorTickGroup)
+	{
+		if (TG && TG->Conveyors.Contains(Conveyor))
+		{
+			TG->Conveyors.Remove(Conveyor);
+			++StaleRemovals;
+		}
+	}
+	if (StaleRemovals > 0)
+	{
+		UE_LOG(LogSmartUpgrade, Display,
+			TEXT("[CHAIN-DIAG] RemoveConveyor guard: %s was STILL in %d tick group(s) after vanilla removal (stale bucket id) - force-removed (freed-pointer factory-tick AV prevented)."),
+			*Conveyor->GetName(), StaleRemovals);
+	}
+	return StaleRemovals;
+}
+
 void USFChainActorService::ScheduleDeferredZombiePurge(float DelaySeconds)
 {
 	USFSubsystem* Sub = Subsystem.Get();

--- a/Source/SmartFoundations/Private/Services/SFChainActorService.cpp
+++ b/Source/SmartFoundations/Private/Services/SFChainActorService.cpp
@@ -1794,6 +1794,59 @@ int32 USFChainActorService::RemoveBuildableFromFactoryTickArrays(AFGBuildable* B
 	return Removed;
 }
 
+int32 USFChainActorService::ScrubFactoryTickArrays()
+{
+	AFGBuildableSubsystem* BuildableSub = GetBuildableSubsystem();
+	if (!BuildableSub) return 0;
+
+	auto IsEntryHealthy = [](AFGBuildable* Entry) -> bool
+	{
+		// IsValidLowLevelFast rejects freed/garbage pointers (GUObjectArray membership + vtable
+		// sanity); IsValid additionally rejects pending-kill objects.
+		return Entry && Entry->IsValidLowLevelFast(/*bRecursive*/ false) && IsValid(Entry);
+	};
+
+	int32 RemovedTotal = 0;
+
+	TArray<AFGBuildable*>& Buildings = BuildableSub->mFactoryBuildings;
+	for (int32 Index = Buildings.Num() - 1; Index >= 0; --Index)
+	{
+		AFGBuildable* Entry = Buildings[Index];
+		if (IsEntryHealthy(Entry))
+		{
+			continue;
+		}
+
+		// Identify the corruption site via valid neighbors (registration order context).
+		AFGBuildable* Prev = Buildings.IsValidIndex(Index - 1) ? Buildings[Index - 1] : nullptr;
+		AFGBuildable* Next = Buildings.IsValidIndex(Index + 1) ? Buildings[Index + 1] : nullptr;
+		UE_LOG(LogSmartUpgrade, Error,
+			TEXT("[CHAIN-DIAG] CORRUPT mFactoryBuildings entry at index %d/%d: ptr=0x%llX (prev=%s next=%s) - removed before the factory tick could call through it."),
+			Index, Buildings.Num(), reinterpret_cast<uint64>(Entry),
+			IsEntryHealthy(Prev) ? *Prev->GetName() : TEXT("<invalid/none>"),
+			IsEntryHealthy(Next) ? *Next->GetName() : TEXT("<invalid/none>"));
+		Buildings.RemoveAt(Index);
+		++RemovedTotal;
+	}
+
+	for (TArray<AFGBuildable*>& Group : BuildableSub->mFactoryBuildingGroups)
+	{
+		for (int32 Index = Group.Num() - 1; Index >= 0; --Index)
+		{
+			if (!IsEntryHealthy(Group[Index]))
+			{
+				UE_LOG(LogSmartUpgrade, Error,
+					TEXT("[CHAIN-DIAG] CORRUPT mFactoryBuildingGroups entry: ptr=0x%llX - removed."),
+					reinterpret_cast<uint64>(Group[Index]));
+				Group.RemoveAt(Index);
+				++RemovedTotal;
+			}
+		}
+	}
+
+	return RemovedTotal;
+}
+
 void USFChainActorService::ScheduleDeferredZombiePurge(float DelaySeconds)
 {
 	USFSubsystem* Sub = Subsystem.Get();

--- a/Source/SmartFoundations/Private/Services/SFChainActorService.cpp
+++ b/Source/SmartFoundations/Private/Services/SFChainActorService.cpp
@@ -163,6 +163,13 @@ int32 USFChainActorService::InvalidateAndRebuildChains(
 		else
 		{
 			++OrphanCount;
+			// [CHAIN-DIAG] An "orphan" affected chain (no owning TG) is assumed inert, but if it
+			// still HOLDS SEGMENTS it will be skipped by the 0-segment zombie purge, persist into
+			// the save (ShouldSave is unconditionally true), and poison the reload — belts appear
+			// in two chains' segment lists (live crash class 2026-06-10).
+			UE_LOG(LogSmartUpgrade, Display,
+				TEXT("[CHAIN-DIAG] Phase1 orphan affected chain %s: segments=%d (no owning TG; left alive)"),
+				*Chain->GetName(), Chain->GetNumChainSegments());
 		}
 	}
 
@@ -482,6 +489,24 @@ int32 USFChainActorService::InvalidateAndRebuildChains(
 
 		BuildableSub->MigrateConveyorGroupToChainActor(TG);
 
+		// [CHAIN-DIAG] One line per migrated group: new chain identity + segment count + members.
+		{
+			FString MemberNames;
+			int32 Listed = 0;
+			for (AFGBuildableConveyorBase* B : TG->Conveyors)
+			{
+				if (!IsValid(B)) continue;
+				if (Listed++ == 5) { MemberNames += TEXT(",..."); break; }
+				if (Listed > 1) MemberNames += TEXT(",");
+				MemberNames += B->GetName();
+			}
+			UE_LOG(LogSmartUpgrade, Display,
+				TEXT("[CHAIN-DIAG] Phase3 migrated TG (%d belts: %s) -> chain %s segments=%d"),
+				ValidBeltCount, *MemberNames,
+				TG->ChainActor ? *TG->ChainActor->GetName() : TEXT("null"),
+				TG->ChainActor ? TG->ChainActor->GetNumChainSegments() : -1);
+		}
+
 		// Post-migrate check: did we produce a valid chain?
 		if (TG->ChainActor)
 		{
@@ -652,6 +677,16 @@ int32 USFChainActorService::InvalidateAndRebuildChains(
 		// calls Destroy() on it in a safe timer context 3 seconds from now.
 		BuildableSub->RemoveConveyorChainActor(Chain);
 		++DetachedCount;
+
+		// [CHAIN-DIAG] CRITICAL probe: this detached chain is assumed to be a 0-segment zombie
+		// (Phase 2's RemoveChainActorFromConveyorGroup supposedly zeroed its segment list). If
+		// segments are NON-zero here, the deferred purge will SKIP it, it saves (ShouldSave is
+		// unconditionally true), and the reload sees its belts in two chains — the 2026-06-10
+		// load-crash poison. This line is the smoking gun for that hypothesis.
+		UE_LOG(LogSmartUpgrade, Display,
+			TEXT("[CHAIN-DIAG] Phase4 detached old chain %s: segments=%d%s"),
+			*Chain->GetName(), Chain->GetNumChainSegments(),
+			Chain->GetNumChainSegments() > 0 ? TEXT("  <-- WILL ESCAPE THE 0-SEG PURGE AND POISON THE SAVE") : TEXT(""));
 	}
 
 	// Phase 5: Verify every affected group is internally consistent before returning.
@@ -725,12 +760,42 @@ int32 USFChainActorService::PurgeZombieChainActors()
 	// Factory_Tick:614 → ForceDestroyChainActor fires from a ParallelFor worker thread
 	// (assertion: GTestRegisterComponentTickFunctions == 0 fails on worker threads).
 	TArray<AFGConveyorChainActor*> Zombies;
+	int32 DetachedWithSegments = 0;
 	for (TActorIterator<AFGConveyorChainActor> It(World); It; ++It)
 	{
 		AFGConveyorChainActor* Chain = *It;
 		if (!Chain || !IsValid(Chain)) continue;
 		if (Chain->GetNumChainSegments() == 0)
+		{
 			Zombies.Add(Chain);
+		}
+		else
+		{
+			// [CHAIN-DIAG] A chain WITH segments that no tick group owns escapes this purge,
+			// saves (ShouldSave unconditionally true), and poisons the reload (belts found in
+			// two chains' segment lists -> vanilla's racy in-tick recovery -> 2026-06-10 crash).
+			bool bOwned = false;
+			for (FConveyorTickGroup* TG : BuildableSub->mConveyorTickGroup)
+			{
+				if (TG && TG->ChainActor == Chain) { bOwned = true; break; }
+			}
+			if (!bOwned)
+			{
+				++DetachedWithSegments;
+				if (DetachedWithSegments <= 12)
+				{
+					UE_LOG(LogSmartUpgrade, Display,
+						TEXT("[CHAIN-DIAG] Purge SKIPPING detached-but-segmented chain %s (segments=%d) — save-poison candidate"),
+						*Chain->GetName(), Chain->GetNumChainSegments());
+				}
+			}
+		}
+	}
+	if (DetachedWithSegments > 0)
+	{
+		UE_LOG(LogSmartUpgrade, Display,
+			TEXT("[CHAIN-DIAG] Purge sweep: %d detached-but-segmented chain(s) NOT purged (save-poison candidates)"),
+			DetachedWithSegments);
 	}
 
 	if (Zombies.Num() == 0) return 0;

--- a/Source/SmartFoundations/Private/Services/SFChainActorService.cpp
+++ b/Source/SmartFoundations/Private/Services/SFChainActorService.cpp
@@ -182,7 +182,7 @@ int32 USFChainActorService::InvalidateAndRebuildChains(
 			// still HOLDS SEGMENTS it will be skipped by the 0-segment zombie purge, persist into
 			// the save (ShouldSave is unconditionally true), and poison the reload — belts appear
 			// in two chains' segment lists (live crash class 2026-06-10).
-			UE_LOG(LogSmartUpgrade, Display,
+			UE_LOG(LogSmartUpgrade, Verbose,
 				TEXT("[CHAIN-DIAG] Phase1 orphan affected chain %s: segments=%d (no owning TG; left alive)"),
 				*Chain->GetName(), Chain->GetNumChainSegments());
 		}
@@ -515,7 +515,7 @@ int32 USFChainActorService::InvalidateAndRebuildChains(
 				if (Listed > 1) MemberNames += TEXT(",");
 				MemberNames += B->GetName();
 			}
-			UE_LOG(LogSmartUpgrade, Display,
+			UE_LOG(LogSmartUpgrade, Verbose,
 				TEXT("[CHAIN-DIAG] Phase3 migrated TG (%d belts: %s) -> chain %s segments=%d"),
 				ValidBeltCount, *MemberNames,
 				TG->ChainActor ? *TG->ChainActor->GetName() : TEXT("null"),
@@ -698,7 +698,7 @@ int32 USFChainActorService::InvalidateAndRebuildChains(
 		// segments are NON-zero here, the deferred purge will SKIP it, it saves (ShouldSave is
 		// unconditionally true), and the reload sees its belts in two chains — the 2026-06-10
 		// load-crash poison. This line is the smoking gun for that hypothesis.
-		UE_LOG(LogSmartUpgrade, Display,
+		UE_LOG(LogSmartUpgrade, Verbose,
 			TEXT("[CHAIN-DIAG] Phase4 detached old chain %s: segments=%d%s"),
 			*Chain->GetName(), Chain->GetNumChainSegments(),
 			Chain->GetNumChainSegments() > 0 ? TEXT("  <-- WILL ESCAPE THE 0-SEG PURGE AND POISON THE SAVE") : TEXT(""));
@@ -831,7 +831,7 @@ int32 USFChainActorService::PurgeZombieChainActors()
 				OrphanedMemberBelts.AddUnique(Seg.ConveyorBase);
 			}
 		}
-		UE_LOG(LogSmartUpgrade, Display,
+		UE_LOG(LogSmartUpgrade, Warning,
 			TEXT("[CHAIN-DIAG] Purge force-destroying detached-but-segmented chain %s (segments=%d) — items transfer back to belts"),
 			*Chain->GetName(), Chain->GetNumChainSegments());
 		BuildableSub->ForceDestroyChainActor(Chain);
@@ -848,7 +848,7 @@ int32 USFChainActorService::PurgeZombieChainActors()
 	}
 	if (ForceDestroyedCount > 0)
 	{
-		UE_LOG(LogSmartUpgrade, Display,
+		UE_LOG(LogSmartUpgrade, Warning,
 			TEXT("[CHAIN-DIAG] Purge sweep: %d detached-but-segmented chain(s) force-destroyed, %d chainless member belt(s) re-registered for vanilla rebuild"),
 			ForceDestroyedCount, ReRegisteredBelts);
 	}
@@ -885,21 +885,21 @@ int32 USFChainActorService::PurgeZombieChainActors()
 		++HealedChainlessBelts;
 		if (HealedChainlessBelts <= 12)
 		{
-			UE_LOG(LogSmartUpgrade, Display,
+			UE_LOG(LogSmartUpgrade, Warning,
 				TEXT("[CHAIN-DIAG] Purge sweep: re-registered connected-but-chainless belt %s (thesis factory-tick hazard)"),
 				*Belt->GetName());
 		}
 	}
 	if (HealedChainlessBelts > 0)
 	{
-		UE_LOG(LogSmartUpgrade, Display,
+		UE_LOG(LogSmartUpgrade, Warning,
 			TEXT("[CHAIN-DIAG] Purge sweep: %d connected-but-chainless belt(s) re-registered total"),
 			HealedChainlessBelts);
 	}
 
 	if (Zombies.Num() == 0)
 	{
-		UE_LOG(LogSmartUpgrade, Display,
+		UE_LOG(LogSmartUpgrade, Verbose,
 			TEXT("[CHAIN-DIAG] Sweep complete: zombiesPurged=0 detachedForceDestroyed=%d orphanBeltsReRegistered=%d chainlessBeltsHealed=%d"),
 			ForceDestroyedCount, ReRegisteredBelts, HealedChainlessBelts);
 		return ForceDestroyedCount;
@@ -936,7 +936,7 @@ int32 USFChainActorService::PurgeZombieChainActors()
 
 	// [CHAIN-DIAG] Always-on sweep summary: lets a shipping dedi log show whether a build path
 	// left chainless belts behind (the thesis factory-tick AV) without verbose logging.
-	UE_LOG(LogSmartUpgrade, Display,
+	UE_LOG(LogSmartUpgrade, Verbose,
 		TEXT("[CHAIN-DIAG] Sweep complete: zombiesPurged=%d detachedForceDestroyed=%d orphanBeltsReRegistered=%d chainlessBeltsHealed=%d"),
 		PurgeCount, ForceDestroyedCount, ReRegisteredBelts, HealedChainlessBelts);
 
@@ -1773,7 +1773,7 @@ int32 USFChainActorService::RemoveConveyorFromAllTickGroups(AFGBuildableConveyor
 	}
 	if (StaleRemovals > 0)
 	{
-		UE_LOG(LogSmartUpgrade, Display,
+		UE_LOG(LogSmartUpgrade, Warning,
 			TEXT("[CHAIN-DIAG] RemoveConveyor guard: %s was STILL in %d tick group(s) after vanilla removal (stale bucket id) - force-removed (freed-pointer factory-tick AV prevented)."),
 			*Conveyor->GetName(), StaleRemovals);
 	}
@@ -1817,25 +1817,6 @@ int32 USFChainActorService::ScrubFactoryTickArrays()
 
 	TArray<AFGBuildable*>& Buildings = BuildableSub->mFactoryBuildings;
 
-	// [CHAIN-DIAG] One-shot identity table around index 1824 - the corrupt entry sat at exactly
-	// that index in two independent live AV captures, and its corpse's FName bits matched the
-	// aimed-at building's name number. Logging address+name+class at boot lets the next crash's
-	// corpse address be matched against the original occupant: same address = the live building
-	// is being silently destroyed/replaced mid-session; different = a same-named ghost instance.
-	static bool bIdentityTableLogged = false;
-	if (!bIdentityTableLogged && Buildings.Num() > 1830)
-	{
-		bIdentityTableLogged = true;
-		for (int32 Index = 1815; Index < FMath::Min(Buildings.Num(), 1844); ++Index)
-		{
-			AFGBuildable* Entry = Buildings[Index];
-			UE_LOG(LogSmartUpgrade, Display,
-				TEXT("[CHAIN-DIAG] FactoryBuildings[%d] = 0x%llX  %s (%s)"),
-				Index, reinterpret_cast<uint64>(Entry),
-				(Entry && Entry->IsValidLowLevelFast(false)) ? *Entry->GetName() : TEXT("<invalid>"),
-				(Entry && Entry->IsValidLowLevelFast(false)) ? *GetNameSafe(Entry->GetClass()) : TEXT("?"));
-		}
-	}
 	for (int32 Index = Buildings.Num() - 1; Index >= 0; --Index)
 	{
 		AFGBuildable* Entry = Buildings[Index];

--- a/Source/SmartFoundations/Private/Services/SFChainActorService.cpp
+++ b/Source/SmartFoundations/Private/Services/SFChainActorService.cpp
@@ -899,7 +899,7 @@ int32 USFChainActorService::PurgeZombieChainActors()
 
 	if (Zombies.Num() == 0)
 	{
-		UE_LOG(LogSmartUpgrade, Verbose,
+		UE_LOG(LogSmartUpgrade, Display,
 			TEXT("[CHAIN-DIAG] Sweep complete: zombiesPurged=0 detachedForceDestroyed=%d orphanBeltsReRegistered=%d chainlessBeltsHealed=%d"),
 			ForceDestroyedCount, ReRegisteredBelts, HealedChainlessBelts);
 		return ForceDestroyedCount;
@@ -936,7 +936,7 @@ int32 USFChainActorService::PurgeZombieChainActors()
 
 	// [CHAIN-DIAG] Always-on sweep summary: lets a shipping dedi log show whether a build path
 	// left chainless belts behind (the thesis factory-tick AV) without verbose logging.
-	UE_LOG(LogSmartUpgrade, Verbose,
+	UE_LOG(LogSmartUpgrade, Display,
 		TEXT("[CHAIN-DIAG] Sweep complete: zombiesPurged=%d detachedForceDestroyed=%d orphanBeltsReRegistered=%d chainlessBeltsHealed=%d"),
 		PurgeCount, ForceDestroyedCount, ReRegisteredBelts, HealedChainlessBelts);
 

--- a/Source/SmartFoundations/Private/Services/SFChainActorService.cpp
+++ b/Source/SmartFoundations/Private/Services/SFChainActorService.cpp
@@ -811,21 +811,90 @@ int32 USFChainActorService::PurgeZombieChainActors()
 	// ParallelFor workers (vanilla's own in-tick recovery crash); this timer context is the
 	// game thread in TG_PrePhysics, before TickFactoryActors dispatches — the same safety
 	// window the 0-segment Destroy() path below has used since April 2026.
+	//
+	// CRITICAL FOLLOW-UP: a belt whose ONLY chain was the destroyed one is left
+	// connected-but-chainless — the THESIS factory-tick hazard (live 2026-06-10: the sweep ran,
+	// the save captured chainless belts, the next boot AV'd in TickFactoryActors ~8 min in,
+	// FGBuildableSubsystem.cpp:644 — the original d79e19b crash line). Collect each destroyed
+	// chain's member belts FIRST, then re-register any belt left chainless through vanilla
+	// (Remove+AddConveyor → the pending-chain path rebuilds a real chain next frame — the
+	// proven ReRegister pattern).
 	int32 ForceDestroyedCount = 0;
+	TArray<AFGBuildableConveyorBase*> OrphanedMemberBelts;
 	for (AFGConveyorChainActor* Chain : DetachedWithSegments)
 	{
 		if (!IsValid(Chain)) continue;
+		for (const FConveyorChainSplineSegment& Seg : Chain->GetChainSegments())
+		{
+			if (Seg.ConveyorBase && IsValid(Seg.ConveyorBase))
+			{
+				OrphanedMemberBelts.AddUnique(Seg.ConveyorBase);
+			}
+		}
 		UE_LOG(LogSmartUpgrade, Display,
 			TEXT("[CHAIN-DIAG] Purge force-destroying detached-but-segmented chain %s (segments=%d) — items transfer back to belts"),
 			*Chain->GetName(), Chain->GetNumChainSegments());
 		BuildableSub->ForceDestroyChainActor(Chain);
 		++ForceDestroyedCount;
 	}
+	int32 ReRegisteredBelts = 0;
+	for (AFGBuildableConveyorBase* Belt : OrphanedMemberBelts)
+	{
+		if (!IsValid(Belt) || Belt->IsActorBeingDestroyed()) continue;
+		if (Belt->GetConveyorChainActor() != nullptr) continue; // still owned by a live chain — fine
+		BuildableSub->RemoveConveyor(Belt);
+		BuildableSub->AddConveyor(Belt);
+		++ReRegisteredBelts;
+	}
 	if (ForceDestroyedCount > 0)
 	{
 		UE_LOG(LogSmartUpgrade, Display,
-			TEXT("[CHAIN-DIAG] Purge sweep: %d detached-but-segmented chain(s) force-destroyed (save-poison + frozen-item fix)"),
-			ForceDestroyedCount);
+			TEXT("[CHAIN-DIAG] Purge sweep: %d detached-but-segmented chain(s) force-destroyed, %d chainless member belt(s) re-registered for vanilla rebuild"),
+			ForceDestroyedCount, ReRegisteredBelts);
+	}
+
+	// General heal: a CONNECTED belt with no chain actor is the thesis factory-tick hazard
+	// regardless of how it got that way — a save can carry them (live 2026-06-10: a save written
+	// right after a force-destroy sweep, before vanilla rebuilt, AV'd the next boot ~8 min in).
+	// Re-register any such belt unless its tick group is already pending a vanilla chain build.
+	int32 HealedChainlessBelts = 0;
+	for (TActorIterator<AFGBuildableConveyorBase> It(World); It; ++It)
+	{
+		AFGBuildableConveyorBase* Belt = *It;
+		if (!Belt || !IsValid(Belt) || Belt->IsActorBeingDestroyed()) continue;
+		if (Belt->GetConveyorChainActor() != nullptr) continue;
+
+		UFGFactoryConnectionComponent* C0 = Belt->GetConnection0();
+		UFGFactoryConnectionComponent* C1 = Belt->GetConnection1();
+		const bool bConnected = (C0 && C0->IsConnected()) || (C1 && C1->IsConnected());
+		if (!bConnected) continue;
+
+		// Skip belts whose tick group vanilla is already going to rebuild this/next frame.
+		const int32 BucketID = Belt->GetConveyorBucketID();
+		if (BuildableSub->mConveyorTickGroup.IsValidIndex(BucketID))
+		{
+			FConveyorTickGroup* TG = BuildableSub->mConveyorTickGroup[BucketID];
+			if (TG && BuildableSub->mConveyorGroupsPendingChainActors.Contains(TG))
+			{
+				continue;
+			}
+		}
+
+		BuildableSub->RemoveConveyor(Belt);
+		BuildableSub->AddConveyor(Belt);
+		++HealedChainlessBelts;
+		if (HealedChainlessBelts <= 12)
+		{
+			UE_LOG(LogSmartUpgrade, Display,
+				TEXT("[CHAIN-DIAG] Purge sweep: re-registered connected-but-chainless belt %s (thesis factory-tick hazard)"),
+				*Belt->GetName());
+		}
+	}
+	if (HealedChainlessBelts > 0)
+	{
+		UE_LOG(LogSmartUpgrade, Display,
+			TEXT("[CHAIN-DIAG] Purge sweep: %d connected-but-chainless belt(s) re-registered total"),
+			HealedChainlessBelts);
 	}
 
 	if (Zombies.Num() == 0) return ForceDestroyedCount;

--- a/Source/SmartFoundations/Private/Services/SFChainActorService.cpp
+++ b/Source/SmartFoundations/Private/Services/SFChainActorService.cpp
@@ -897,7 +897,13 @@ int32 USFChainActorService::PurgeZombieChainActors()
 			HealedChainlessBelts);
 	}
 
-	if (Zombies.Num() == 0) return ForceDestroyedCount;
+	if (Zombies.Num() == 0)
+	{
+		UE_LOG(LogSmartUpgrade, Display,
+			TEXT("[CHAIN-DIAG] Sweep complete: zombiesPurged=0 detachedForceDestroyed=%d orphanBeltsReRegistered=%d chainlessBeltsHealed=%d"),
+			ForceDestroyedCount, ReRegisteredBelts, HealedChainlessBelts);
+		return ForceDestroyedCount;
+	}
 
 	int32 PurgeCount = 0;
 	for (AFGConveyorChainActor* Chain : Zombies)
@@ -927,6 +933,12 @@ int32 USFChainActorService::PurgeZombieChainActors()
 
 		++PurgeCount;
 	}
+
+	// [CHAIN-DIAG] Always-on sweep summary: lets a shipping dedi log show whether a build path
+	// left chainless belts behind (the thesis factory-tick AV) without verbose logging.
+	UE_LOG(LogSmartUpgrade, Display,
+		TEXT("[CHAIN-DIAG] Sweep complete: zombiesPurged=%d detachedForceDestroyed=%d orphanBeltsReRegistered=%d chainlessBeltsHealed=%d"),
+		PurgeCount, ForceDestroyedCount, ReRegisteredBelts, HealedChainlessBelts);
 
 	return PurgeCount + ForceDestroyedCount;
 }

--- a/Source/SmartFoundations/Private/Services/SFChainActorService.cpp
+++ b/Source/SmartFoundations/Private/Services/SFChainActorService.cpp
@@ -1816,6 +1816,26 @@ int32 USFChainActorService::ScrubFactoryTickArrays()
 	int32 RemovedTotal = 0;
 
 	TArray<AFGBuildable*>& Buildings = BuildableSub->mFactoryBuildings;
+
+	// [CHAIN-DIAG] One-shot identity table around index 1824 - the corrupt entry sat at exactly
+	// that index in two independent live AV captures, and its corpse's FName bits matched the
+	// aimed-at building's name number. Logging address+name+class at boot lets the next crash's
+	// corpse address be matched against the original occupant: same address = the live building
+	// is being silently destroyed/replaced mid-session; different = a same-named ghost instance.
+	static bool bIdentityTableLogged = false;
+	if (!bIdentityTableLogged && Buildings.Num() > 1830)
+	{
+		bIdentityTableLogged = true;
+		for (int32 Index = 1815; Index < FMath::Min(Buildings.Num(), 1844); ++Index)
+		{
+			AFGBuildable* Entry = Buildings[Index];
+			UE_LOG(LogSmartUpgrade, Display,
+				TEXT("[CHAIN-DIAG] FactoryBuildings[%d] = 0x%llX  %s (%s)"),
+				Index, reinterpret_cast<uint64>(Entry),
+				(Entry && Entry->IsValidLowLevelFast(false)) ? *Entry->GetName() : TEXT("<invalid>"),
+				(Entry && Entry->IsValidLowLevelFast(false)) ? *GetNameSafe(Entry->GetClass()) : TEXT("?"));
+		}
+	}
 	for (int32 Index = Buildings.Num() - 1; Index >= 0; --Index)
 	{
 		AFGBuildable* Entry = Buildings[Index];

--- a/Source/SmartFoundations/Private/Services/SFHintBarService.cpp
+++ b/Source/SmartFoundations/Private/Services/SFHintBarService.cpp
@@ -184,11 +184,18 @@ void USFHintBarService::OnHintTickTimer()
 
 UUserWidget* USFHintBarService::FindWidgetBuildMode() const
 {
-	// Load the Widget_BuildMode Blueprint generated class
+	// Hint bars are client UI: a dedicated server has no UI assets cooked, so the load below
+	// fails on EVERY hint tick and spams Warnings (live 2026-06-10 dedi logs). Warn once, then
+	// stay quiet - the nullptr return already no-ops the injection.
 	UClass* WidgetClass = LoadClass<UUserWidget>(nullptr, WidgetBuildModePath);
 	if (!WidgetClass)
 	{
-		UE_LOG(LogSmartUI, Warning, TEXT("HintBarService: Failed to load Widget_BuildMode class"));
+		static bool bWarnedOnce = false;
+		if (!bWarnedOnce)
+		{
+			bWarnedOnce = true;
+			UE_LOG(LogSmartUI, Warning, TEXT("HintBarService: Failed to load Widget_BuildMode class (further occurrences suppressed; expected on dedicated servers)"));
+		}
 		return nullptr;
 	}
 

--- a/Source/SmartFoundations/Private/Subsystem/SFHologramHelperService.cpp
+++ b/Source/SmartFoundations/Private/Subsystem/SFHologramHelperService.cpp
@@ -967,7 +967,7 @@ void FSFHologramHelperService::RegenerateChildHologramGrid(
 		// and on which net side. NetMode: 0=Standalone 1=DedicatedServer 2=ListenServer 3=Client.
 		{
 			const int32 NetMode = ParentHologram->GetWorld() ? (int32)ParentHologram->GetWorld()->GetNetMode() : -1;
-			UE_LOG(LogSmartFoundations, Display,
+			UE_LOG(LogSmartFoundations, Verbose,
 				TEXT("[MP-SLICE0] GridRegen: parent=%s NetMode=%d HasAuthority=%d grid=%dx%dx%d previewChildren=%d"),
 				*ParentHologram->GetName(), NetMode, ParentHologram->HasAuthority() ? 1 : 0,
 				GridCounters.X, GridCounters.Y, GridCounters.Z, SpawnedChildren.Num());

--- a/Source/SmartFoundations/Private/Subsystem/SFHologramHelperService.cpp
+++ b/Source/SmartFoundations/Private/Subsystem/SFHologramHelperService.cpp
@@ -961,6 +961,17 @@ void FSFHologramHelperService::RegenerateChildHologramGrid(
 
 		UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("RegenerateChildHologramGrid: Spawned %d children, total now: %d"),
 			ToSpawn, SpawnedChildren.Num());
+
+		// [MP-SLICE0] TEMP multiplayer instrumentation — remove before release.
+		// Client-side preview signal: how many child holograms exist after a grid regen,
+		// and on which net side. NetMode: 0=Standalone 1=DedicatedServer 2=ListenServer 3=Client.
+		{
+			const int32 NetMode = ParentHologram->GetWorld() ? (int32)ParentHologram->GetWorld()->GetNetMode() : -1;
+			UE_LOG(LogSmartFoundations, Display,
+				TEXT("[MP-SLICE0] GridRegen: parent=%s NetMode=%d HasAuthority=%d grid=%dx%dx%d previewChildren=%d"),
+				*ParentHologram->GetName(), NetMode, ParentHologram->HasAuthority() ? 1 : 0,
+				GridCounters.X, GridCounters.Y, GridCounters.Z, SpawnedChildren.Num());
+		}
 	}
 	else if (ChildrenNeeded < CurrentChildren)
 	{

--- a/Source/SmartFoundations/Private/Subsystem/SFSubsystem.cpp
+++ b/Source/SmartFoundations/Private/Subsystem/SFSubsystem.cpp
@@ -473,10 +473,12 @@ void USFSubsystem::StageExtendCommitForPlayer(APlayerController* PC, const FSFEx
 	if (Spec.bValid)
 	{
 		StagedExtendCommits.Add(PC, Spec);
+		StagedExtendCommitTimes.Add(PC, FPlatformTime::Seconds());
 	}
 	else
 	{
 		StagedExtendCommits.Remove(PC);
+		StagedExtendCommitTimes.Remove(PC);
 	}
 }
 
@@ -496,6 +498,13 @@ bool USFSubsystem::PeekExtendCommitForInstigator(APawn* Instigator, UClass* Buil
 	{
 		return false;
 	}
+	// Freshness TTL: a live session pre-stages every ~250ms; an entry older than this belongs to
+	// an abandoned session whose CLEAR was lost - never consume it into an unrelated construct.
+	const double* StagedAt = StagedExtendCommitTimes.Find(PC);
+	if (!StagedAt || FPlatformTime::Seconds() - *StagedAt > 10.0)
+	{
+		return false;
+	}
 	OutSpec = *Staged;
 	return true;
 }
@@ -506,7 +515,9 @@ bool USFSubsystem::ConsumeExtendCommitForInstigator(APawn* Instigator, UClass* B
 	{
 		return false;
 	}
-	StagedExtendCommits.Remove(Cast<APlayerController>(Instigator->GetController()));
+	APlayerController* PC = Cast<APlayerController>(Instigator->GetController());
+	StagedExtendCommits.Remove(PC);
+	StagedExtendCommitTimes.Remove(PC);
 	return true;
 }
 

--- a/Source/SmartFoundations/Private/Subsystem/SFSubsystem.cpp
+++ b/Source/SmartFoundations/Private/Subsystem/SFSubsystem.cpp
@@ -462,6 +462,54 @@ bool USFSubsystem::ConsumeScalingSpecForInstigator(APawn* Instigator, UClass* Bu
 	return true;
 }
 
+// [EXTEND-MP] Extend commit staging - identical model to the scaling spec above.
+
+void USFSubsystem::StageExtendCommitForPlayer(APlayerController* PC, const FSFExtendCommitSpec& Spec)
+{
+	if (!PC)
+	{
+		return;
+	}
+	if (Spec.bValid)
+	{
+		StagedExtendCommits.Add(PC, Spec);
+	}
+	else
+	{
+		StagedExtendCommits.Remove(PC);
+	}
+}
+
+bool USFSubsystem::PeekExtendCommitForInstigator(APawn* Instigator, UClass* BuildClass, FSFExtendCommitSpec& OutSpec) const
+{
+	if (!Instigator || !BuildClass)
+	{
+		return false;
+	}
+	APlayerController* PC = Cast<APlayerController>(Instigator->GetController());
+	if (!PC)
+	{
+		return false;
+	}
+	const FSFExtendCommitSpec* Staged = StagedExtendCommits.Find(PC);
+	if (!Staged || !Staged->bValid || Staged->BuildClass != BuildClass)
+	{
+		return false;
+	}
+	OutSpec = *Staged;
+	return true;
+}
+
+bool USFSubsystem::ConsumeExtendCommitForInstigator(APawn* Instigator, UClass* BuildClass, FSFExtendCommitSpec& OutSpec)
+{
+	if (!PeekExtendCommitForInstigator(Instigator, BuildClass, OutSpec))
+	{
+		return false;
+	}
+	StagedExtendCommits.Remove(Cast<APlayerController>(Instigator->GetController()));
+	return true;
+}
+
 void USFSubsystem::Initialize(FSubsystemCollectionBase& Collection)
 {
 	Super::Initialize(Collection);

--- a/Source/SmartFoundations/Private/Subsystem/SFSubsystem.cpp
+++ b/Source/SmartFoundations/Private/Subsystem/SFSubsystem.cpp
@@ -984,7 +984,7 @@ void USFSubsystem::Tick(float DeltaTime)
 			const double NowExt = FPlatformTime::Seconds();
 			if (NowExt - LastExtMpLog > 1.0)
 			{
-				UE_LOG(LogSmartFoundations, Display,
+				UE_LOG(LogSmartFoundations, Verbose,
 					TEXT("[EXTEND-MP] NetMode=%d PC=%s rawHit=%s dir=(%.2f,%.2f,%.2f) LookedAt=%s holoBuildClass=%s"),
 					GetWorld() ? (int32)GetWorld()->GetNetMode() : -1,
 					PC ? TEXT("ok") : TEXT("NULL"),

--- a/Source/SmartFoundations/Private/Subsystem/SFSubsystem.cpp
+++ b/Source/SmartFoundations/Private/Subsystem/SFSubsystem.cpp
@@ -800,6 +800,8 @@ void USFSubsystem::Tick(float DeltaTime)
 	{
 		// Get the building the player is looking at via line trace
 		AFGBuildable* LookedAtBuilding = nullptr;
+		FString DbgRawHit = TEXT("(no-pc/cam)"); // [EXTEND-MP] raw trace result for diagnostics
+		FVector DbgDir = FVector::ZeroVector;
 
 		AFGPlayerController* PC = Cast<AFGPlayerController>(LastController.Get());
 		if (!PC)
@@ -815,8 +817,13 @@ void USFSubsystem::Tick(float DeltaTime)
 		{
 			if (APlayerCameraManager* CameraManager = PC->PlayerCameraManager)
 			{
-				FVector Start = CameraManager->GetCameraLocation();
-				FVector End = Start + CameraManager->GetActorForwardVector() * 5000.0f;  // 50m range
+				// [EXTEND-MP] Use the player view point for the aim ray (robust on clients) instead of the
+				// camera-manager actor's forward vector, which can be stale/wrong on a remote client.
+				FVector ViewLoc; FRotator ViewRot;
+				PC->GetPlayerViewPoint(ViewLoc, ViewRot);
+				FVector Start = ViewLoc;
+				DbgDir = ViewRot.Vector();
+				FVector End = Start + DbgDir * 5000.0f;  // 50m range
 
 				FHitResult HitResult;
 				FCollisionQueryParams Params;
@@ -824,7 +831,9 @@ void USFSubsystem::Tick(float DeltaTime)
 				Params.AddIgnoredActor(ActiveHologram.Get());
 
 				// Use WorldStatic channel which hits buildings, not just visibility
-				if (GetWorld()->LineTraceSingleByChannel(HitResult, Start, End, ECC_WorldStatic, Params))
+				const bool bHit = GetWorld()->LineTraceSingleByChannel(HitResult, Start, End, ECC_WorldStatic, Params);
+				DbgRawHit = bHit ? (HitResult.GetActor() ? HitResult.GetActor()->GetClass()->GetName() : TEXT("hit(no-actor)")) : TEXT("MISS");
+				if (bHit)
 				{
 					AActor* HitActor = HitResult.GetActor();
 					LookedAtBuilding = Cast<AFGBuildable>(HitActor);
@@ -865,11 +874,11 @@ void USFSubsystem::Tick(float DeltaTime)
 			if (NowExt - LastExtMpLog > 1.0)
 			{
 				UE_LOG(LogSmartFoundations, Display,
-					TEXT("[EXTEND-MP] NetMode=%d PC=%s LookedAt=%s class=%s holoBuildClass=%s"),
+					TEXT("[EXTEND-MP] NetMode=%d PC=%s rawHit=%s dir=(%.2f,%.2f,%.2f) LookedAt=%s holoBuildClass=%s"),
 					GetWorld() ? (int32)GetWorld()->GetNetMode() : -1,
 					PC ? TEXT("ok") : TEXT("NULL"),
+					*DbgRawHit, DbgDir.X, DbgDir.Y, DbgDir.Z,
 					LookedAtBuilding ? *LookedAtBuilding->GetName() : TEXT("none"),
-					LookedAtBuilding ? *LookedAtBuilding->GetClass()->GetName() : TEXT("-"),
 					(ActiveHologram.IsValid() && ActiveHologram->GetBuildClass()) ? *ActiveHologram->GetBuildClass()->GetName() : TEXT("-"));
 				LastExtMpLog = NowExt;
 			}

--- a/Source/SmartFoundations/Private/Subsystem/SFSubsystem.cpp
+++ b/Source/SmartFoundations/Private/Subsystem/SFSubsystem.cpp
@@ -857,6 +857,24 @@ void USFSubsystem::Tick(float DeltaTime)
 			}
 		}
 
+		// [EXTEND-MP] TEMP diagnostic: why does Extend never activate on a client? Log the detection state
+		// once/sec (Display so it shows in-game; remove before release).
+		{
+			static double LastExtMpLog = 0;
+			const double NowExt = FPlatformTime::Seconds();
+			if (NowExt - LastExtMpLog > 1.0)
+			{
+				UE_LOG(LogSmartFoundations, Display,
+					TEXT("[EXTEND-MP] NetMode=%d PC=%s LookedAt=%s class=%s holoBuildClass=%s"),
+					GetWorld() ? (int32)GetWorld()->GetNetMode() : -1,
+					PC ? TEXT("ok") : TEXT("NULL"),
+					LookedAtBuilding ? *LookedAtBuilding->GetName() : TEXT("none"),
+					LookedAtBuilding ? *LookedAtBuilding->GetClass()->GetName() : TEXT("-"),
+					(ActiveHologram.IsValid() && ActiveHologram->GetBuildClass()) ? *ActiveHologram->GetBuildClass()->GetName() : TEXT("-"));
+				LastExtMpLog = NowExt;
+			}
+		}
+
 		// TryExtendFromBuilding handles the automatic activation/deactivation
 		ExtendService->TryExtendFromBuilding(LookedAtBuilding, ActiveHologram.Get());
 	}

--- a/Source/SmartFoundations/Private/Subsystem/SFSubsystem.cpp
+++ b/Source/SmartFoundations/Private/Subsystem/SFSubsystem.cpp
@@ -410,6 +410,58 @@ void USFSubsystem::UpdateCounterState(const FSFCounterState& NewState)
 	}
 }
 
+// ========================================
+// MP spec-based scaling construction - server-side per-player spec staging
+// ========================================
+
+void USFSubsystem::StageScalingSpecForPlayer(APlayerController* PC, const FSFScalingSpec& Spec)
+{
+	if (!PC)
+	{
+		return;
+	}
+	if (Spec.bValid)
+	{
+		StagedScalingSpecs.Add(PC, Spec);
+	}
+	else
+	{
+		// An invalid spec is an explicit CLEAR (sent on every non-grid fire) - overwrite semantics
+		// guarantee a stale spec from an earlier failed construct cannot leak into a later fire.
+		StagedScalingSpecs.Remove(PC);
+	}
+}
+
+bool USFSubsystem::PeekScalingSpecForInstigator(APawn* Instigator, UClass* BuildClass, FSFScalingSpec& OutSpec) const
+{
+	if (!Instigator || !BuildClass)
+	{
+		return false;
+	}
+	APlayerController* PC = Cast<APlayerController>(Instigator->GetController());
+	if (!PC)
+	{
+		return false;
+	}
+	const FSFScalingSpec* Staged = StagedScalingSpecs.Find(PC);
+	if (!Staged || !Staged->bValid || Staged->BuildClass != BuildClass)
+	{
+		return false;
+	}
+	OutSpec = *Staged;
+	return true;
+}
+
+bool USFSubsystem::ConsumeScalingSpecForInstigator(APawn* Instigator, UClass* BuildClass, FSFScalingSpec& OutSpec)
+{
+	if (!PeekScalingSpecForInstigator(Instigator, BuildClass, OutSpec))
+	{
+		return false;
+	}
+	StagedScalingSpecs.Remove(Cast<APlayerController>(Instigator->GetController()));
+	return true;
+}
+
 void USFSubsystem::Initialize(FSubsystemCollectionBase& Collection)
 {
 	Super::Initialize(Collection);

--- a/Source/SmartFoundations/Private/Subsystem/SFSubsystem_HologramLifecycle.cpp
+++ b/Source/SmartFoundations/Private/Subsystem/SFSubsystem_HologramLifecycle.cpp
@@ -6,6 +6,10 @@
  */
 
 #include "Subsystem/SFSubsystemImpl.h"
+#include "Holograms/Core/SFFactoryHologram.h"
+#include "Hologram/FGFactoryHologram.h"
+#include "Features/Extend/SFExtendService.h"
+#include "HAL/IConsoleManager.h"
 
 
 // Hologram management with enhanced logging
@@ -117,14 +121,43 @@ void USFSubsystem::RegisterActiveHologram(AFGHologram* Hologram)
 		CurrentAutoConnectSetting = EAutoConnectSetting::Enabled;
 	}
 
-	// NOTE: Hologram swapping is DISABLED to fix the infinite re-registration loop
-	// The build gun holds the original hologram reference, and swapping creates a mismatch:
+	// NOTE: Hologram swapping is DISABLED by default to avoid the infinite re-registration loop
+	// The build gun holds the original hologram reference, and a NAIVE swap creates a mismatch:
 	// - BuildState->GetHologram() returns vanilla hologram
 	// - ActiveHologram is our swapped custom hologram
 	// - PollForActiveHologram sees mismatch → unregister/re-register → infinite loop
 	//
-	// EXTEND and Scaling work with vanilla holograms - no swap needed.
-	// If custom hologram behavior is needed in the future, use Blueprint class remapping at module load.
+	// EXTEND and Scaling work with vanilla holograms - no swap needed (default path).
+	//
+	// [MP] EXCEPTION (gated): when sf.MP.SpecConstruction=1, swap the vanilla factory hologram to
+	// ASFFactoryHologram so it can carry the grid spec + override the construct-message hooks
+	// (PLAN_MP_ScalingConstruction_Impl.md). This reuses the PROVEN Extend swap, which repoints
+	// BuildState->mHologram via reflection; we then set ActiveHologram to the same swapped hologram
+	// below, so Poll sees a MATCH (not the mismatch that caused the historical loop). A re-entrancy
+	// guard prevents the swap's FinishSpawning from recursing into another swap. Default 0 ⇒ this
+	// block is skipped entirely and behaviour is unchanged. RUNTIME VALIDATION PENDING (MP session):
+	// confirm no re-registration loop and no Extend-state interference (the swap sets ExtendService
+	// bHasSwappedHologram; benign when no Extend target is active, but watch it under test).
+	{
+		static const IConsoleVariable* CVarSpec =
+			IConsoleManager::Get().FindConsoleVariable(TEXT("sf.MP.SpecConstruction"));
+		static bool bReentryGuard = false;
+		const bool bSpecOn = CVarSpec && CVarSpec->GetInt() != 0;
+		if (bSpecOn && !bReentryGuard && ExtendService
+			&& Hologram->IsA(AFGFactoryHologram::StaticClass())
+			&& !Hologram->IsA(ASFFactoryHologram::StaticClass()))
+		{
+			TGuardValue<bool> ReentryScope(bReentryGuard, true);
+			if (ASFFactoryHologram* Swapped = ExtendService->SwapToSmartFactoryHologram(Hologram))
+			{
+				UE_LOG(LogSmartFoundations, Display,
+					TEXT("[MP-SPEC] RegisterActiveHologram: swapped vanilla factory hologram to ")
+					TEXT("ASFFactoryHologram for spec-construction (%s)."), *Swapped->GetName());
+				Hologram = Swapped; // continue registration with the swapped custom hologram
+			}
+		}
+	}
+
 	ActiveHologram = Hologram;
 	UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("RegisterActiveHologram: %s"), *Hologram->GetName());
 

--- a/Source/SmartFoundations/Private/Subsystem/SFSubsystem_HologramLifecycle.cpp
+++ b/Source/SmartFoundations/Private/Subsystem/SFSubsystem_HologramLifecycle.cpp
@@ -6,14 +6,6 @@
  */
 
 #include "Subsystem/SFSubsystemImpl.h"
-#include "Holograms/Core/SFFactoryHologram.h"
-#include "Holograms/Core/SFFoundationHologram.h"
-#include "Holograms/Core/SFScalingSpecExpansion.h"
-#include "Hologram/FGFactoryHologram.h"
-#include "Hologram/FGFoundationHologram.h"
-#include "Hologram/FGRampHologram.h"
-#include "Data/SFBuildableSizeRegistry.h"
-#include "Features/Extend/SFExtendService.h"
 
 
 // Hologram management with enhanced logging
@@ -125,95 +117,17 @@ void USFSubsystem::RegisterActiveHologram(AFGHologram* Hologram)
 		CurrentAutoConnectSetting = EAutoConnectSetting::Enabled;
 	}
 
-	// NOTE: Hologram swapping is DISABLED by default to avoid the infinite re-registration loop
-	// The build gun holds the original hologram reference, and a NAIVE swap creates a mismatch:
+	// NOTE: Hologram swapping is DISABLED to fix the infinite re-registration loop
+	// The build gun holds the original hologram reference, and swapping creates a mismatch:
 	// - BuildState->GetHologram() returns vanilla hologram
 	// - ActiveHologram is our swapped custom hologram
 	// - PollForActiveHologram sees mismatch → unregister/re-register → infinite loop
 	//
-	// EXTEND and Scaling work with vanilla holograms - no swap needed (default path).
-	//
-	// [MP] EXCEPTION (gated): when sf.MP.SpecConstruction=1, swap the vanilla factory hologram to
-	// ASFFactoryHologram so it can carry the grid spec + override the construct-message hooks
-	// (PLAN_MP_ScalingConstruction_Impl.md). This reuses the PROVEN Extend swap, which repoints
-	// BuildState->mHologram via reflection; we then set ActiveHologram to the same swapped hologram
-	// below, so Poll sees a MATCH (not the mismatch that caused the historical loop). A re-entrancy
-	// guard prevents the swap's FinishSpawning from recursing into another swap. Default 0 ⇒ this
-	// block is skipped entirely and behaviour is unchanged. Both swaps are NOT tracked as Extend
-	// swaps (bTrackAsExtendSwap=false / never), so Extend state stays untouched. RUNTIME VALIDATION
-	// PENDING (MP session): confirm no re-registration loop.
-	{
-		static bool bReentryGuard = false;
-		if (SFScalingSpecExpansion::IsSpecConstructionEnabled() && !bReentryGuard && ExtendService)
-		{
-			TGuardValue<bool> ReentryScope(bReentryGuard, true);
-
-			// Eligibility comes from the buildable size registry - Smart's existing source of truth
-			// for what may scale (the same profile whose DefaultSize/AnchorOffset the spec already
-			// reproduces server-side). Only swap holograms Smart would actually scale.
-			USFBuildableSizeRegistry::Initialize();
-			const bool bSupportsScaling =
-				USFBuildableSizeRegistry::GetProfile(Hologram->GetBuildClass()).bSupportsScaling;
-
-			if (!bSupportsScaling)
-			{
-				// fall through: not Smart-scalable -> never spec-swapped, legacy behaviour
-			}
-			else if (Hologram->IsA(AFGFactoryHologram::StaticClass())
-				&& !Hologram->IsA(ASFFactoryHologram::StaticClass()))
-			{
-				// Production buildings -> ASFFactoryHologram (no Extend swap tracking: this is the
-				// scaling spec path, not Extend; RestoreOriginalHologram must stay a no-op).
-				if (ASFFactoryHologram* Swapped =
-					ExtendService->SwapToSmartFactoryHologram(Hologram, /*bTrackAsExtendSwap=*/false))
-				{
-					UE_LOG(LogSmartFoundations, Display,
-						TEXT("[MP-SPEC] RegisterActiveHologram: swapped vanilla factory hologram to ")
-						TEXT("ASFFactoryHologram for spec-construction (%s)."), *Swapped->GetName());
-					Hologram = Swapped; // continue registration with the swapped custom hologram
-				}
-			}
-			else if (Hologram->IsA(AFGFoundationHologram::StaticClass())
-				&& !Hologram->IsA(ASFFoundationHologram::StaticClass())
-				&& !Hologram->IsA(AFGRampHologram::StaticClass()))
-			{
-				// Foundation family -> ASFFoundationHologram. Live test 2026-06-09: vanilla flat
-				// foundations use a BLUEPRINT hologram subclass (Holo_Foundation_C, parent
-				// FGFoundationHologram), so an exact-class gate never matches - match the family.
-				// AFGRampHologram (the only C++ subclass: ramps/quarter-pipe family) is excluded:
-				// its inclined placement behaviour would be lost by our generic replacement, so it
-				// stays on the legacy path until covered explicitly.
-				if (ASFFoundationHologram* Swapped =
-					ExtendService->SwapToSmartFoundationHologram(Hologram))
-				{
-					UE_LOG(LogSmartFoundations, Display,
-						TEXT("[MP-SPEC] RegisterActiveHologram: swapped vanilla foundation hologram to ")
-						TEXT("ASFFoundationHologram for spec-construction (%s)."), *Swapped->GetName());
-					Hologram = Swapped;
-				}
-			}
-			else if (!Hologram->IsA(ASFFactoryHologram::StaticClass())
-				&& !Hologram->IsA(ASFFoundationHologram::StaticClass()))
-			{
-				// Coverage diagnostic (once per class): live test 2026-06-09 showed the 4m foundation
-				// hologram did NOT match the exact-class gate above - this names the actual class so
-				// the gate can be widened deliberately instead of guessed.
-				static TSet<FName> LoggedUnmatchedClasses;
-				const FName HoloClassName = Hologram->GetClass()->GetFName();
-				if (!LoggedUnmatchedClasses.Contains(HoloClassName))
-				{
-					LoggedUnmatchedClasses.Add(HoloClassName);
-					UE_LOG(LogSmartFoundations, Display,
-						TEXT("[MP-SPEC] RegisterActiveHologram: no spec swap for hologram class %s ")
-						TEXT("(build=%s, parent=%s) - not covered yet."),
-						*HoloClassName.ToString(),
-						*GetNameSafe(Hologram->GetBuildClass()),
-						*GetNameSafe(Hologram->GetClass()->GetSuperClass()));
-				}
-			}
-		}
-	}
-
+	// EXTEND and Scaling work with vanilla holograms - no swap needed.
+	// (The MP spec-construction path is hologram-class-agnostic: it rides SML hooks on the vanilla
+	// virtual bodies + the per-hologram data registry - see RegisterSpecConstructionHooks in
+	// SFGameInstanceModule. An earlier iteration swapped to ASF spec-parent classes here; that was
+	// live-validated but replaced by the hook path for total coverage incl. BP hologram wrappers.)
 	ActiveHologram = Hologram;
 	UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("RegisterActiveHologram: %s"), *Hologram->GetName());
 

--- a/Source/SmartFoundations/Private/Subsystem/SFSubsystem_HologramLifecycle.cpp
+++ b/Source/SmartFoundations/Private/Subsystem/SFSubsystem_HologramLifecycle.cpp
@@ -7,9 +7,11 @@
 
 #include "Subsystem/SFSubsystemImpl.h"
 #include "Holograms/Core/SFFactoryHologram.h"
+#include "Holograms/Core/SFFoundationHologram.h"
+#include "Holograms/Core/SFScalingSpecExpansion.h"
 #include "Hologram/FGFactoryHologram.h"
+#include "Hologram/FGFoundationHologram.h"
 #include "Features/Extend/SFExtendService.h"
-#include "HAL/IConsoleManager.h"
 
 
 // Hologram management with enhanced logging
@@ -135,25 +137,42 @@ void USFSubsystem::RegisterActiveHologram(AFGHologram* Hologram)
 	// BuildState->mHologram via reflection; we then set ActiveHologram to the same swapped hologram
 	// below, so Poll sees a MATCH (not the mismatch that caused the historical loop). A re-entrancy
 	// guard prevents the swap's FinishSpawning from recursing into another swap. Default 0 ⇒ this
-	// block is skipped entirely and behaviour is unchanged. RUNTIME VALIDATION PENDING (MP session):
-	// confirm no re-registration loop and no Extend-state interference (the swap sets ExtendService
-	// bHasSwappedHologram; benign when no Extend target is active, but watch it under test).
+	// block is skipped entirely and behaviour is unchanged. Both swaps are NOT tracked as Extend
+	// swaps (bTrackAsExtendSwap=false / never), so Extend state stays untouched. RUNTIME VALIDATION
+	// PENDING (MP session): confirm no re-registration loop.
 	{
-		static const IConsoleVariable* CVarSpec =
-			IConsoleManager::Get().FindConsoleVariable(TEXT("sf.MP.SpecConstruction"));
 		static bool bReentryGuard = false;
-		const bool bSpecOn = CVarSpec && CVarSpec->GetInt() != 0;
-		if (bSpecOn && !bReentryGuard && ExtendService
-			&& Hologram->IsA(AFGFactoryHologram::StaticClass())
-			&& !Hologram->IsA(ASFFactoryHologram::StaticClass()))
+		if (SFScalingSpecExpansion::IsSpecConstructionEnabled() && !bReentryGuard && ExtendService)
 		{
 			TGuardValue<bool> ReentryScope(bReentryGuard, true);
-			if (ASFFactoryHologram* Swapped = ExtendService->SwapToSmartFactoryHologram(Hologram))
+
+			if (Hologram->IsA(AFGFactoryHologram::StaticClass())
+				&& !Hologram->IsA(ASFFactoryHologram::StaticClass()))
 			{
-				UE_LOG(LogSmartFoundations, Display,
-					TEXT("[MP-SPEC] RegisterActiveHologram: swapped vanilla factory hologram to ")
-					TEXT("ASFFactoryHologram for spec-construction (%s)."), *Swapped->GetName());
-				Hologram = Swapped; // continue registration with the swapped custom hologram
+				// Production buildings -> ASFFactoryHologram (no Extend swap tracking: this is the
+				// scaling spec path, not Extend; RestoreOriginalHologram must stay a no-op).
+				if (ASFFactoryHologram* Swapped =
+					ExtendService->SwapToSmartFactoryHologram(Hologram, /*bTrackAsExtendSwap=*/false))
+				{
+					UE_LOG(LogSmartFoundations, Display,
+						TEXT("[MP-SPEC] RegisterActiveHologram: swapped vanilla factory hologram to ")
+						TEXT("ASFFactoryHologram for spec-construction (%s)."), *Swapped->GetName());
+					Hologram = Swapped; // continue registration with the swapped custom hologram
+				}
+			}
+			else if (Hologram->GetClass() == AFGFoundationHologram::StaticClass())
+			{
+				// Flat foundations -> ASFFoundationHologram. EXACT class only: foundation-family
+				// subclasses (ramps, quarter pipes, ...) have placement behaviour our generic
+				// replacement would lose, so they stay on the legacy path until covered explicitly.
+				if (ASFFoundationHologram* Swapped =
+					ExtendService->SwapToSmartFoundationHologram(Hologram))
+				{
+					UE_LOG(LogSmartFoundations, Display,
+						TEXT("[MP-SPEC] RegisterActiveHologram: swapped vanilla foundation hologram to ")
+						TEXT("ASFFoundationHologram for spec-construction (%s)."), *Swapped->GetName());
+					Hologram = Swapped;
+				}
 			}
 		}
 	}

--- a/Source/SmartFoundations/Private/Subsystem/SFSubsystem_HologramLifecycle.cpp
+++ b/Source/SmartFoundations/Private/Subsystem/SFSubsystem_HologramLifecycle.cpp
@@ -11,6 +11,7 @@
 #include "Holograms/Core/SFScalingSpecExpansion.h"
 #include "Hologram/FGFactoryHologram.h"
 #include "Hologram/FGFoundationHologram.h"
+#include "Hologram/FGRampHologram.h"
 #include "Features/Extend/SFExtendService.h"
 
 
@@ -160,11 +161,16 @@ void USFSubsystem::RegisterActiveHologram(AFGHologram* Hologram)
 					Hologram = Swapped; // continue registration with the swapped custom hologram
 				}
 			}
-			else if (Hologram->GetClass() == AFGFoundationHologram::StaticClass())
+			else if (Hologram->IsA(AFGFoundationHologram::StaticClass())
+				&& !Hologram->IsA(ASFFoundationHologram::StaticClass())
+				&& !Hologram->IsA(AFGRampHologram::StaticClass()))
 			{
-				// Flat foundations -> ASFFoundationHologram. EXACT class only: foundation-family
-				// subclasses (ramps, quarter pipes, ...) have placement behaviour our generic
-				// replacement would lose, so they stay on the legacy path until covered explicitly.
+				// Foundation family -> ASFFoundationHologram. Live test 2026-06-09: vanilla flat
+				// foundations use a BLUEPRINT hologram subclass (Holo_Foundation_C, parent
+				// FGFoundationHologram), so an exact-class gate never matches - match the family.
+				// AFGRampHologram (the only C++ subclass: ramps/quarter-pipe family) is excluded:
+				// its inclined placement behaviour would be lost by our generic replacement, so it
+				// stays on the legacy path until covered explicitly.
 				if (ASFFoundationHologram* Swapped =
 					ExtendService->SwapToSmartFoundationHologram(Hologram))
 				{

--- a/Source/SmartFoundations/Private/Subsystem/SFSubsystem_HologramLifecycle.cpp
+++ b/Source/SmartFoundations/Private/Subsystem/SFSubsystem_HologramLifecycle.cpp
@@ -12,6 +12,7 @@
 #include "Hologram/FGFactoryHologram.h"
 #include "Hologram/FGFoundationHologram.h"
 #include "Hologram/FGRampHologram.h"
+#include "Data/SFBuildableSizeRegistry.h"
 #include "Features/Extend/SFExtendService.h"
 
 
@@ -147,7 +148,18 @@ void USFSubsystem::RegisterActiveHologram(AFGHologram* Hologram)
 		{
 			TGuardValue<bool> ReentryScope(bReentryGuard, true);
 
-			if (Hologram->IsA(AFGFactoryHologram::StaticClass())
+			// Eligibility comes from the buildable size registry - Smart's existing source of truth
+			// for what may scale (the same profile whose DefaultSize/AnchorOffset the spec already
+			// reproduces server-side). Only swap holograms Smart would actually scale.
+			USFBuildableSizeRegistry::Initialize();
+			const bool bSupportsScaling =
+				USFBuildableSizeRegistry::GetProfile(Hologram->GetBuildClass()).bSupportsScaling;
+
+			if (!bSupportsScaling)
+			{
+				// fall through: not Smart-scalable -> never spec-swapped, legacy behaviour
+			}
+			else if (Hologram->IsA(AFGFactoryHologram::StaticClass())
 				&& !Hologram->IsA(ASFFactoryHologram::StaticClass()))
 			{
 				// Production buildings -> ASFFactoryHologram (no Extend swap tracking: this is the

--- a/Source/SmartFoundations/Private/Subsystem/SFSubsystem_HologramLifecycle.cpp
+++ b/Source/SmartFoundations/Private/Subsystem/SFSubsystem_HologramLifecycle.cpp
@@ -174,6 +174,25 @@ void USFSubsystem::RegisterActiveHologram(AFGHologram* Hologram)
 					Hologram = Swapped;
 				}
 			}
+			else if (!Hologram->IsA(ASFFactoryHologram::StaticClass())
+				&& !Hologram->IsA(ASFFoundationHologram::StaticClass()))
+			{
+				// Coverage diagnostic (once per class): live test 2026-06-09 showed the 4m foundation
+				// hologram did NOT match the exact-class gate above - this names the actual class so
+				// the gate can be widened deliberately instead of guessed.
+				static TSet<FName> LoggedUnmatchedClasses;
+				const FName HoloClassName = Hologram->GetClass()->GetFName();
+				if (!LoggedUnmatchedClasses.Contains(HoloClassName))
+				{
+					LoggedUnmatchedClasses.Add(HoloClassName);
+					UE_LOG(LogSmartFoundations, Display,
+						TEXT("[MP-SPEC] RegisterActiveHologram: no spec swap for hologram class %s ")
+						TEXT("(build=%s, parent=%s) - not covered yet."),
+						*HoloClassName.ToString(),
+						*GetNameSafe(Hologram->GetBuildClass()),
+						*GetNameSafe(Hologram->GetClass()->GetSuperClass()));
+				}
+			}
 		}
 	}
 

--- a/Source/SmartFoundations/Private/Subsystem/SFSubsystem_OnActorSpawned.cpp
+++ b/Source/SmartFoundations/Private/Subsystem/SFSubsystem_OnActorSpawned.cpp
@@ -6,6 +6,7 @@
  */
 
 #include "Subsystem/SFSubsystemImpl.h"
+#include "Core/Helpers/SFNetworkHelper.h"  // [#334] authority gate
 
 
 void USFSubsystem::OnActorSpawned(AActor* SpawnedActor)
@@ -14,6 +15,22 @@ void USFSubsystem::OnActorSpawned(AActor* SpawnedActor)
 	if (RecipeManagementService)
 	{
 		RecipeManagementService->OnActorSpawned(SpawnedActor);
+	}
+
+	// ========================================
+	// [MP / #334] AUTHORITY GATE for everything below.
+	// Every remaining section of this handler MUTATES world state post-build (blueprint-proxy
+	// grouping, belt/pipe auto-connect builds, stackable pipe/belt wiring). On a NETWORK CLIENT,
+	// OnActorSpawned fires for REPLICATED server-built actors - running these sections there
+	// spawns client-only ghost actors and connections the server never sees (the root cause of
+	// #334: client-only power wires, and the same class of bug for belts/pipes). Authority sides
+	// (single player standalone, listen-server host, dedicated server) are unchanged: the server
+	// runs its OWN preview/decision pipeline against its mirrored hologram and performs the
+	// wiring here with authority.
+	// ========================================
+	if (FSFNetworkHelper::IsClient(GetWorld()))
+	{
+		return;
 	}
 
 	// ========================================

--- a/Source/SmartFoundations/Private/Subsystem/SFSubsystem_OnActorSpawned.cpp
+++ b/Source/SmartFoundations/Private/Subsystem/SFSubsystem_OnActorSpawned.cpp
@@ -158,6 +158,31 @@ void USFSubsystem::OnActorSpawned(AActor* SpawnedActor)
 		}
 	}
 
+	// [MP-334] TEMP diagnostic: report every gate of the belt auto-connect build path at once
+	// (the path is silent at Display level, and on the dedi we cannot see which gate fails).
+	if (AFGBuildableConveyorAttachment* DiagAttachment = Cast<AFGBuildableConveyorAttachment>(SpawnedActor))
+	{
+		const bool bDiagHoloValid = ActiveHologram.IsValid();
+		const bool bDiagIsDistributor = bDiagHoloValid && AutoConnectService
+			&& AutoConnectService->IsDistributorHologram(ActiveHologram.Get());
+		int32 DiagPreviewCount = -1;
+		if (bDiagIsDistributor)
+		{
+			if (TArray<TSharedPtr<FBeltPreviewHelper>>* DiagPreviews = AutoConnectService->GetBeltPreviews(ActiveHologram.Get()))
+			{
+				DiagPreviewCount = DiagPreviews->Num();
+			}
+		}
+		UE_LOG(LogSmartFoundations, Display,
+			TEXT("[MP-334] OnActorSpawned(attachment=%s): svc=%d activeHolo=%s isDistributorHolo=%d busyLatch=%d previews=%d"),
+			*DiagAttachment->GetName(),
+			AutoConnectService ? 1 : 0,
+			*GetNameSafe(ActiveHologram.Get()),
+			bDiagIsDistributor ? 1 : 0,
+			bProcessingGridPlacement ? 1 : 0,
+			DiagPreviewCount);
+	}
+
 	if (AutoConnectService && ActiveHologram.IsValid())
 	{
 		AFGBuildableConveyorAttachment* Attachment = Cast<AFGBuildableConveyorAttachment>(SpawnedActor);

--- a/Source/SmartFoundations/Private/Subsystem/SFSubsystem_OnActorSpawned.cpp
+++ b/Source/SmartFoundations/Private/Subsystem/SFSubsystem_OnActorSpawned.cpp
@@ -47,8 +47,14 @@ void USFSubsystem::OnActorSpawned(AActor* SpawnedActor)
 			const FIntVector& Grid = GetGridCounters();
 			const bool bIsMultiGrid = (FMath::Abs(Grid.X) > 1 || FMath::Abs(Grid.Y) > 1 || FMath::Abs(Grid.Z) > 1);
 			const bool bIsExtendActive = ExtendService && ExtendService->IsExtendModeActive();  // Issue #270
+			// Smart Restore of a SINGLE extend clone is neither multi-grid (counters stay 1x1x1)
+			// nor extend-active (bHasValidTarget belongs to the aim-at-target flow, not the replay) —
+			// without this arm its buildables never join a proxy and R-key dismantle only takes one
+			// building. The restore session flag stays set through the commit; it is cleared on the
+			// post-build tick once the parent hologram goes invalid.
+			const bool bIsRestoreReplayActive = ExtendService && ExtendService->IsRestoredCloneTopologyActive();
 
-			if ((bIsMultiGrid || bIsExtendActive) && !Buildable->GetBlueprintProxy())
+			if ((bIsMultiGrid || bIsExtendActive || bIsRestoreReplayActive) && !Buildable->GetBlueprintProxy())
 			{
 				// DIAGNOSTIC: Log what type of building is spawning
 				UE_LOG(LogSmartFoundations, VeryVerbose, TEXT(" SMART DISMANTLE: Building spawned: %s (class: %s)"),

--- a/Source/SmartFoundations/Private/Subsystem/SFSubsystem_OnActorSpawned.cpp
+++ b/Source/SmartFoundations/Private/Subsystem/SFSubsystem_OnActorSpawned.cpp
@@ -135,7 +135,9 @@ void USFSubsystem::OnActorSpawned(AActor* SpawnedActor)
 							return;
 						}
 
-						UE_LOG(LogSmartFoundations, VeryVerbose, TEXT("🔧 EXTEND: Deferred connection wiring executing for %s"), *WeakFactory->GetName());
+						// [EXTEND-MP] Display level while MP Extend validates: this is the wiring
+						// pass trigger and the dedi log is the only visibility (Verbose stripped).
+						UE_LOG(LogSmartFoundations, Display, TEXT("[EXTEND-MP] Deferred connection wiring executing for %s"), *WeakFactory->GetName());
 						// NOTE: Child holograms (belts, lifts, pipes) are built by vanilla via AddChild
 						// We just need to wire their connections here
 

--- a/Source/SmartFoundations/Private/Subsystem/SFSubsystem_OnActorSpawned.cpp
+++ b/Source/SmartFoundations/Private/Subsystem/SFSubsystem_OnActorSpawned.cpp
@@ -137,7 +137,7 @@ void USFSubsystem::OnActorSpawned(AActor* SpawnedActor)
 
 						// [EXTEND-MP] Display level while MP Extend validates: this is the wiring
 						// pass trigger and the dedi log is the only visibility (Verbose stripped).
-						UE_LOG(LogSmartFoundations, Display, TEXT("[EXTEND-MP] Deferred connection wiring executing for %s"), *WeakFactory->GetName());
+						UE_LOG(LogSmartFoundations, Verbose, TEXT("[EXTEND-MP] Deferred connection wiring executing for %s"), *WeakFactory->GetName());
 						// NOTE: Child holograms (belts, lifts, pipes) are built by vanilla via AddChild
 						// We just need to wire their connections here
 
@@ -175,7 +175,7 @@ void USFSubsystem::OnActorSpawned(AActor* SpawnedActor)
 				DiagPreviewCount = DiagPreviews->Num();
 			}
 		}
-		UE_LOG(LogSmartFoundations, Display,
+		UE_LOG(LogSmartFoundations, Verbose,
 			TEXT("[MP-334] OnActorSpawned(attachment=%s): svc=%d activeHolo=%s isDistributorHolo=%d busyLatch=%d previews=%d"),
 			*DiagAttachment->GetName(),
 			AutoConnectService ? 1 : 0,

--- a/Source/SmartFoundations/Private/Subsystem/SFValidationService.cpp
+++ b/Source/SmartFoundations/Private/Subsystem/SFValidationService.cpp
@@ -80,12 +80,13 @@ FSFValidationService::FValidationResult FSFValidationService::ValidateGridSize(c
 	// non-positive/overflow sizes. The real protection against UObject exhaustion is the
 	// GRID_CHILDREN_HARD_CAP (2000) critical downscale in USFHologramHelperService, plus its
 	// UObject warning thresholds. Keep this comparison as an overflow guard only.
-	if (TotalSize > SMART_MAX_GRID_SIZE + 1)  // +1 for parent
+	// 64-bit arithmetic: SMART_MAX_GRID_SIZE is INT_MAX, so +1 overflows int32 (clang -Werror)
+	if ((int64)TotalSize > (int64)SMART_MAX_GRID_SIZE + 1)  // +1 for parent
 	{
 		FString ErrorMsg = FString::Printf(
-			TEXT("Grid size %d exceeds maximum limit of %d (prevents UObject exhaustion)"),
+			TEXT("Grid size %d exceeds maximum limit of %lld (prevents UObject exhaustion)"),
 			TotalSize,
-			SMART_MAX_GRID_SIZE + 1
+			(int64)SMART_MAX_GRID_SIZE + 1
 		);
 		return FValidationResult::Failure(ErrorMsg);
 	}
@@ -114,11 +115,13 @@ bool FSFValidationService::ValidateAndAdjustGridSize(FIntVector& GridCounters, i
 	// Adjustment needed - scale down proportionally
 	const int32 OriginalChildren = ChildrenNeeded;
 	const int32 OriginalTotal = TotalItems;
+	// Saturating cap: SMART_MAX_GRID_SIZE is INT_MAX, so +1 must be computed in 64-bit
+	const int64 MaxTotalItems = (int64)SMART_MAX_GRID_SIZE + 1;  // +1 for parent
 	ChildrenNeeded = SMART_MAX_GRID_SIZE;
-	TotalItems = SMART_MAX_GRID_SIZE + 1;  // +1 for parent
-	
+	TotalItems = (int32)FMath::Min<int64>(MaxTotalItems, MAX_int32);
+
 	// Adjust grid counters proportionally to reflect the capped size
-	const float ScaleFactor = FMath::Sqrt((float)(SMART_MAX_GRID_SIZE + 1) / (float)OriginalTotal);
+	const float ScaleFactor = FMath::Sqrt((float)MaxTotalItems / (float)OriginalTotal);
 	XCount = FMath::Max(1, FMath::RoundToInt(XCount * ScaleFactor));
 	YCount = FMath::Max(1, FMath::RoundToInt(YCount * ScaleFactor));
 	ZCount = FMath::Max(1, FMath::RoundToInt(ZCount * ScaleFactor));
@@ -134,9 +137,9 @@ bool FSFValidationService::ValidateAndAdjustGridSize(FIntVector& GridCounters, i
 	
 	// Log the adjustment
 	UE_LOG(LogSmartFoundations, Error, 
-		TEXT("⚠️ GRID SIZE LIMIT! Requested %dx%dx%d (%d items) exceeds max (%d). Adjusted to %dx%dx%d (%d items)."),
+		TEXT("⚠️ GRID SIZE LIMIT! Requested %dx%dx%d (%d items) exceeds max (%lld). Adjusted to %dx%dx%d (%d items)."),
 		FMath::Abs(GridCounters.X), FMath::Abs(GridCounters.Y), FMath::Abs(GridCounters.Z), OriginalTotal,
-		SMART_MAX_GRID_SIZE + 1,
+		MaxTotalItems,
 		XCount, YCount, ZCount, AdjustedTotal);
 	
 	return true;  // Adjustment was made

--- a/Source/SmartFoundations/Private/UI/SmartUpgradePanel.cpp
+++ b/Source/SmartFoundations/Private/UI/SmartUpgradePanel.cpp
@@ -528,18 +528,17 @@ void USmartUpgradePanel::OnUpgradeButtonClicked()
 	// exactly as in SP. Never fall through to a client-side run (client-only actors + desync).
 	if (GetWorld() && GetWorld()->GetNetMode() == NM_Client)
 	{
-		TArray<AActor*> RCOActors;
-		UGameplayStatics::GetAllActorsOfClass(GetWorld(), USFRCO::StaticClass(), RCOActors);
-		for (AActor* Actor : RCOActors)
+		// RCOs are UObjects outered to the player controller, NOT actors —
+		// GetAllActorsOfClass can never find one (live finding 2026-06-10: the audit panel's
+		// identical lookup failed silently on every client, so the audit RCO port had never
+		// actually worked in MP). GetRemoteCallObjectOfClass is the correct resolution.
+		if (AFGPlayerController* FGPC = Cast<AFGPlayerController>(PC))
 		{
-			if (USFRCO* RCO = Cast<USFRCO>(Actor))
+			if (USFRCO* RCO = FGPC->GetRemoteCallObjectOfClass<USFRCO>())
 			{
-				if (RCO->GetOuter() == PC)
-				{
-					RCO->Server_StartUpgrade(Params);
-					UE_LOG(LogSmartUI, Verbose, TEXT("Upgrade Panel: Sent upgrade request via SFRCO"));
-					return;
-				}
+				RCO->Server_StartUpgrade(Params);
+				UE_LOG(LogSmartUI, Verbose, TEXT("Upgrade Panel: Sent upgrade request via SFRCO"));
+				return;
 			}
 		}
 		UE_LOG(LogSmartUI, Warning, TEXT("Upgrade Panel: Could not find SFRCO instance for upgrade execution"));
@@ -575,19 +574,15 @@ void USmartUpgradePanel::RefreshAudit()
 			// Trigger via RCO if we're a client, otherwise direct call
 			if (World->GetNetMode() == NM_Client)
 			{
-				TArray<AActor*> RCOActors;
-				UGameplayStatics::GetAllActorsOfClass(World, USFRCO::StaticClass(), RCOActors);
-
-				for (AActor* Actor : RCOActors)
+				// RCOs are not actors — GetRemoteCallObjectOfClass, never GetAllActorsOfClass
+				// (the old actor scan failed silently on every client; live finding 2026-06-10).
+				if (AFGPlayerController* FGPC = Cast<AFGPlayerController>(PC))
 				{
-					if (USFRCO* RCO = Cast<USFRCO>(Actor))
+					if (USFRCO* RCO = FGPC->GetRemoteCallObjectOfClass<USFRCO>())
 					{
-						if (RCO->GetOuter() == PC)
-						{
-							RCO->Server_StartUpgradeAudit(Params);
-							UE_LOG(LogSmartUI, VeryVerbose, TEXT("Upgrade Panel: Sent Refresh request via SFRCO"));
-							return;
-						}
+						RCO->Server_StartUpgradeAudit(Params);
+						UE_LOG(LogSmartUI, VeryVerbose, TEXT("Upgrade Panel: Sent Refresh request via SFRCO"));
+						return;
 					}
 				}
 				UE_LOG(LogSmartUI, Warning, TEXT("Upgrade Panel: Could not find SFRCO instance for Refresh"));
@@ -617,19 +612,14 @@ void USmartUpgradePanel::CancelAudit()
 		{
 			if (World->GetNetMode() == NM_Client)
 			{
-				TArray<AActor*> RCOActors;
-				UGameplayStatics::GetAllActorsOfClass(World, USFRCO::StaticClass(), RCOActors);
-
-				for (AActor* Actor : RCOActors)
+				// RCOs are not actors — GetRemoteCallObjectOfClass, never GetAllActorsOfClass.
+				if (AFGPlayerController* FGPC = Cast<AFGPlayerController>(PC))
 				{
-					if (USFRCO* RCO = Cast<USFRCO>(Actor))
+					if (USFRCO* RCO = FGPC->GetRemoteCallObjectOfClass<USFRCO>())
 					{
-						if (RCO->GetOuter() == PC)
-						{
-							RCO->Server_CancelUpgradeAudit();
-							UE_LOG(LogSmartUI, VeryVerbose, TEXT("Upgrade Panel: Sent Cancel request via SFRCO"));
-							return;
-						}
+						RCO->Server_CancelUpgradeAudit();
+						UE_LOG(LogSmartUI, VeryVerbose, TEXT("Upgrade Panel: Sent Cancel request via SFRCO"));
+						return;
 					}
 				}
 			}

--- a/Source/SmartFoundations/Private/UI/SmartUpgradePanel.cpp
+++ b/Source/SmartFoundations/Private/UI/SmartUpgradePanel.cpp
@@ -6,6 +6,14 @@
 #define LOCTEXT_NAMESPACE "SmartFoundations"
 
 
+void USmartUpgradePanel::NativeDestruct()
+{
+	// [UPGRADE-MP] The traversal-result delegate is static (the panel news up a throwaway
+	// traversal service per scan) - unbind so a dead widget is never broadcast to.
+	USFUpgradeTraversalService::OnClientTraversalResultReceived.RemoveAll(this);
+	Super::NativeDestruct();
+}
+
 void USmartUpgradePanel::NativeConstruct()
 {
 	Super::NativeConstruct();
@@ -511,6 +519,35 @@ void USmartUpgradePanel::OnUpgradeButtonClicked()
 	if (StatusText)
 	{
 		StatusText->SetText(FText::Format(LOCTEXT("Upgrade_Upgrading", "Upgrading {0} Mk.{1} \u2192 Mk.{2}..."), FText::FromString(FamilyName), FText::AsNumber(SelectedTier), FText::AsNumber(TargetTier)));
+	}
+
+	// [UPGRADE-MP] On a network client the whole execution pipeline (hologram replacement, actor
+	// destruction, connection repair, chain rebuild, cost) is server-authoritative world mutation
+	// - route the request through the RCO. The result comes back via Client_ReceiveUpgradeResult
+	// and is injected into the LOCAL execution service, so the delegate subscriptions above fire
+	// exactly as in SP. Never fall through to a client-side run (client-only actors + desync).
+	if (GetWorld() && GetWorld()->GetNetMode() == NM_Client)
+	{
+		TArray<AActor*> RCOActors;
+		UGameplayStatics::GetAllActorsOfClass(GetWorld(), USFRCO::StaticClass(), RCOActors);
+		for (AActor* Actor : RCOActors)
+		{
+			if (USFRCO* RCO = Cast<USFRCO>(Actor))
+			{
+				if (RCO->GetOuter() == PC)
+				{
+					RCO->Server_StartUpgrade(Params);
+					UE_LOG(LogSmartUI, Verbose, TEXT("Upgrade Panel: Sent upgrade request via SFRCO"));
+					return;
+				}
+			}
+		}
+		UE_LOG(LogSmartUI, Warning, TEXT("Upgrade Panel: Could not find SFRCO instance for upgrade execution"));
+		if (StatusText)
+		{
+			StatusText->SetText(LOCTEXT("Upgrade_ErrRCO", "Error: server connection unavailable"));
+		}
+		return;
 	}
 
 	ExecutionService->StartUpgrade(Params);

--- a/Source/SmartFoundations/Private/UI/SmartUpgradePanel_Detail.cpp
+++ b/Source/SmartFoundations/Private/UI/SmartUpgradePanel_Detail.cpp
@@ -1055,11 +1055,50 @@ void USmartUpgradePanel::OnTraversalScanClicked()
 		TraversalConfig.bCrossTrainPlatforms = CrossTrainPlatformsCheckBox->IsChecked();
 	}
 
+	// [UPGRADE-MP] On a network client the walk must run on the SERVER: traversal follows
+	// factory/pipe/circuit connection components and their connection values are server-only
+	// (GetConnection() is null on clients - the same limitation as the Extend topology walk).
+	// The result arrives via Client_ReceiveTraversalResult -> InjectTraversalResult -> the
+	// static delegate below, and lands in the same UpdateTraversalUI path as the SP scan.
+	if (GetWorld() && GetWorld()->GetNetMode() == NM_Client)
+	{
+		USFUpgradeTraversalService::OnClientTraversalResultReceived.RemoveAll(this);
+		USFUpgradeTraversalService::OnClientTraversalResultReceived.AddUObject(
+			this, &USmartUpgradePanel::OnClientTraversalResult);
+
+		TArray<AActor*> RCOActors;
+		UGameplayStatics::GetAllActorsOfClass(GetWorld(), USFRCO::StaticClass(), RCOActors);
+		for (AActor* Actor : RCOActors)
+		{
+			if (USFRCO* RCO = Cast<USFRCO>(Actor))
+			{
+				if (RCO->GetOuter() == PC)
+				{
+					RCO->Server_StartUpgradeTraversal(AnchorBuildable, TraversalConfig);
+					UE_LOG(LogSmartUI, Verbose, TEXT("Upgrade Panel: Sent traversal request via SFRCO"));
+					return;
+				}
+			}
+		}
+		UE_LOG(LogSmartUI, Warning, TEXT("Upgrade Panel: Could not find SFRCO instance for traversal scan"));
+		if (SharedStatusText)
+		{
+			SharedStatusText->SetText(LOCTEXT("Upgrade_ErrRCOScan", "Error: server connection unavailable"));
+		}
+		return;
+	}
+
 	// Create traversal service and run scan
 	USFUpgradeTraversalService* TraversalService = NewObject<USFUpgradeTraversalService>();
 	CachedTraversalResult = TraversalService->TraverseNetwork(AnchorBuildable, TraversalConfig, PC);
 
 	// Update UI with results
+	UpdateTraversalUI(CachedTraversalResult);
+}
+
+void USmartUpgradePanel::OnClientTraversalResult(const FSFTraversalResult& Result)
+{
+	CachedTraversalResult = Result;
 	UpdateTraversalUI(CachedTraversalResult);
 }
 

--- a/Source/SmartFoundations/Private/UI/SmartUpgradePanel_Detail.cpp
+++ b/Source/SmartFoundations/Private/UI/SmartUpgradePanel_Detail.cpp
@@ -1066,18 +1066,15 @@ void USmartUpgradePanel::OnTraversalScanClicked()
 		USFUpgradeTraversalService::OnClientTraversalResultReceived.AddUObject(
 			this, &USmartUpgradePanel::OnClientTraversalResult);
 
-		TArray<AActor*> RCOActors;
-		UGameplayStatics::GetAllActorsOfClass(GetWorld(), USFRCO::StaticClass(), RCOActors);
-		for (AActor* Actor : RCOActors)
+		// RCOs are not actors — GetRemoteCallObjectOfClass, never GetAllActorsOfClass
+		// (the old actor scan failed silently on every client; live finding 2026-06-10).
+		if (AFGPlayerController* FGPC = Cast<AFGPlayerController>(PC))
 		{
-			if (USFRCO* RCO = Cast<USFRCO>(Actor))
+			if (USFRCO* RCO = FGPC->GetRemoteCallObjectOfClass<USFRCO>())
 			{
-				if (RCO->GetOuter() == PC)
-				{
-					RCO->Server_StartUpgradeTraversal(AnchorBuildable, TraversalConfig);
-					UE_LOG(LogSmartUI, Verbose, TEXT("Upgrade Panel: Sent traversal request via SFRCO"));
-					return;
-				}
+				RCO->Server_StartUpgradeTraversal(AnchorBuildable, TraversalConfig);
+				UE_LOG(LogSmartUI, Verbose, TEXT("Upgrade Panel: Sent traversal request via SFRCO"));
+				return;
 			}
 		}
 		UE_LOG(LogSmartUI, Warning, TEXT("Upgrade Panel: Could not find SFRCO instance for traversal scan"));

--- a/Source/SmartFoundations/Public/Data/SFHologramData.h
+++ b/Source/SmartFoundations/Public/Data/SFHologramData.h
@@ -4,7 +4,6 @@
 
 #include "CoreMinimal.h"
 #include "Hologram/FGSplineHologram.h"  // For FSplinePointData
-#include "Features/Scaling/SFScalingSpec.h"  // FSFScalingSpec (MP spec-based construction)
 #include "SFHologramData.generated.h"
 
 // Forward declarations
@@ -48,13 +47,6 @@ struct SMARTFOUNDATIONS_API FSFHologramData {
     // Recipe copying support
     UPROPERTY()
     TSubclassOf<UFGRecipe> StoredRecipe = nullptr;
-
-    // MP spec-based scaling construction (class-agnostic hook path): the compact grid description
-    // captured client-side at fire time and read back server-side from the construct message.
-    // Attached HERE (registry) rather than as a hologram UPROPERTY so it works for EVERY hologram
-    // class - including the vanilla Blueprint wrappers (Holo_Foundation_C etc.) - without swapping.
-    UPROPERTY()
-    FSFScalingSpec ScalingSpec;
     
     // Backup spline data for EXTEND belt holograms
     // Stored because mSplineData on AFGSplineHologram can be cleared by replication

--- a/Source/SmartFoundations/Public/Data/SFHologramData.h
+++ b/Source/SmartFoundations/Public/Data/SFHologramData.h
@@ -4,6 +4,7 @@
 
 #include "CoreMinimal.h"
 #include "Hologram/FGSplineHologram.h"  // For FSplinePointData
+#include "Features/Scaling/SFScalingSpec.h"  // FSFScalingSpec (MP spec-based construction)
 #include "SFHologramData.generated.h"
 
 // Forward declarations
@@ -47,6 +48,13 @@ struct SMARTFOUNDATIONS_API FSFHologramData {
     // Recipe copying support
     UPROPERTY()
     TSubclassOf<UFGRecipe> StoredRecipe = nullptr;
+
+    // MP spec-based scaling construction (class-agnostic hook path): the compact grid description
+    // captured client-side at fire time and read back server-side from the construct message.
+    // Attached HERE (registry) rather than as a hologram UPROPERTY so it works for EVERY hologram
+    // class - including the vanilla Blueprint wrappers (Holo_Foundation_C etc.) - without swapping.
+    UPROPERTY()
+    FSFScalingSpec ScalingSpec;
     
     // Backup spline data for EXTEND belt holograms
     // Stored because mSplineData on AFGSplineHologram can be cleared by replication

--- a/Source/SmartFoundations/Public/Features/Arrows/SFArrowModule_StaticMesh.h
+++ b/Source/SmartFoundations/Public/Features/Arrows/SFArrowModule_StaticMesh.h
@@ -220,6 +220,16 @@ private:
 	/** Timer handle for deferred attachment timeout */
 	FTimerHandle DeferredAttachTimerHandle;
 
+	/** World the deferred-attach timer was armed in. Cleanup previously reached the world only
+	 *  through ArrowX's outer - the HOLOGRAM - which usually dies first, so the timer was never
+	 *  cleared when it mattered ([CHAIN-FIX] 2026-06-10 dedi heap-corruption investigation). */
+	TWeakObjectPtr<UWorld> DeferredAttachTimerWorld;
+
+	/** [CHAIN-FIX] Arrows are pure client cosmetics. On a dedicated server the asset "readiness"
+	 *  checks can never pass (no render data under the null renderer), so every attach deferred,
+	 *  re-armed timers, and re-ran failing async loads forever. Disabled wholesale there. */
+	bool bDisabledOnDedicatedServer = false;
+
 	/** Current configuration */
 	FArrowConfig Config;
 

--- a/Source/SmartFoundations/Public/Features/Extend/SFExtendCommitSpec.h
+++ b/Source/SmartFoundations/Public/Features/Extend/SFExtendCommitSpec.h
@@ -1,0 +1,45 @@
+// Copyright (c) 2025-present Finalomega. All rights reserved. See LICENSE.md.
+// Smart! Mod - Multiplayer Extend commit spec ([EXTEND-MP] slice 2)
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Features/Extend/SFExtendCloneTopology.h"   // FSFCloneTopology (value-only, wire-safe)
+#include "ItemAmount.h"                               // FItemAmount (staged cost)
+#include "SFExtendCommitSpec.generated.h"
+
+/**
+ * The staged Extend commit a CLIENT ships to the server right before firing the build gun
+ * ([EXTEND-MP] slice 2; see PLAN_MP_ExtendConstruction_Strategy.md). Mirrors the scaling spec's
+ * intent->authority model: the client re-emits a FRESH clone topology at fire time (the preview's
+ * stored topology has stale world transforms - children are re-positioned while aiming), destroys
+ * its preview children, and fires a childless O(1) parent; the server's Construct hook consumes
+ * this spec and reconstructs the clone children PRE-scope() via the same executor the client
+ * preview uses (FSFCloneTopology::SpawnChildHolograms + WireChildHologramConnections).
+ *
+ * FSFCloneTopology is wire-safe by construction: a fully reflected, VALUE-ONLY schema (strings,
+ * floats, transforms, spline points - zero object pointers).
+ */
+USTRUCT()
+struct SMARTFOUNDATIONS_API FSFExtendCommitSpec
+{
+	GENERATED_BODY()
+
+	/** The clone description, emitted at FIRE time with the final parent offset. */
+	UPROPERTY()
+	FSFCloneTopology Clone;
+
+	/** Exact preview cost (parent + all preview children, vanilla GetCost(true) at fire) -
+	 *  the server's GetCost hook overrides with this so the commit charges what was previewed. */
+	UPROPERTY()
+	TArray<FItemAmount> Cost;
+
+	/** Parent build class - the server only consumes a staged commit for a construct of the SAME
+	 *  class (guards against any client/server fire mismatch or RPC race). */
+	UPROPERTY()
+	TSubclassOf<class AFGBuildable> BuildClass = nullptr;
+
+	/** True once populated from a live Extend session. */
+	UPROPERTY()
+	bool bValid = false;
+};

--- a/Source/SmartFoundations/Public/Features/Extend/SFExtendCommitSpec.h
+++ b/Source/SmartFoundations/Public/Features/Extend/SFExtendCommitSpec.h
@@ -5,8 +5,12 @@
 
 #include "CoreMinimal.h"
 #include "Features/Extend/SFExtendCloneTopology.h"   // FSFCloneTopology (value-only, wire-safe)
+#include "HUD/SFHUDTypes.h"                           // FSFCounterState (Restore commit panel state)
 #include "ItemAmount.h"                               // FItemAmount (staged cost)
+#include "Templates/SubclassOf.h"
 #include "SFExtendCommitSpec.generated.h"
+
+class UFGRecipe;
 
 /**
  * The staged Extend commit a CLIENT ships to the server right before firing the build gun
@@ -75,6 +79,31 @@ struct SMARTFOUNDATIONS_API FSFExtendCommitSpec
 	 *  Empty for a normal (single-clone) Extend. */
 	UPROPERTY()
 	TArray<FSFExtendCommitScaledClone> ScaledClones;
+
+	/** RESTORE commit ([EXTEND-MP] Restore slice). A Smart Restore replay has NO source building
+	 *  to walk: the topology comes from the saved preset, a value-only template captured at save
+	 *  time. The client ships that compact TEMPLATE (not the expanded preview) plus the Smart
+	 *  Panel counter state and the stored production recipe; the server installs them and re-runs
+	 *  the SAME replay pipeline the SP preview uses (ReplayRestoreCloneTopology: expansion at the
+	 *  validated parent's final position + rr_X_Y factory placement + infra spawn + pre-wiring).
+	 *  The connection data is preset-sourced, not GetConnection()-derived at fire time, so the
+	 *  client-capture poisoning that forbids shipping the EXTEND topology does not apply here. */
+	UPROPERTY()
+	bool bIsRestore = false;
+
+	UPROPERTY()
+	FSFCloneTopology RestoreTemplate;
+
+	/** Smart Panel state the replay expansion + restored-factory placement math read
+	 *  (grid counters, spacing, steps, rotation). The server's own counter state is a default
+	 *  mirror that never saw the client's panel. */
+	UPROPERTY()
+	FSFCounterState RestoreCounterState;
+
+	/** The preset's production recipe for the restored factories (asset class - package-map
+	 *  safe). Null when the preset carried none. */
+	UPROPERTY()
+	TSubclassOf<UFGRecipe> RestoreProductionRecipe = nullptr;
 
 	/** True once populated from a live Extend session. */
 	UPROPERTY()

--- a/Source/SmartFoundations/Public/Features/Extend/SFExtendCommitSpec.h
+++ b/Source/SmartFoundations/Public/Features/Extend/SFExtendCommitSpec.h
@@ -20,6 +20,32 @@
  * FSFCloneTopology is wire-safe by construction: a fully reflected, VALUE-ONLY schema (strings,
  * floats, transforms, spline points - zero object pointers).
  */
+/** One Scaled Extend clone set's PARAMETERS ([EXTEND-MP]). The server does not need the clone
+ *  topologies themselves: it re-walks the source's graph authoritatively and re-runs the SAME
+ *  spawn pipeline the SP preview uses (SpawnScaledExtendPreviews) with these parameters - that
+ *  regenerates each clone's factory child, infrastructure topology, rigid-body rotation fix-ups,
+ *  and lane segments exactly as the client previewed them. */
+USTRUCT()
+struct SMARTFOUNDATIONS_API FSFExtendCommitScaledClone
+{
+	GENERATED_BODY()
+
+	UPROPERTY()
+	FVector WorldOffset = FVector::ZeroVector;     // offset from the SOURCE building
+
+	UPROPERTY()
+	FRotator RotationOffset = FRotator::ZeroRotator;
+
+	UPROPERTY()
+	int32 GridX = 0;
+
+	UPROPERTY()
+	int32 GridY = 0;
+
+	UPROPERTY()
+	bool bIsSeed = false;
+};
+
 USTRUCT()
 struct SMARTFOUNDATIONS_API FSFExtendCommitSpec
 {
@@ -45,6 +71,11 @@ struct SMARTFOUNDATIONS_API FSFExtendCommitSpec
 	 *  head) must arrive with the commit. */
 	UPROPERTY()
 	TObjectPtr<class AFGBuildable> SourceBuilding = nullptr;
+
+	/** Scaled Extend ([EXTEND-MP]): the per-clone parameters of every additional clone set.
+	 *  Empty for a normal (single-clone) Extend. */
+	UPROPERTY()
+	TArray<FSFExtendCommitScaledClone> ScaledClones;
 
 	/** True once populated from a live Extend session. */
 	UPROPERTY()

--- a/Source/SmartFoundations/Public/Features/Extend/SFExtendCommitSpec.h
+++ b/Source/SmartFoundations/Public/Features/Extend/SFExtendCommitSpec.h
@@ -11,14 +11,12 @@
 /**
  * The staged Extend commit a CLIENT ships to the server right before firing the build gun
  * ([EXTEND-MP] slice 2; see PLAN_MP_ExtendConstruction_Strategy.md). Mirrors the scaling spec's
- * intent->authority model: the client re-emits a FRESH clone topology at fire time (the preview's
- * stored topology has stale world transforms - children are re-positioned while aiming), destroys
- * its preview children, and fires a childless O(1) parent; the server's Construct hook consumes
- * this spec and reconstructs the clone children PRE-scope() via the same executor the client
- * preview uses (FSFCloneTopology::SpawnChildHolograms + WireChildHologramConnections).
- *
- * FSFCloneTopology is wire-safe by construction: a fully reflected, VALUE-ONLY schema (strings,
- * floats, transforms, spline points - zero object pointers).
+ * intent->authority model, and like it the spec carries ONLY PARAMETERS: the server re-derives
+ * the clone topology ITSELF (authoritative graph walk -> CaptureFromTopology -> FromSource at
+ * ParentOffset) and reconstructs the children pre-scope(). The clone topology MUST be built
+ * server-side: capturing it on the client poisons every segment's connections, because
+ * CaptureBeltChain/CapturePipeChain read GetConnection() - null on clients by design - so the
+ * wiring manifest comes out empty (live root cause 2026-06-10: every MP Extend built unwired).
  */
 /** One Scaled Extend clone set's PARAMETERS ([EXTEND-MP]). The server does not need the clone
  *  topologies themselves: it re-walks the source's graph authoritatively and re-runs the SAME
@@ -51,9 +49,10 @@ struct SMARTFOUNDATIONS_API FSFExtendCommitSpec
 {
 	GENERATED_BODY()
 
-	/** The clone description, emitted at FIRE time with the final parent offset. */
+	/** Final fire-position offset of the parent clone from the SOURCE building. The server runs
+	 *  FromSource(serverWalkedTopology, ParentOffset) to derive the clone topology itself. */
 	UPROPERTY()
-	FSFCloneTopology Clone;
+	FVector ParentOffset = FVector::ZeroVector;
 
 	/** Exact preview cost (parent + all preview children, vanilla GetCost(true) at fire) -
 	 *  the server's GetCost hook overrides with this so the commit charges what was previewed. */

--- a/Source/SmartFoundations/Public/Features/Extend/SFExtendCommitSpec.h
+++ b/Source/SmartFoundations/Public/Features/Extend/SFExtendCommitSpec.h
@@ -39,6 +39,13 @@ struct SMARTFOUNDATIONS_API FSFExtendCommitSpec
 	UPROPERTY()
 	TSubclassOf<class AFGBuildable> BuildClass = nullptr;
 
+	/** The building the player extended FROM (replicated actor, serializes via the package map).
+	 *  The dedi no longer runs the Extend preview pipeline, so the session state the post-build
+	 *  wiring anchors on (LastBuiltFromBuilding / CurrentExtendTarget - e.g. the #344 daisy-chain
+	 *  head) must arrive with the commit. */
+	UPROPERTY()
+	TObjectPtr<class AFGBuildable> SourceBuilding = nullptr;
+
 	/** True once populated from a live Extend session. */
 	UPROPERTY()
 	bool bValid = false;

--- a/Source/SmartFoundations/Public/Features/Extend/SFExtendScaledService.h
+++ b/Source/SmartFoundations/Public/Features/Extend/SFExtendScaledService.h
@@ -73,6 +73,11 @@ public:
     void ClearScaledExtendClones();
     bool ValidatePowerCapacity();
 
+    /** [EXTEND-MP] Server-commit entry: run the SAME spawn pipeline the SP preview uses against
+     *  the already-installed session state (CurrentExtendTarget/CurrentExtendHologram/topology +
+     *  ScaledExtendClones parameters). Used by ReconstructScaledCommitOnServer. */
+    void SpawnCloneSetsForServerCommit() { SpawnScaledExtendPreviews(); }
+
 private:
     /** Calculate world offsets for all clones based on current grid state */
     void CalculateScaledExtendPositions();

--- a/Source/SmartFoundations/Public/Features/Extend/SFExtendService.h
+++ b/Source/SmartFoundations/Public/Features/Extend/SFExtendService.h
@@ -270,6 +270,14 @@ public:
     int32 ReconstructScaledCommitOnServer(AFGHologram* ParentHologram,
         const TArray<struct FSFExtendCommitScaledClone>& Clones);
 
+    /** [EXTEND-MP] Server-side: reconstruct the FULL staged commit at the construct seam. Walks
+     *  the source graph (authoritative - GetConnection() is real here, unlike the client where it
+     *  is null and poisons every captured segment connection), derives the parent clone topology
+     *  via CaptureFromTopology + FromSource(ParentOffset), installs it as StoredCloneTopology,
+     *  spawns the parent clone set, then reconstructs the scaled clone sets. Returns children
+     *  spawned for the parent set. */
+    int32 ReconstructCommitOnServer(AFGHologram* ParentHologram, const struct FSFExtendCommitSpec& Spec);
+
     UFUNCTION(BlueprintCallable, Category = "Smart|Extend")
     const FSFExtendTopology& GetLastExtendTopology() const;
 

--- a/Source/SmartFoundations/Public/Features/Extend/SFExtendService.h
+++ b/Source/SmartFoundations/Public/Features/Extend/SFExtendService.h
@@ -457,9 +457,21 @@ public:
      * Swap the build gun's active hologram to our custom ASFFactoryHologram.
      * This gives us control over SetHologramLocationAndRotation for EXTEND positioning.
      * @param VanillaHologram The current vanilla factory hologram
+     * @param bTrackAsExtendSwap When true (Extend), record SwappedHologram/bHasSwappedHologram so
+     *        RestoreOriginalHologram works. Pass false for the MP scaling spec swap, which reuses
+     *        the mechanism but must not put the Extend service into "swapped" state.
      * @return The swapped custom hologram, or nullptr if swap failed
      */
-    ASFFactoryHologram* SwapToSmartFactoryHologram(AFGHologram* VanillaHologram);
+    ASFFactoryHologram* SwapToSmartFactoryHologram(AFGHologram* VanillaHologram, bool bTrackAsExtendSwap = true);
+
+    /**
+     * Swap the build gun's active hologram to ASFFoundationHologram (MP scaling spec path for
+     * FOUNDATION grids). Same proven mechanism as the factory swap (repoints BuildState->mHologram);
+     * never tracked as an Extend swap.
+     * @param VanillaHologram The current vanilla foundation hologram (exact-class AFGFoundationHologram)
+     * @return The swapped custom hologram, or nullptr if swap failed
+     */
+    class ASFFoundationHologram* SwapToSmartFoundationHologram(AFGHologram* VanillaHologram);
 
     /**
      * Restore the original hologram when EXTEND mode ends.

--- a/Source/SmartFoundations/Public/Features/Extend/SFExtendService.h
+++ b/Source/SmartFoundations/Public/Features/Extend/SFExtendService.h
@@ -240,6 +240,19 @@ public:
      *  2026-06-10). */
     void SetServerCommitSourceBuilding(AFGBuildable* Source);
 
+    /** [EXTEND-MP] Client-side capture: copy the active Scaled Extend clone PARAMETERS (offsets /
+     *  rotations / grid coords) into the commit spec. Empty when Scaled Extend is not active. */
+    void GetScaledClonePlanForCommit(TArray<struct FSFExtendCommitScaledClone>& OutClones) const;
+
+    /** [EXTEND-MP] Server-side: reconstruct the Scaled Extend clone sets for a staged commit.
+     *  Re-walks the SOURCE building's graph (authoritative on the server), installs the shipped
+     *  per-clone parameters as ScaledExtendClones, and re-runs the SAME spawn pipeline the SP
+     *  preview uses (SpawnScaledExtendPreviews) against the constructing parent - regenerating
+     *  factory children, infrastructure topologies, rotation fix-ups, and lanes identically.
+     *  Requires SetServerCommitSourceBuilding to have been called. Returns clone sets installed. */
+    int32 ReconstructScaledCommitOnServer(AFGHologram* ParentHologram,
+        const TArray<struct FSFExtendCommitScaledClone>& Clones);
+
     UFUNCTION(BlueprintCallable, Category = "Smart|Extend")
     const FSFExtendTopology& GetLastExtendTopology() const;
 

--- a/Source/SmartFoundations/Public/Features/Extend/SFExtendService.h
+++ b/Source/SmartFoundations/Public/Features/Extend/SFExtendService.h
@@ -233,6 +233,13 @@ public:
      *  children populate during Construct) finds the same state an SP build would have. */
     void SetStoredCloneTopologyForServerCommit(const struct FSFCloneTopology& Clone);
 
+    /** [EXTEND-MP] Server-side: install the commit's SOURCE building as the Extend session anchor
+     *  (LastBuiltFromBuilding + CurrentExtendTarget). The dedi never runs the preview pipeline, so
+     *  the post-build wiring state it normally sets must come from the staged commit - without it
+     *  the #344 daisy-chain head is null and building-to-building power never wires (live finding
+     *  2026-06-10). */
+    void SetServerCommitSourceBuilding(AFGBuildable* Source);
+
     UFUNCTION(BlueprintCallable, Category = "Smart|Extend")
     const FSFExtendTopology& GetLastExtendTopology() const;
 

--- a/Source/SmartFoundations/Public/Features/Extend/SFExtendService.h
+++ b/Source/SmartFoundations/Public/Features/Extend/SFExtendService.h
@@ -275,7 +275,9 @@ public:
      *  is null and poisons every captured segment connection), derives the parent clone topology
      *  via CaptureFromTopology + FromSource(ParentOffset), installs it as StoredCloneTopology,
      *  spawns the parent clone set, then reconstructs the scaled clone sets. Returns children
-     *  spawned for the parent set. */
+     *  spawned for the parent set. A RESTORE commit (Spec.bIsRestore) has no source building to
+     *  walk: the preset TEMPLATE arrives in the spec; the panel state + production recipe are
+     *  installed and the SAME SP replay pipeline runs (ReplayRestoreCloneTopology). */
     int32 ReconstructCommitOnServer(AFGHologram* ParentHologram, const struct FSFExtendCommitSpec& Spec);
 
     UFUNCTION(BlueprintCallable, Category = "Smart|Extend")

--- a/Source/SmartFoundations/Public/Features/Extend/SFExtendService.h
+++ b/Source/SmartFoundations/Public/Features/Extend/SFExtendService.h
@@ -224,6 +224,10 @@ public:
     UFUNCTION(BlueprintCallable, Category = "Smart|Extend")
     const FSFExtendTopology& GetCurrentTopology() const;
 
+    /** [EXTEND-MP] Client-side: store a server-walked topology (USFRCO reply). WalkTopology's
+     *  client branch consumes it on the next activation tick. */
+    void ReceiveServerTopology(const FSFExtendTopology& Topology);
+
     UFUNCTION(BlueprintCallable, Category = "Smart|Extend")
     const FSFExtendTopology& GetLastExtendTopology() const;
 
@@ -617,6 +621,23 @@ private:
 
     UPROPERTY()
     FSFExtendTopology LastExtendTopology;
+
+    // [EXTEND-MP] Client-side cache of the last SERVER-walked topology (USFRCO reply), keyed by
+    // building with a short TTL. bIsValid=false entries are negative results ("nothing to extend
+    // here") cached to stop per-tick request spam while aiming.
+    UPROPERTY()
+    FSFExtendTopology CachedServerTopology;
+
+    UPROPERTY()
+    TWeakObjectPtr<AFGBuildable> CachedServerTopologyBuilding;
+
+    double CachedServerTopologyTime = 0.0;
+
+    /** [EXTEND-MP] Request throttle: last building asked for + when. */
+    UPROPERTY()
+    TWeakObjectPtr<AFGBuildable> PendingTopologyRequestBuilding;
+
+    double LastTopologyRequestTime = 0.0;
 
     TSharedPtr<FSFCloneTopology> LastCloneTopology;
 

--- a/Source/SmartFoundations/Public/Features/Extend/SFExtendService.h
+++ b/Source/SmartFoundations/Public/Features/Extend/SFExtendService.h
@@ -228,6 +228,13 @@ public:
      *  client branch consumes it on the next activation tick. */
     void ReceiveServerTopology(const FSFExtendTopology& Topology);
 
+    /** [EXTEND-MP] Client-side: cache the AUTHORITATIVELY derived clone topology the server
+     *  pushes after every Extend commit reconstruction. GetLastCloneTopology prefers this on
+     *  clients - the client's own capture has empty segment connections (GetConnection() null),
+     *  which poisoned presets saved via Import-from-Last-Extend (live finding 2026-06-10:
+     *  restored builds came out with unconnected belt segments). */
+    void ReceiveServerCloneTopology(const struct FSFCloneTopology& Topology);
+
     /** [EXTEND-MP] Server-side: install the staged commit's clone topology as StoredCloneTopology
      *  so the post-build wiring pass (WireBuiltChildConnections, fed by the registries the clone
      *  children populate during Construct) finds the same state an SP build would have. */
@@ -695,6 +702,10 @@ private:
     double LastCommitStageTime = 0.0;
 
     TSharedPtr<FSFCloneTopology> LastCloneTopology;
+
+    /** [EXTEND-MP] Client cache of the server-derived clone topology (pushed after every commit
+     *  reconstruction; full segment connections - see ReceiveServerCloneTopology). */
+    TSharedPtr<FSFCloneTopology> ServerDerivedCloneTopology;
 
     // ==================== Scaled Extend State (Issue #265) ====================
 

--- a/Source/SmartFoundations/Public/Features/Extend/SFExtendService.h
+++ b/Source/SmartFoundations/Public/Features/Extend/SFExtendService.h
@@ -244,6 +244,23 @@ public:
      *  rotations / grid coords) into the commit spec. Empty when Scaled Extend is not active. */
     void GetScaledClonePlanForCommit(TArray<struct FSFExtendCommitScaledClone>& OutClones) const;
 
+    /** [EXTEND-MP] Client-side: build the full Extend commit spec from the live session (fresh
+     *  clone topology at the hologram's CURRENT position, preview cost, source building, scaled
+     *  clone parameters). Returns false when no valid Extend session backs the hologram. */
+    bool BuildCommitSpecForMP(AFGHologram* ParentHologram, struct FSFExtendCommitSpec& OutSpec) const;
+
+    /** [EXTEND-MP] Client-side: PRE-STAGE the commit on the server (throttled, ~4/s) while the
+     *  Extend preview is active. The commit RPC is LARGE (spline data -> fragmented bunches) and
+     *  the construct RPC is tiny; staged-at-fire lost the cross-channel race live (2026-06-10:
+     *  rotated scaled fire built a bare parent). Continuous pre-staging makes the commit long
+     *  since staged when the fire lands; the fire-time stage remains as the final refresh. */
+    void MaybeStageCommitForMP(AFGHologram* ParentHologram);
+
+    /** [EXTEND-MP] Client-side: stage an explicit CLEAR (invalid commit) so a stale pre-staged
+     *  commit can never be consumed by a later non-Extend construct. Called on session teardown
+     *  and on every non-Extend fire of a scalable class. */
+    void StageCommitClearForMP();
+
     /** [EXTEND-MP] Server-side: reconstruct the Scaled Extend clone sets for a staged commit.
      *  Re-walks the SOURCE building's graph (authoritative on the server), installs the shipped
      *  per-clone parameters as ScaledExtendClones, and re-runs the SAME spawn pipeline the SP
@@ -663,6 +680,9 @@ private:
     TWeakObjectPtr<AFGBuildable> PendingTopologyRequestBuilding;
 
     double LastTopologyRequestTime = 0.0;
+
+    /** [EXTEND-MP] Pre-stage throttle for the commit RPC. */
+    double LastCommitStageTime = 0.0;
 
     TSharedPtr<FSFCloneTopology> LastCloneTopology;
 

--- a/Source/SmartFoundations/Public/Features/Extend/SFExtendService.h
+++ b/Source/SmartFoundations/Public/Features/Extend/SFExtendService.h
@@ -458,20 +458,11 @@ public:
      * This gives us control over SetHologramLocationAndRotation for EXTEND positioning.
      * @param VanillaHologram The current vanilla factory hologram
      * @param bTrackAsExtendSwap When true (Extend), record SwappedHologram/bHasSwappedHologram so
-     *        RestoreOriginalHologram works. Pass false for the MP scaling spec swap, which reuses
-     *        the mechanism but must not put the Extend service into "swapped" state.
+     *        RestoreOriginalHologram works. Pass false to reuse the mechanism without putting the
+     *        Extend service into "swapped" state.
      * @return The swapped custom hologram, or nullptr if swap failed
      */
     ASFFactoryHologram* SwapToSmartFactoryHologram(AFGHologram* VanillaHologram, bool bTrackAsExtendSwap = true);
-
-    /**
-     * Swap the build gun's active hologram to ASFFoundationHologram (MP scaling spec path for
-     * FOUNDATION grids). Same proven mechanism as the factory swap (repoints BuildState->mHologram);
-     * never tracked as an Extend swap.
-     * @param VanillaHologram The current vanilla foundation hologram (exact-class AFGFoundationHologram)
-     * @return The swapped custom hologram, or nullptr if swap failed
-     */
-    class ASFFoundationHologram* SwapToSmartFoundationHologram(AFGHologram* VanillaHologram);
 
     /**
      * Restore the original hologram when EXTEND mode ends.

--- a/Source/SmartFoundations/Public/Features/Extend/SFExtendService.h
+++ b/Source/SmartFoundations/Public/Features/Extend/SFExtendService.h
@@ -228,6 +228,11 @@ public:
      *  client branch consumes it on the next activation tick. */
     void ReceiveServerTopology(const FSFExtendTopology& Topology);
 
+    /** [EXTEND-MP] Server-side: install the staged commit's clone topology as StoredCloneTopology
+     *  so the post-build wiring pass (WireBuiltChildConnections, fed by the registries the clone
+     *  children populate during Construct) finds the same state an SP build would have. */
+    void SetStoredCloneTopologyForServerCommit(const struct FSFCloneTopology& Clone);
+
     UFUNCTION(BlueprintCallable, Category = "Smart|Extend")
     const FSFExtendTopology& GetLastExtendTopology() const;
 

--- a/Source/SmartFoundations/Public/Features/Extend/SFExtendTopologyService.h
+++ b/Source/SmartFoundations/Public/Features/Extend/SFExtendTopologyService.h
@@ -60,6 +60,12 @@ public:
     UFUNCTION(BlueprintCallable, Category = "Smart|Extend|Topology")
     void ClearTopology();
 
+    /** [EXTEND-MP] Inject a SERVER-walked topology as the current cached topology. A network
+     *  client cannot walk locally (mConnectedComponent is SaveGame-only, GetConnection() is null
+     *  on clients); the server walks via the USFRCO topology request and the client injects the
+     *  reply here - the referenced actors/components are replicated, so they resolve locally. */
+    void InjectTopology(const FSFExtendTopology& Topology) { CachedTopology = Topology; }
+
     /** Check if we have valid cached topology */
     UFUNCTION(BlueprintCallable, Category = "Smart|Extend|Topology")
     bool HasValidTopology() const;

--- a/Source/SmartFoundations/Public/Features/Extend/SFExtendTypes.h
+++ b/Source/SmartFoundations/Public/Features/Extend/SFExtendTypes.h
@@ -160,16 +160,22 @@ struct FSFPowerChainNode
     UPROPERTY()
     TWeakObjectPtr<UFGCircuitConnectionComponent> PoleConnector;
 
-    /** Relative offset from factory to pole (world space) */
+    /** Relative offset from factory to pole (world space).
+     *  UPROPERTY (with the three below) since 2026-06-10: FSFExtendTopology crosses the wire in
+     *  the [EXTEND-MP] topology RCO, and only reflected members serialize. */
+    UPROPERTY()
     FVector RelativeOffset = FVector::ZeroVector;
 
     /** Whether the source pole has free connections for source↔clone wiring */
+    UPROPERTY()
     bool bSourceHasFreeConnections = false;
 
     /** Number of free connections on source pole at time of topology capture */
+    UPROPERTY()
     int32 SourceFreeConnections = 0;
 
     /** Max connections for this pole tier (Mk1=4, Mk2=7, Mk3=10) */
+    UPROPERTY()
     int32 MaxConnections = 4;
 
     FSFPowerChainNode()

--- a/Source/SmartFoundations/Public/Features/Scaling/SFScalingSpec.h
+++ b/Source/SmartFoundations/Public/Features/Scaling/SFScalingSpec.h
@@ -23,38 +23,71 @@
  * and SFHUDTypes.h already includes SFScalingTypes.h for the scale-axis enums — putting the spec in
  * SFScalingTypes.h would form an include cycle.
  */
+/** Which auto-connect family a staged conduit plan entry belongs to - selects the replay recipe
+ *  (hologram class, tags, registry data) so the existing family-specific Construct wiring runs. */
+UENUM()
+enum class ESFConduitPlanKind : uint8
+{
+	Belt,            // distributor auto-connect belt (SF_BeltAutoConnectChild)
+	Pipe,            // junction / floor-hole auto-connect pipe (SF_PipeAutoConnectChild)
+	StackableBelt,   // stacked-pole belt (SF_StackableChild)
+	StackablePipe,   // stacked-support pipe (SF_StackableChild)
+	Wire             // power auto-connect wire (SF_PowerAutoConnectChild)
+};
+
 /**
- * One auto-connect belt of the staged wiring plan (#334). Captured CLIENT-side at fire time from the
- * live belt preview hologram - the only party that ever holds the complete, real plan (server-side
- * re-derivation and aim-time-preview reuse both failed live; see PLAN_MP_AutoConnect_334.md). The
- * server replays each entry as a fresh ASFConveyorBeltHologram child appended AFTER the grid cells,
- * so the vanilla child-construct loop builds it and the SF_BeltAutoConnectChild Construct path wires
- * it geometrically (nearest free connector within 50cm, BUILT actors only) - no connector names or
- * replicated component refs need to cross the wire.
+ * One auto-connect conduit (belt / pipe / wire) of the staged wiring plan (#334). Captured
+ * CLIENT-side at fire time from the live preview child holograms - the only party that ever holds
+ * the complete, real plan (server-side re-derivation and aim-time-preview reuse both failed live;
+ * see PLAN_MP_AutoConnect_334.md). The server replays each entry as a fresh tagged child hologram
+ * appended AFTER the grid cells, so the vanilla child-construct loop builds it and the family's
+ * existing post-build wiring path connects it geometrically against BUILT actors - no connector
+ * names or replicated component refs need to cross the wire. Wires are the exception: their two
+ * endpoint connection components are resolved by WORLD LOCATION against the pre-construct hologram
+ * set (vanilla remaps hologram connections to built poles during construct, the SP mechanism).
  */
 USTRUCT()
-struct SMARTFOUNDATIONS_API FSFBeltPlanEntry
+struct SMARTFOUNDATIONS_API FSFConduitPlanEntry
 {
 	GENERATED_BODY()
 
-	/** Belt buildable class (tier) of the preview hologram. */
 	UPROPERTY()
-	TSubclassOf<class AFGBuildable> BeltClass = nullptr;
+	ESFConduitPlanKind Kind = ESFConduitPlanKind::Belt;
 
-	/** Belt recipe (cost basis + dismantle refund identity). */
+	/** Buildable class (tier) of the preview hologram. */
+	UPROPERTY()
+	TSubclassOf<class AFGBuildable> BuildClass = nullptr;
+
+	/** Recipe (cost basis + dismantle refund identity). */
 	UPROPERTY()
 	TSubclassOf<class UFGRecipe> Recipe = nullptr;
 
-	/** World transform of the belt hologram (spline points below are local to it). */
+	/** World transform of the conduit hologram (spline points below are local to it). */
 	UPROPERTY()
 	FVector Location = FVector::ZeroVector;
 
 	UPROPERTY()
 	FRotator Rotation = FRotator::ZeroRotator;
 
-	/** Routed spline, local space - exactly what the client preview committed to. */
+	/** Routed spline, local space - exactly what the client preview committed to. Empty for Wire. */
 	UPROPERTY()
 	TArray<FSplinePointData> SplinePoints;
+
+	/** Wire only: world locations of the two endpoint power connections at capture time. */
+	UPROPERTY()
+	FVector WireStart = FVector::ZeroVector;
+
+	UPROPERTY()
+	FVector WireEnd = FVector::ZeroVector;
+
+	/** Pipe only: floor-hole (passthrough) pipe - replay leaves the junction-connector registry
+	 *  field null so the floor-hole Construct branch (passthrough snap registration) runs. */
+	UPROPERTY()
+	bool bFloorHolePipe = false;
+
+	/** Stackable kinds: position in the run (registry StackableBeltIndex / StackablePipeIndex). */
+	UPROPERTY()
+	int32 StackIndex = -1;
 };
 
 USTRUCT()
@@ -83,16 +116,17 @@ struct SMARTFOUNDATIONS_API FSFScalingSpec
 	UPROPERTY()
 	bool bValid = false;
 
-	/** Auto-connect belt wiring plan (#334), captured from the client's live previews at fire time.
-	 *  May be non-empty even for a 1-cell spec (a single distributor with belts). */
+	/** Auto-connect conduit wiring plan (#334) - belts, pipes, stackable runs, power wires -
+	 *  captured from the client's live previews at fire time. May be non-empty even for a 1-cell
+	 *  spec (a single distributor/junction/pole with previews). */
 	UPROPERTY()
-	TArray<FSFBeltPlanEntry> BeltPlan;
+	TArray<FSFConduitPlanEntry> ConduitPlan;
 
-	/** Aggregated cost of the planned belts - the EXACT vanilla length-based preview costs, summed
-	 *  client-side per item class. The server's GetCost hook appends this so the staged belts are
-	 *  charged with the grid (server-built belts were previously free - known interim gap, closed). */
+	/** Aggregated cost of the planned conduits - the EXACT vanilla preview costs (length-based for
+	 *  belts/pipes, span-based for wires), summed client-side per item class. The server's GetCost
+	 *  hook appends this so the staged conduits are charged with the grid. */
 	UPROPERTY()
-	TArray<FItemAmount> BeltPlanCost;
+	TArray<FItemAmount> ConduitPlanCost;
 
 	/** Total cells described by the spec (product of |counters|, each treated as >=1). */
 	int32 CellCount() const

--- a/Source/SmartFoundations/Public/Features/Scaling/SFScalingSpec.h
+++ b/Source/SmartFoundations/Public/Features/Scaling/SFScalingSpec.h
@@ -5,6 +5,8 @@
 
 #include "CoreMinimal.h"
 #include "HUD/SFHUDTypes.h"   // FSFCounterState (grid + transform counters)
+#include "Components/SplineComponent.h"   // FSplinePointData (CSS engine addition)
+#include "ItemAmount.h"                    // FItemAmount (belt plan cost)
 #include "SFScalingSpec.generated.h"
 
 /**
@@ -21,6 +23,40 @@
  * and SFHUDTypes.h already includes SFScalingTypes.h for the scale-axis enums — putting the spec in
  * SFScalingTypes.h would form an include cycle.
  */
+/**
+ * One auto-connect belt of the staged wiring plan (#334). Captured CLIENT-side at fire time from the
+ * live belt preview hologram - the only party that ever holds the complete, real plan (server-side
+ * re-derivation and aim-time-preview reuse both failed live; see PLAN_MP_AutoConnect_334.md). The
+ * server replays each entry as a fresh ASFConveyorBeltHologram child appended AFTER the grid cells,
+ * so the vanilla child-construct loop builds it and the SF_BeltAutoConnectChild Construct path wires
+ * it geometrically (nearest free connector within 50cm, BUILT actors only) - no connector names or
+ * replicated component refs need to cross the wire.
+ */
+USTRUCT()
+struct SMARTFOUNDATIONS_API FSFBeltPlanEntry
+{
+	GENERATED_BODY()
+
+	/** Belt buildable class (tier) of the preview hologram. */
+	UPROPERTY()
+	TSubclassOf<class AFGBuildable> BeltClass = nullptr;
+
+	/** Belt recipe (cost basis + dismantle refund identity). */
+	UPROPERTY()
+	TSubclassOf<class UFGRecipe> Recipe = nullptr;
+
+	/** World transform of the belt hologram (spline points below are local to it). */
+	UPROPERTY()
+	FVector Location = FVector::ZeroVector;
+
+	UPROPERTY()
+	FRotator Rotation = FRotator::ZeroRotator;
+
+	/** Routed spline, local space - exactly what the client preview committed to. */
+	UPROPERTY()
+	TArray<FSplinePointData> SplinePoints;
+};
+
 USTRUCT()
 struct SMARTFOUNDATIONS_API FSFScalingSpec
 {
@@ -46,6 +82,17 @@ struct SMARTFOUNDATIONS_API FSFScalingSpec
 	/** True once populated from a live grid; the server only expands when valid. */
 	UPROPERTY()
 	bool bValid = false;
+
+	/** Auto-connect belt wiring plan (#334), captured from the client's live previews at fire time.
+	 *  May be non-empty even for a 1-cell spec (a single distributor with belts). */
+	UPROPERTY()
+	TArray<FSFBeltPlanEntry> BeltPlan;
+
+	/** Aggregated cost of the planned belts - the EXACT vanilla length-based preview costs, summed
+	 *  client-side per item class. The server's GetCost hook appends this so the staged belts are
+	 *  charged with the grid (server-built belts were previously free - known interim gap, closed). */
+	UPROPERTY()
+	TArray<FItemAmount> BeltPlanCost;
 
 	/** Total cells described by the spec (product of |counters|, each treated as >=1). */
 	int32 CellCount() const

--- a/Source/SmartFoundations/Public/Features/Scaling/SFScalingSpec.h
+++ b/Source/SmartFoundations/Public/Features/Scaling/SFScalingSpec.h
@@ -1,0 +1,53 @@
+// Copyright (c) 2025-present Finalomega. All rights reserved. See LICENSE.md.
+// Smart! Mod - Multiplayer scaling construction spec
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "HUD/SFHUDTypes.h"   // FSFCounterState (grid + transform counters)
+#include "SFScalingSpec.generated.h"
+
+/**
+ * Compact, fixed-size description of a Smart! scaling grid, sufficient to RECONSTRUCT the entire
+ * grid server-side. This is the O(1) "intent" payload of the multiplayer construction model
+ * (docs/Features/Multiplayer/DESIGN_MP_ConstructionModel.md): instead of serializing N child
+ * holograms across the wire (the 64KB ceiling), the client ships this spec on the parent hologram
+ * and the server expands it into N buildables via FSFPositionCalculator + the normal child-construct
+ * path. Scaling grids are UNIFORM, so the recipe / build class / base transform come from the parent
+ * hologram itself (vanilla-serialized); this spec only needs the grid + transform counters and the
+ * per-cell sizing the position calculator requires.
+ *
+ * Lives in its own header (not SFScalingTypes.h) because it depends on FSFCounterState (SFHUDTypes.h),
+ * and SFHUDTypes.h already includes SFScalingTypes.h for the scale-axis enums — putting the spec in
+ * SFScalingTypes.h would form an include cycle.
+ */
+USTRUCT()
+struct SMARTFOUNDATIONS_API FSFScalingSpec
+{
+	GENERATED_BODY()
+
+	/** Grid dimensions + spacing/steps/stagger/rotation. Drives FSFPositionCalculator per cell. */
+	UPROPERTY()
+	FSFCounterState Counters;
+
+	/** Cell size used by the position calculator (from the buildable size registry at capture time). */
+	UPROPERTY()
+	FVector ItemSize = FVector::ZeroVector;
+
+	/** Attachment anchor compensation (from the size registry at capture time). */
+	UPROPERTY()
+	FVector AnchorOffset = FVector::ZeroVector;
+
+	/** True once populated from a live grid; the server only expands when valid. */
+	UPROPERTY()
+	bool bValid = false;
+
+	/** Total cells described by the spec (product of |counters|, each treated as >=1). */
+	int32 CellCount() const
+	{
+		const int32 X = FMath::Max(1, FMath::Abs(Counters.GridCounters.X));
+		const int32 Y = FMath::Max(1, FMath::Abs(Counters.GridCounters.Y));
+		const int32 Z = FMath::Max(1, FMath::Abs(Counters.GridCounters.Z));
+		return X * Y * Z;
+	}
+};

--- a/Source/SmartFoundations/Public/Features/Scaling/SFScalingSpec.h
+++ b/Source/SmartFoundations/Public/Features/Scaling/SFScalingSpec.h
@@ -38,6 +38,11 @@ struct SMARTFOUNDATIONS_API FSFScalingSpec
 	UPROPERTY()
 	FVector AnchorOffset = FVector::ZeroVector;
 
+	/** Build class of the uniform grid - the server only consumes a staged spec for a construct of
+	 *  the SAME class (guards against any client/server fire mismatch or RPC race). */
+	UPROPERTY()
+	TSubclassOf<class AFGBuildable> BuildClass = nullptr;
+
 	/** True once populated from a live grid; the server only expands when valid. */
 	UPROPERTY()
 	bool bValid = false;

--- a/Source/SmartFoundations/Public/Features/Upgrade/SFUpgradeExecutionService.h
+++ b/Source/SmartFoundations/Public/Features/Upgrade/SFUpgradeExecutionService.h
@@ -135,6 +135,11 @@ public:
 	UFUNCTION(BlueprintCallable, Category = "SmartFoundations|Upgrade")
 	void CancelUpgrade();
 
+	/** [UPGRADE-MP] Client-side: install a server-executed result and broadcast completion, so
+	 *  panel delegates bound to this (local) service fire exactly as in SP. Mirrors
+	 *  USFUpgradeAuditService::InjectAuditResult. */
+	void InjectUpgradeResult(const FSFUpgradeExecutionResult& Result);
+
 	/** Check if upgrade is in progress */
 	UFUNCTION(BlueprintPure, Category = "SmartFoundations|Upgrade")
 	bool IsUpgradeInProgress() const { return bUpgradeInProgress; }

--- a/Source/SmartFoundations/Public/Features/Upgrade/SFUpgradeTraversalService.h
+++ b/Source/SmartFoundations/Public/Features/Upgrade/SFUpgradeTraversalService.h
@@ -68,8 +68,9 @@ struct FSFTraversalResult
 	UPROPERTY()
 	TArray<FSFUpgradeAuditEntry> Entries;
 
-	/** Count by tier */
-	UPROPERTY()
+	/** Count by tier. NotReplicated: UHT forbids TMaps in RPC structs; this never crosses the
+	 *  wire - InjectTraversalResult recomputes it from Entries on the client ([UPGRADE-MP]). */
+	UPROPERTY(NotReplicated)
 	TMap<int32, int32> CountByTier;
 
 	/** Total count of buildables in network */
@@ -92,6 +93,9 @@ struct FSFTraversalResult
 	bool IsValid() const { return Family != ESFUpgradeFamily::None && ErrorMessage.IsEmpty(); }
 };
 
+/** [UPGRADE-MP] Native delegate for server-walked traversal results delivered to a client. */
+DECLARE_MULTICAST_DELEGATE_OneParam(FSFOnTraversalResultReceived, const FSFTraversalResult&);
+
 /**
  * Service for traversing connected buildable networks
  * Used by the Upgrade Panel to find all buildables in a connected system
@@ -102,6 +106,16 @@ class SMARTFOUNDATIONS_API USFUpgradeTraversalService : public UObject
 	GENERATED_BODY()
 
 public:
+	/** [UPGRADE-MP] Broadcast on the CLIENT when a server-walked traversal result arrives via
+	 *  USFRCO::Client_ReceiveTraversalResult. Static because the panel news up a throwaway
+	 *  traversal service per scan - there is no shared instance to route through. Subscribers
+	 *  (the Upgrade Panel) must RemoveAll(this) on destruction. */
+	static FSFOnTraversalResultReceived OnClientTraversalResultReceived;
+
+	/** [UPGRADE-MP] Client-side: normalize and broadcast a server-walked result. CountByTier is
+	 *  recomputed from Entries (a TMap UPROPERTY is not reliably serialized across an RPC). */
+	static void InjectTraversalResult(FSFTraversalResult Result);
+
 	/**
 	 * Traverse a network starting from an anchor buildable
 	 * @param AnchorBuildable The starting point for traversal

--- a/Source/SmartFoundations/Public/Holograms/Core/SFFactoryHologram.h
+++ b/Source/SmartFoundations/Public/Holograms/Core/SFFactoryHologram.h
@@ -5,7 +5,6 @@
 #include "CoreMinimal.h"
 #include "SFBuildableHologram.h"
 #include "Hologram/FGFactoryHologram.h"
-#include "Features/Scaling/SFScalingSpec.h"  // FSFScalingSpec (MP spec-based construction)
 #include "SFFactoryHologram.generated.h"
 
 /**
@@ -47,36 +46,12 @@ public:
      */
     void InitializeFromHologram(AFGHologram* SourceHologram);
 
-    // ── Multiplayer spec-based construction (docs/Features/Multiplayer/DESIGN_MP_ConstructionModel.md)
-    // The client populates a compact FSFScalingSpec describing the whole grid; on a remote client
-    // fire the grid children are stripped from the wire (PreConstructMessageSerialization) so the
-    // construct message stays O(1); the server regenerates the children from the spec
-    // (PostConstructMessageDeserialization) before vanilla cost-aggregation + Construct run, so both
-    // reuse proven machinery. All gated behind the `sf.MP.SpecConstruction` console variable.
-
-    /** Set by the scaling activation path whenever the grid changes; the authoritative spec to expand. */
-    void SetScalingSpec(const FSFScalingSpec& InSpec) { mScalingSpec = InSpec; }
-    const FSFScalingSpec& GetScalingSpec() const { return mScalingSpec; }
-
-    /** Client: strip grid children from the serialized construct message (keep the spec only). */
-    virtual void PreConstructMessageSerialization() override;
-    /** Client (saving): after the message bytes are written, restore the stripped children into
-     *  mChildren so the post-fire hologram teardown destroys the previews normally (no orphans). */
-    virtual void SerializeConstructMessage(FArchive& ar, FNetConstructionID id) override;
-
-    /** Spec path: at server cost-charge time the grid children do not exist yet (they are expanded
-     *  inside Construct, AFTER validation), so scale the uniform per-cell cost by the cell count. */
-    virtual TArray<FItemAmount> GetCost(bool includeChildren) const override;
+    // (The MP spec-based construction machinery that briefly lived on this class - spec UPROPERTY,
+    // Pre/SerializeConstructMessage overrides, GetCost scaling, Construct expansion - moved to the
+    // class-agnostic hook path in USFGameInstanceModule::RegisterSpecConstructionHooks + the
+    // hologram data registry, so it covers every scalable buildable without hologram swaps.)
 
 protected:
-    /** Compact grid description, replicated/serialized with the construct message (CustomSerialization). */
-    UPROPERTY(CustomSerialization)
-    FSFScalingSpec mScalingSpec;
-
-    /** Children temporarily detached from mChildren during client serialization (kept off the wire). */
-    UPROPERTY(Transient)
-    TArray<TObjectPtr<class AFGHologram>> mStashedSpecChildren;
-
     // Recipe copying implementation
     virtual void ApplyStoredRecipe(AActor* Building) const;
     virtual bool IsProductionBuilding(AActor* Building) const;

--- a/Source/SmartFoundations/Public/Holograms/Core/SFFactoryHologram.h
+++ b/Source/SmartFoundations/Public/Holograms/Core/SFFactoryHologram.h
@@ -63,8 +63,10 @@ public:
     /** Client (saving): after the message bytes are written, restore the stripped children into
      *  mChildren so the post-fire hologram teardown destroys the previews normally (no orphans). */
     virtual void SerializeConstructMessage(FArchive& ar, FNetConstructionID id) override;
-    /** Server: regenerate the grid children from the spec before cost/Construct. */
-    virtual void PostConstructMessageDeserialization() override;
+
+    /** Spec path: at server cost-charge time the grid children do not exist yet (they are expanded
+     *  inside Construct, AFTER validation), so scale the uniform per-cell cost by the cell count. */
+    virtual TArray<FItemAmount> GetCost(bool includeChildren) const override;
 
 protected:
     /** Compact grid description, replicated/serialized with the construct message (CustomSerialization). */

--- a/Source/SmartFoundations/Public/Holograms/Core/SFFactoryHologram.h
+++ b/Source/SmartFoundations/Public/Holograms/Core/SFFactoryHologram.h
@@ -64,10 +64,6 @@ public:
     virtual void PostConstructMessageDeserialization() override;
 
 protected:
-    /** Server-side expansion: spawn one child hologram per non-origin grid cell from mScalingSpec,
-     *  positioned via USFPositionCalculator, parented via the vanilla SpawnChildHologramFromRecipe. */
-    void ExpandScalingSpecIntoChildren();
-
     /** Compact grid description, replicated/serialized with the construct message (CustomSerialization). */
     UPROPERTY(CustomSerialization)
     FSFScalingSpec mScalingSpec;

--- a/Source/SmartFoundations/Public/Holograms/Core/SFFactoryHologram.h
+++ b/Source/SmartFoundations/Public/Holograms/Core/SFFactoryHologram.h
@@ -60,6 +60,9 @@ public:
 
     /** Client: strip grid children from the serialized construct message (keep the spec only). */
     virtual void PreConstructMessageSerialization() override;
+    /** Client (saving): after the message bytes are written, restore the stripped children into
+     *  mChildren so the post-fire hologram teardown destroys the previews normally (no orphans). */
+    virtual void SerializeConstructMessage(FArchive& ar, FNetConstructionID id) override;
     /** Server: regenerate the grid children from the spec before cost/Construct. */
     virtual void PostConstructMessageDeserialization() override;
 

--- a/Source/SmartFoundations/Public/Holograms/Core/SFFactoryHologram.h
+++ b/Source/SmartFoundations/Public/Holograms/Core/SFFactoryHologram.h
@@ -5,6 +5,7 @@
 #include "CoreMinimal.h"
 #include "SFBuildableHologram.h"
 #include "Hologram/FGFactoryHologram.h"
+#include "Features/Scaling/SFScalingSpec.h"  // FSFScalingSpec (MP spec-based construction)
 #include "SFFactoryHologram.generated.h"
 
 /**
@@ -46,7 +47,35 @@ public:
      */
     void InitializeFromHologram(AFGHologram* SourceHologram);
 
+    // ── Multiplayer spec-based construction (docs/Features/Multiplayer/DESIGN_MP_ConstructionModel.md)
+    // The client populates a compact FSFScalingSpec describing the whole grid; on a remote client
+    // fire the grid children are stripped from the wire (PreConstructMessageSerialization) so the
+    // construct message stays O(1); the server regenerates the children from the spec
+    // (PostConstructMessageDeserialization) before vanilla cost-aggregation + Construct run, so both
+    // reuse proven machinery. All gated behind the `sf.MP.SpecConstruction` console variable.
+
+    /** Set by the scaling activation path whenever the grid changes; the authoritative spec to expand. */
+    void SetScalingSpec(const FSFScalingSpec& InSpec) { mScalingSpec = InSpec; }
+    const FSFScalingSpec& GetScalingSpec() const { return mScalingSpec; }
+
+    /** Client: strip grid children from the serialized construct message (keep the spec only). */
+    virtual void PreConstructMessageSerialization() override;
+    /** Server: regenerate the grid children from the spec before cost/Construct. */
+    virtual void PostConstructMessageDeserialization() override;
+
 protected:
+    /** Server-side expansion: spawn one child hologram per non-origin grid cell from mScalingSpec,
+     *  positioned via USFPositionCalculator, parented via the vanilla SpawnChildHologramFromRecipe. */
+    void ExpandScalingSpecIntoChildren();
+
+    /** Compact grid description, replicated/serialized with the construct message (CustomSerialization). */
+    UPROPERTY(CustomSerialization)
+    FSFScalingSpec mScalingSpec;
+
+    /** Children temporarily detached from mChildren during client serialization (kept off the wire). */
+    UPROPERTY(Transient)
+    TArray<TObjectPtr<class AFGHologram>> mStashedSpecChildren;
+
     // Recipe copying implementation
     virtual void ApplyStoredRecipe(AActor* Building) const;
     virtual bool IsProductionBuilding(AActor* Building) const;

--- a/Source/SmartFoundations/Public/Holograms/Core/SFFoundationHologram.h
+++ b/Source/SmartFoundations/Public/Holograms/Core/SFFoundationHologram.h
@@ -5,11 +5,17 @@
 #include "CoreMinimal.h"
 #include "SFBuildableHologram.h"
 #include "Hologram/FGFoundationHologram.h"
+#include "Features/Scaling/SFScalingSpec.h"  // FSFScalingSpec (MP spec-based construction)
 #include "SFFoundationHologram.generated.h"
 
 /**
  * Base class for all Smart foundation holograms.
  * Handles foundation-specific validation and grid snapping.
+ *
+ * Also the spec-capable scaling parent for FOUNDATION grids in multiplayer: mirrors
+ * ASFFactoryHologram's spec hooks (capture + strip client-side, regenerate server-side), delegating
+ * the shared logic to SFScalingSpecExpansion. The plain-scaling swap in RegisterActiveHologram picks
+ * this class for foundation-family holograms (production buildings use ASFFactoryHologram).
  */
 UCLASS()
 class SMARTFOUNDATIONS_API ASFFoundationHologram : public AFGFoundationHologram
@@ -23,11 +29,31 @@ public:
     virtual void BeginPlay() override;
     virtual void ConfigureActor(AFGBuildable* InBuildable) const override;
 
+    /** Copy mBuildClass/mRecipe from the vanilla hologram being swapped out (call before FinishSpawning). */
+    void InitializeFromHologram(AFGHologram* SourceHologram);
+
+    // ── Multiplayer spec-based construction (see ASFFactoryHologram for the model description)
+    void SetScalingSpec(const FSFScalingSpec& InSpec) { mScalingSpec = InSpec; }
+    const FSFScalingSpec& GetScalingSpec() const { return mScalingSpec; }
+
+    /** Client: capture the grid spec + strip grid children from the serialized construct message. */
+    virtual void PreConstructMessageSerialization() override;
+    /** Server: regenerate the grid children from the spec before cost/Construct. */
+    virtual void PostConstructMessageDeserialization() override;
+
 protected:
+    /** Compact grid description, replicated/serialized with the construct message (CustomSerialization). */
+    UPROPERTY(CustomSerialization)
+    FSFScalingSpec mScalingSpec;
+
+    /** Children temporarily detached from mChildren during client serialization (kept off the wire). */
+    UPROPERTY(Transient)
+    TArray<TObjectPtr<class AFGHologram>> mStashedSpecChildren;
+
     // Foundation validation and snapping
     virtual void ValidateFoundationPlacement();
     virtual void ApplyFoundationSnapping();
-    
+
     // Common helper functions
     virtual void LogSmartActivity(const FString& Activity) const;
 };

--- a/Source/SmartFoundations/Public/Holograms/Core/SFFoundationHologram.h
+++ b/Source/SmartFoundations/Public/Holograms/Core/SFFoundationHologram.h
@@ -41,8 +41,13 @@ public:
     /** Client (saving): after the message bytes are written, restore the stripped children into
      *  mChildren so the post-fire hologram teardown destroys the previews normally (no orphans). */
     virtual void SerializeConstructMessage(FArchive& ar, FNetConstructionID id) override;
-    /** Server: regenerate the grid children from the spec before cost/Construct. */
-    virtual void PostConstructMessageDeserialization() override;
+
+    /** Spec path: at server cost-charge time the grid children do not exist yet (they are expanded
+     *  inside Construct, AFTER validation), so scale the uniform per-cell cost by the cell count. */
+    virtual TArray<FItemAmount> GetCost(bool includeChildren) const override;
+
+    /** Server: expand the grid children from the spec post-validation, then construct normally. */
+    virtual AActor* Construct(TArray<AActor*>& out_children, FNetConstructionID constructionID) override;
 
 protected:
     /** Compact grid description, replicated/serialized with the construct message (CustomSerialization). */

--- a/Source/SmartFoundations/Public/Holograms/Core/SFFoundationHologram.h
+++ b/Source/SmartFoundations/Public/Holograms/Core/SFFoundationHologram.h
@@ -38,6 +38,9 @@ public:
 
     /** Client: capture the grid spec + strip grid children from the serialized construct message. */
     virtual void PreConstructMessageSerialization() override;
+    /** Client (saving): after the message bytes are written, restore the stripped children into
+     *  mChildren so the post-fire hologram teardown destroys the previews normally (no orphans). */
+    virtual void SerializeConstructMessage(FArchive& ar, FNetConstructionID id) override;
     /** Server: regenerate the grid children from the spec before cost/Construct. */
     virtual void PostConstructMessageDeserialization() override;
 

--- a/Source/SmartFoundations/Public/Holograms/Core/SFFoundationHologram.h
+++ b/Source/SmartFoundations/Public/Holograms/Core/SFFoundationHologram.h
@@ -5,17 +5,11 @@
 #include "CoreMinimal.h"
 #include "SFBuildableHologram.h"
 #include "Hologram/FGFoundationHologram.h"
-#include "Features/Scaling/SFScalingSpec.h"  // FSFScalingSpec (MP spec-based construction)
 #include "SFFoundationHologram.generated.h"
 
 /**
  * Base class for all Smart foundation holograms.
  * Handles foundation-specific validation and grid snapping.
- *
- * Also the spec-capable scaling parent for FOUNDATION grids in multiplayer: mirrors
- * ASFFactoryHologram's spec hooks (capture + strip client-side, regenerate server-side), delegating
- * the shared logic to SFScalingSpecExpansion. The plain-scaling swap in RegisterActiveHologram picks
- * this class for foundation-family holograms (production buildings use ASFFactoryHologram).
  */
 UCLASS()
 class SMARTFOUNDATIONS_API ASFFoundationHologram : public AFGFoundationHologram
@@ -29,35 +23,7 @@ public:
     virtual void BeginPlay() override;
     virtual void ConfigureActor(AFGBuildable* InBuildable) const override;
 
-    /** Copy mBuildClass/mRecipe from the vanilla hologram being swapped out (call before FinishSpawning). */
-    void InitializeFromHologram(AFGHologram* SourceHologram);
-
-    // ── Multiplayer spec-based construction (see ASFFactoryHologram for the model description)
-    void SetScalingSpec(const FSFScalingSpec& InSpec) { mScalingSpec = InSpec; }
-    const FSFScalingSpec& GetScalingSpec() const { return mScalingSpec; }
-
-    /** Client: capture the grid spec + strip grid children from the serialized construct message. */
-    virtual void PreConstructMessageSerialization() override;
-    /** Client (saving): after the message bytes are written, restore the stripped children into
-     *  mChildren so the post-fire hologram teardown destroys the previews normally (no orphans). */
-    virtual void SerializeConstructMessage(FArchive& ar, FNetConstructionID id) override;
-
-    /** Spec path: at server cost-charge time the grid children do not exist yet (they are expanded
-     *  inside Construct, AFTER validation), so scale the uniform per-cell cost by the cell count. */
-    virtual TArray<FItemAmount> GetCost(bool includeChildren) const override;
-
-    /** Server: expand the grid children from the spec post-validation, then construct normally. */
-    virtual AActor* Construct(TArray<AActor*>& out_children, FNetConstructionID constructionID) override;
-
 protected:
-    /** Compact grid description, replicated/serialized with the construct message (CustomSerialization). */
-    UPROPERTY(CustomSerialization)
-    FSFScalingSpec mScalingSpec;
-
-    /** Children temporarily detached from mChildren during client serialization (kept off the wire). */
-    UPROPERTY(Transient)
-    TArray<TObjectPtr<class AFGHologram>> mStashedSpecChildren;
-
     // Foundation validation and snapping
     virtual void ValidateFoundationPlacement();
     virtual void ApplyFoundationSnapping();

--- a/Source/SmartFoundations/Public/Module/SFGameInstanceModule.h
+++ b/Source/SmartFoundations/Public/Module/SFGameInstanceModule.h
@@ -52,6 +52,17 @@ protected:
 	 */
 	void RegisterClientConstructChunkGuardHook();
 
+	/**
+	 * MP Slice 0 chunking. Hooks UFGBuildGunStateBuild::InternalExecuteDuBuildStepInput (the client fire
+	 * handler, BEFORE vanilla serializes the construct). For an oversized client scaled grid, slices the
+	 * active hologram's child list down to a chunk that fits one 64KB Server_ConstructHologram before vanilla
+	 * serializes it, so the construct succeeds instead of being dropped. Increment 1 builds a single chunk
+	 * (proof of the shrink-then-vanilla-serialize mechanic); Increment 2 loops the remaining chunks. The
+	 * Server_ConstructHologram guard remains as a backstop. Accesses mChildren via the USFGameInstanceModule
+	 * friend AccessTransformer. Engages only for NM_Client + Smart grids; everything else is untouched.
+	 */
+	void RegisterClientGridChunkFireHook();
+
 	/** Smart! Configuration blueprint - registered with SML for in-game menu access */
 	UPROPERTY(EditDefaultsOnly, BlueprintReadWrite, Category = "Smart! Configuration")
 	TSubclassOf<class UModConfiguration> SmartConfigClass;

--- a/Source/SmartFoundations/Public/Module/SFGameInstanceModule.h
+++ b/Source/SmartFoundations/Public/Module/SFGameInstanceModule.h
@@ -70,6 +70,13 @@ protected:
 	 */
 	static void SetActiveHologramChildren(class AFGHologram* Holo, const TArray<class AFGHologram*>& NewChildren);
 
+	/**
+	 * Core-ticker callback that fires the queued MP grid chunks one-per-frame. A static member so it inherits
+	 * the friend access to UFGBuildGunStateBuild::InternalExecuteDuBuildStepInput (AccessTransformers.ini).
+	 * Returns true to keep ticking, false to unregister.
+	 */
+	static bool TickPendingGridChunks(float Dt);
+
 	/** Smart! Configuration blueprint - registered with SML for in-game menu access */
 	UPROPERTY(EditDefaultsOnly, BlueprintReadWrite, Category = "Smart! Configuration")
 	TSubclassOf<class UModConfiguration> SmartConfigClass;

--- a/Source/SmartFoundations/Public/Module/SFGameInstanceModule.h
+++ b/Source/SmartFoundations/Public/Module/SFGameInstanceModule.h
@@ -38,6 +38,19 @@ protected:
 	 */
 	void RegisterBeltSupportConstructHook();
 
+	/**
+	 * Multiplayer Slice 0 (Phase 1 - construct chunk guard). Hooks UFGBuildGunStateBuild::InternalConstructHologram
+	 * on the CLIENT. A Smart scaled grid commits as a single reliable Server_ConstructHologram RPC carrying the
+	 * parent + all child holograms serialized into one blob; past an engine byte ceiling (empirical ~135 cells)
+	 * that RPC is dropped at the net layer -> all-or-nothing failure with orphaned previews (no failure callback
+	 * fires because the server never processed it). This guard cancels the oversized construct BEFORE it is sent,
+	 * so nothing orphans (the preview stays as the live active hologram) and the player is told to build in
+	 * smaller sections. Engages only for a network client (NM_Client) above the safe cell count; single-player,
+	 * listen-server host, dedicated-server authority, and small grids take the untouched vanilla path.
+	 * (Phase 2 will auto-chunk the placement instead of refusing it.)
+	 */
+	void RegisterClientConstructChunkGuardHook();
+
 	/** Smart! Configuration blueprint - registered with SML for in-game menu access */
 	UPROPERTY(EditDefaultsOnly, BlueprintReadWrite, Category = "Smart! Configuration")
 	TSubclassOf<class UModConfiguration> SmartConfigClass;

--- a/Source/SmartFoundations/Public/Module/SFGameInstanceModule.h
+++ b/Source/SmartFoundations/Public/Module/SFGameInstanceModule.h
@@ -53,29 +53,15 @@ protected:
 	void RegisterClientConstructChunkGuardHook();
 
 	/**
-	 * MP Slice 0 chunking. Hooks UFGBuildGunStateBuild::InternalExecuteDuBuildStepInput (the client fire
-	 * handler, BEFORE vanilla serializes the construct). For an oversized client scaled grid, slices the
-	 * active hologram's child list down to a chunk that fits one 64KB Server_ConstructHologram before vanilla
-	 * serializes it, so the construct succeeds instead of being dropped. Increment 1 builds a single chunk
-	 * (proof of the shrink-then-vanilla-serialize mechanic); Increment 2 loops the remaining chunks. The
-	 * Server_ConstructHologram guard remains as a backstop. Accesses mChildren via the USFGameInstanceModule
-	 * friend AccessTransformer. Engages only for NM_Client + Smart grids; everything else is untouched.
+	 * MP Slice 0 SAFETY GUARD. Hooks UFGBuildGunStateBuild::InternalExecuteDuBuildStepInput (the client fire
+	 * handler, BEFORE vanilla serializes the construct). For an oversized client scaled grid (one that can't
+	 * fit a single 64KB Server_ConstructHologram), it cancels the fire so nothing is serialized or sent - the
+	 * grid stays live for the player to scale down. This prevents the orphaned-preview/dropped-RPC bug AND the
+	 * server crash that hand-built chunk messages cause. It is NOT a large-grid MP feature (those constructs
+	 * are not safely achievable today - see the method body and AGENTS.md). Engages only for NM_Client + Smart
+	 * grids (tagged SF_GridChild); vanilla placements and blueprints are untouched.
 	 */
 	void RegisterClientGridChunkFireHook();
-
-	/**
-	 * Set the active hologram's child list to exactly the given holograms (replacing mChildren and the name
-	 * lookup map). A static member so it inherits USFGameInstanceModule's friend access to AFGHologram's
-	 * protected child members (see AccessTransformers.ini). Used by the MP chunk loop.
-	 */
-	static void SetActiveHologramChildren(class AFGHologram* Holo, const TArray<class AFGHologram*>& NewChildren);
-
-	/**
-	 * Core-ticker callback that fires the queued MP grid chunks one-per-frame. A static member so it inherits
-	 * the friend access to UFGBuildGunStateBuild::InternalExecuteDuBuildStepInput (AccessTransformers.ini).
-	 * Returns true to keep ticking, false to unregister.
-	 */
-	static bool TickPendingGridChunks(float Dt);
 
 	/** Smart! Configuration blueprint - registered with SML for in-game menu access */
 	UPROPERTY(EditDefaultsOnly, BlueprintReadWrite, Category = "Smart! Configuration")

--- a/Source/SmartFoundations/Public/Module/SFGameInstanceModule.h
+++ b/Source/SmartFoundations/Public/Module/SFGameInstanceModule.h
@@ -63,6 +63,13 @@ protected:
 	 */
 	void RegisterClientGridChunkFireHook();
 
+	/**
+	 * Set the active hologram's child list to exactly the given holograms (replacing mChildren and the name
+	 * lookup map). A static member so it inherits USFGameInstanceModule's friend access to AFGHologram's
+	 * protected child members (see AccessTransformers.ini). Used by the MP chunk loop.
+	 */
+	static void SetActiveHologramChildren(class AFGHologram* Holo, const TArray<class AFGHologram*>& NewChildren);
+
 	/** Smart! Configuration blueprint - registered with SML for in-game menu access */
 	UPROPERTY(EditDefaultsOnly, BlueprintReadWrite, Category = "Smart! Configuration")
 	TSubclassOf<class UModConfiguration> SmartConfigClass;

--- a/Source/SmartFoundations/Public/Module/SFGameInstanceModule.h
+++ b/Source/SmartFoundations/Public/Module/SFGameInstanceModule.h
@@ -63,6 +63,23 @@ protected:
 	 */
 	void RegisterClientGridChunkFireHook();
 
+	/**
+	 * MP spec-based scaling construction - CLASS-AGNOSTIC hook path (covers every scalable
+	 * buildable, including vanilla Blueprint hologram wrappers like Holo_Foundation_C, without
+	 * swapping the active hologram). Three hooks on vanilla virtual BODIES (they fire via the
+	 * Super chain from any subclass):
+	 *  - AFGHologram::SerializeConstructMessage: saving = capture spec + strip SF_GridChild
+	 *    children -> original writes the O(1) message -> append spec -> restore children;
+	 *    loading = original reads -> read spec into the hologram data registry.
+	 *  - AFGHologram::Construct (before original runs): server expands the registry spec into
+	 *    children post-validation (fresh holograms cannot pass vanilla placement validation -
+	 *    live finding 2026-06-09).
+	 *  - AFGHologram::GetCost: server scales the per-cell cost by the cell count while the
+	 *    children do not exist yet (pre-Construct charge time).
+	 * Gated by sf.MP.SpecConstruction + USFBuildableSizeRegistry.bSupportsScaling.
+	 */
+	void RegisterSpecConstructionHooks();
+
 	/** Smart! Configuration blueprint - registered with SML for in-game menu access */
 	UPROPERTY(EditDefaultsOnly, BlueprintReadWrite, Category = "Smart! Configuration")
 	TSubclassOf<class UModConfiguration> SmartConfigClass;

--- a/Source/SmartFoundations/Public/Module/SFGameInstanceModule.h
+++ b/Source/SmartFoundations/Public/Module/SFGameInstanceModule.h
@@ -39,15 +39,16 @@ protected:
 	void RegisterBeltSupportConstructHook();
 
 	/**
-	 * Multiplayer Slice 0 (Phase 1 - construct chunk guard). Hooks UFGBuildGunStateBuild::InternalConstructHologram
-	 * on the CLIENT. A Smart scaled grid commits as a single reliable Server_ConstructHologram RPC carrying the
-	 * parent + all child holograms serialized into one blob; past an engine byte ceiling (empirical ~135 cells)
-	 * that RPC is dropped at the net layer -> all-or-nothing failure with orphaned previews (no failure callback
-	 * fires because the server never processed it). This guard cancels the oversized construct BEFORE it is sent,
-	 * so nothing orphans (the preview stays as the live active hologram) and the player is told to build in
-	 * smaller sections. Engages only for a network client (NM_Client) above the safe cell count; single-player,
-	 * listen-server host, dedicated-server authority, and small grids take the untouched vanilla path.
-	 * (Phase 2 will auto-chunk the placement instead of refusing it.)
+	 * Multiplayer Slice 0 (Phase 1 - construct chunk guard). Hooks UFGBuildGunStateBuild::Server_ConstructHologram
+	 * on the CLIENT (confirmed seam: the client calls this RPC directly; an earlier InternalConstructHologram hook
+	 * never fired). A Smart scaled grid serializes the parent + all child holograms into one
+	 * FConstructHologramMessage.SerializedHologramData blob; past an engine byte ceiling (~64KB, empirical ~135
+	 * cells) the RPC fails to marshal ("Failed to serialize properties") and is dropped -> all-or-nothing failure
+	 * with orphaned previews (no failure callback fires because the server never processed it). This guard reads
+	 * the ACTUAL serialized byte size and cancels the send for an oversized Smart-grid construct, so nothing
+	 * orphans (the preview stays live) and the player is told to build in smaller sections. Engages only for a
+	 * network client (NM_Client) and only for Smart grids (children tagged SF_GridChild) - vanilla placements and
+	 * blueprints are untouched. (Phase 2 will auto-chunk the placement instead of refusing it.)
 	 */
 	void RegisterClientConstructChunkGuardHook();
 

--- a/Source/SmartFoundations/Public/SFRCO.h
+++ b/Source/SmartFoundations/Public/SFRCO.h
@@ -6,7 +6,8 @@
 #include "FGRemoteCallObject.h"
 #include "Features/Spacing/SFSpacingTypes.h"
 #include "Features/Scaling/SFScalingSpec.h"
-#include "Features/Extend/SFExtendTypes.h"   // FSFExtendTopology ([EXTEND-MP] topology RCO)
+#include "Features/Extend/SFExtendTypes.h"      // FSFExtendTopology ([EXTEND-MP] topology RCO)
+#include "Features/Extend/SFExtendCommitSpec.h" // FSFExtendCommitSpec ([EXTEND-MP] commit staging)
 #include "Features/Upgrade/SFUpgradeExecutionService.h"
 #include "SFRCO.generated.h"
 
@@ -112,6 +113,15 @@ public:
 	 *  which the client caches briefly as a negative result to avoid request spam). */
 	UFUNCTION(Client, Reliable)
 	void Client_ReceiveExtendTopology(FSFExtendTopology Topology);
+
+	/**
+	 * [EXTEND-MP] Client stages the Extend commit (fresh clone topology + preview cost) right
+	 * before firing the build gun; the Construct hook consumes it (matched by instigator + build
+	 * class) and reconstructs the clone children server-side. Overwrite semantics like the
+	 * scaling spec (an invalid commit is an explicit clear).
+	 */
+	UFUNCTION(Server, Reliable, WithValidation)
+	void Server_StageExtendCommit(FSFExtendCommitSpec Spec);
 
 	// ========================================
 	// Upgrade Audit RPCs

--- a/Source/SmartFoundations/Public/SFRCO.h
+++ b/Source/SmartFoundations/Public/SFRCO.h
@@ -103,6 +103,17 @@ public:
 	UFUNCTION(Client, Reliable)
 	void Client_ReceiveAuditResult(FSFUpgradeAuditResult Result);
 
+	//~ Begin UObject Interface
+	virtual void GetLifetimeReplicatedProps(TArray<class FLifetimeProperty>& OutLifetimeProps) const override;
+	//~ End UObject Interface
+
+	// SML requires a Remote Call Object to have at least one replicated UPROPERTY (registered in
+	// GetLifetimeReplicatedProps) - otherwise the RCO does not replicate and its client->server RPCs
+	// silently do nothing. (See the official SML multiplayer docs.) This dummy satisfies that requirement;
+	// nothing reads it. Without it, the scaling/spacing/arrow/upgrade RPCs above never actually run.
+	UPROPERTY(Replicated)
+	bool bDummyReplicated = true;
+
 protected:
 	// ========================================
 	// Validation & Security

--- a/Source/SmartFoundations/Public/SFRCO.h
+++ b/Source/SmartFoundations/Public/SFRCO.h
@@ -9,6 +9,7 @@
 #include "Features/Extend/SFExtendTypes.h"      // FSFExtendTopology ([EXTEND-MP] topology RCO)
 #include "Features/Extend/SFExtendCommitSpec.h" // FSFExtendCommitSpec ([EXTEND-MP] commit staging)
 #include "Features/Upgrade/SFUpgradeExecutionService.h"
+#include "Features/Upgrade/SFUpgradeTraversalService.h" // [UPGRADE-MP] FSFTraversalConfig/Result
 #include "SFRCO.generated.h"
 
 /**
@@ -148,6 +149,38 @@ public:
 	 */
 	UFUNCTION(Client, Reliable)
 	void Client_ReceiveAuditResult(FSFUpgradeAuditResult Result);
+
+	// ========================================
+	// Upgrade Execution + Traversal RPCs ([UPGRADE-MP])
+	// ========================================
+
+	/**
+	 * Client requests a Smart Upgrade batch execution. The whole pipeline (target gathering,
+	 * hologram replacement, connection capture/repair, chain stabilization, cost) is world
+	 * mutation and MUST run with authority - running it client-side spawns client-only actors
+	 * and desyncs (the #334 hazard class). PlayerController is overridden server-side from the
+	 * RCO owner; the client-supplied field is never trusted.
+	 */
+	UFUNCTION(Server, Reliable, WithValidation)
+	void Server_StartUpgrade(FSFUpgradeExecutionParams Params);
+
+	/** Server sends the execution result back; injected into the client's local execution
+	 *  service so panel delegates fire as in SP. */
+	UFUNCTION(Client, Reliable)
+	void Client_ReceiveUpgradeResult(FSFUpgradeExecutionResult Result);
+
+	/**
+	 * Client requests a network traversal walk. Traversal follows factory/pipe/circuit
+	 * connection components whose connection values are server-only (the same null-GetConnection
+	 * client limitation as the Extend topology walk), so the walk must run on the server.
+	 */
+	UFUNCTION(Server, Reliable, WithValidation)
+	void Server_StartUpgradeTraversal(AFGBuildable* AnchorBuildable, FSFTraversalConfig Config);
+
+	/** Server sends the traversal result back; injected via
+	 *  USFUpgradeTraversalService::InjectTraversalResult (tier counts recomputed client-side). */
+	UFUNCTION(Client, Reliable)
+	void Client_ReceiveTraversalResult(FSFTraversalResult Result);
 
 	//~ Begin UObject Interface
 	virtual void GetLifetimeReplicatedProps(TArray<class FLifetimeProperty>& OutLifetimeProps) const override;

--- a/Source/SmartFoundations/Public/SFRCO.h
+++ b/Source/SmartFoundations/Public/SFRCO.h
@@ -5,6 +5,7 @@
 #include "CoreMinimal.h"
 #include "FGRemoteCallObject.h"
 #include "Features/Spacing/SFSpacingTypes.h"
+#include "Features/Scaling/SFScalingSpec.h"
 #include "Features/Upgrade/SFUpgradeExecutionService.h"
 #include "SFRCO.generated.h"
 
@@ -76,6 +77,20 @@ public:
 	 */
 	UFUNCTION(Server, Reliable, WithValidation)
 	void Server_ToggleArrows(bool bVisible);
+
+	// ========================================
+	// MP spec-based scaling construction
+	// ========================================
+
+	/**
+	 * Client stages the compact grid spec on the server right before firing the build gun.
+	 * The server keys it by this RCO's owning player controller; the AFGBuildableHologram::Construct
+	 * hook consumes it (matched by instigator + build class) and expands the grid server-side.
+	 * Sent on EVERY client fire - with an INVALID spec when there is no grid - so a stale spec from
+	 * a failed construct can never leak into a later fire (overwrite semantics).
+	 */
+	UFUNCTION(Server, Reliable, WithValidation)
+	void Server_StageScalingSpec(FSFScalingSpec Spec);
 
 	// ========================================
 	// Upgrade Audit RPCs

--- a/Source/SmartFoundations/Public/SFRCO.h
+++ b/Source/SmartFoundations/Public/SFRCO.h
@@ -6,6 +6,7 @@
 #include "FGRemoteCallObject.h"
 #include "Features/Spacing/SFSpacingTypes.h"
 #include "Features/Scaling/SFScalingSpec.h"
+#include "Features/Extend/SFExtendTypes.h"   // FSFExtendTopology ([EXTEND-MP] topology RCO)
 #include "Features/Upgrade/SFUpgradeExecutionService.h"
 #include "SFRCO.generated.h"
 
@@ -91,6 +92,26 @@ public:
 	 */
 	UFUNCTION(Server, Reliable, WithValidation)
 	void Server_StageScalingSpec(FSFScalingSpec Spec);
+
+	// ========================================
+	// Extend MP: server-side topology walk
+	// ========================================
+
+	/**
+	 * [EXTEND-MP] Client asks the server to walk the Extend connection topology for a target
+	 * building. A network client cannot walk locally: mConnectedComponent is UPROPERTY(SaveGame)
+	 * (server-only), so GetConnection() is null on clients by design. The server has the
+	 * authoritative graph; it walks and replies with Client_ReceiveExtendTopology. The topology
+	 * references replicated actors + their default-subobject components, so the client resolves
+	 * every reference against its local proxies.
+	 */
+	UFUNCTION(Server, Reliable, WithValidation)
+	void Server_RequestExtendTopology(class AFGBuildable* SourceBuilding);
+
+	/** [EXTEND-MP] Server's reply: the walked topology (bIsValid=false = nothing to extend,
+	 *  which the client caches briefly as a negative result to avoid request spam). */
+	UFUNCTION(Client, Reliable)
+	void Client_ReceiveExtendTopology(FSFExtendTopology Topology);
 
 	// ========================================
 	// Upgrade Audit RPCs

--- a/Source/SmartFoundations/Public/SFRCO.h
+++ b/Source/SmartFoundations/Public/SFRCO.h
@@ -182,6 +182,17 @@ public:
 	UFUNCTION(Client, Reliable)
 	void Client_ReceiveTraversalResult(FSFTraversalResult Result);
 
+	/**
+	 * [EXTEND-MP] Server pushes the AUTHORITATIVELY derived clone topology to the building client
+	 * after every Extend commit reconstruction. The client's own capture poisons every segment
+	 * connection (GetConnection() is null on clients), so a preset saved on a client via
+	 * Import-from-Last-Extend carried empty wiring targets and restored builds came out with
+	 * unconnected belt segments (live finding 2026-06-10). The client caches this copy and
+	 * GetLastCloneTopology prefers it.
+	 */
+	UFUNCTION(Client, Reliable)
+	void Client_ReceiveServerCloneTopology(FSFCloneTopology Topology);
+
 	//~ Begin UObject Interface
 	virtual void GetLifetimeReplicatedProps(TArray<class FLifetimeProperty>& OutLifetimeProps) const override;
 	//~ End UObject Interface

--- a/Source/SmartFoundations/Public/Services/SFChainActorService.h
+++ b/Source/SmartFoundations/Public/Services/SFChainActorService.h
@@ -261,6 +261,14 @@ public:
 	 *  to be found here. Returns entries removed. */
 	int32 RemoveBuildableFromFactoryTickArrays(class AFGBuildable* Buildable);
 
+	/** [CHAIN-FIX] Pre-tick integrity scrub of mFactoryBuildings (+ groups): validate every entry
+	 *  against the UObject table (IsValidLowLevelFast + IsValid) and remove corrupt/freed ones,
+	 *  logging the index, raw pointer, and VALID NEIGHBORS' names — turning the 2026-06-10
+	 *  freed-pointer tick AV (7 repros, three falsified guards: RemoveConveyor, conveyor EndPlay,
+	 *  buildable EndPlay) into a survivable, precisely-located log line. Called from the
+	 *  TickFactory before-hook every factory tick (~2us for ~2k entries). Returns removed count. */
+	int32 ScrubFactoryTickArrays();
+
 	/**
 	 * Schedule a deferred call to PurgeZombieChainActors after a short delay, giving
 	 * vanilla one or two factory ticks to settle pending migrations before we sweep.

--- a/Source/SmartFoundations/Public/Services/SFChainActorService.h
+++ b/Source/SmartFoundations/Public/Services/SFChainActorService.h
@@ -253,6 +253,14 @@ public:
 	 *  the access grant. Returns the number of stale entries removed. */
 	int32 RemoveConveyorFromAllTickGroups(class AFGBuildableConveyorBase* Conveyor);
 
+	/** [CHAIN-FIX] Force-remove a buildable from mFactoryBuildings + mFactoryBuildingGroups.
+	 *  cdb on the 5th freed-pointer tick AV (2026-06-10) showed TickFactoryActors' lambda walking
+	 *  mFactoryBuildings (+0x3C0) and virtual-calling a freed entry near the array END (the most
+	 *  recently registered buildables) — some destruction path skips vanilla RemoveBuildable.
+	 *  Called from the AFGBuildable::EndPlay after-hook; only true leaks survive vanilla cleanup
+	 *  to be found here. Returns entries removed. */
+	int32 RemoveBuildableFromFactoryTickArrays(class AFGBuildable* Buildable);
+
 	/**
 	 * Schedule a deferred call to PurgeZombieChainActors after a short delay, giving
 	 * vanilla one or two factory ticks to settle pending migrations before we sweep.

--- a/Source/SmartFoundations/Public/Services/SFChainActorService.h
+++ b/Source/SmartFoundations/Public/Services/SFChainActorService.h
@@ -245,6 +245,14 @@ public:
 	 */
 	int32 PurgeZombieChainActors();
 
+	/** [CHAIN-FIX] Force-remove a conveyor from EVERY tick group's Conveyors array. Called by the
+	 *  RemoveConveyor after-hook: a stale mConveyorBucketID makes vanilla's removal silently fail
+	 *  in shipping, leaving a soon-to-be-freed pointer in a TG that TickFactoryActors' ParallelFor
+	 *  later calls through (the 2026-06-10 freed-pointer factory-tick AV, reproduced 3x). Lives
+	 *  here because mConveyorTickGroup is private to AFGBuildableSubsystem and this service holds
+	 *  the access grant. Returns the number of stale entries removed. */
+	int32 RemoveConveyorFromAllTickGroups(class AFGBuildableConveyorBase* Conveyor);
+
 	/**
 	 * Schedule a deferred call to PurgeZombieChainActors after a short delay, giving
 	 * vanilla one or two factory ticks to settle pending migrations before we sweep.

--- a/Source/SmartFoundations/Public/Subsystem/SFHologramHelperService.h
+++ b/Source/SmartFoundations/Public/Subsystem/SFHologramHelperService.h
@@ -503,9 +503,11 @@ private:
 		const FRotator& Rotation
 	);
 
+public:
 	/**
 	 * Destroy all current child holograms
-	 * Helper for regenerating grid
+	 * Helper for regenerating grid. Public: also used by the MP spec-construction fire hook to
+	 * clear the preview grid at fire time (the sticky counters regenerate it on the next hologram).
 	 */
 	void DestroyAllChildren();
 };

--- a/Source/SmartFoundations/Public/Subsystem/SFSubsystem.h
+++ b/Source/SmartFoundations/Public/Subsystem/SFSubsystem.h
@@ -14,6 +14,7 @@
 #include "Features/Arrows/FSFArrowTypes.h"
 #include "HUD/SFHUDTypes.h"
 #include "Features/Scaling/SFScalingSpec.h"
+#include "Features/Extend/SFExtendCommitSpec.h"   // [EXTEND-MP] staged Extend commit
 #include "Config/Smart_ConfigStruct.h"
 
 // Service includes - needed for FSFBuildingMetadata and FSplinePointData struct members
@@ -826,9 +827,24 @@ public:
     /** Server: consume (clear) the staged spec for a construct instigator if it matches. */
     bool ConsumeScalingSpecForInstigator(class APawn* Instigator, UClass* BuildClass, FSFScalingSpec& OutSpec);
 
+    // [EXTEND-MP] Same staging model for the Extend commit (clone topology + cost), staged via
+    // USFRCO::Server_StageExtendCommit at fire time, consumed by the same Construct hook.
+
+    /** Server: stage (or clear, when !Spec.bValid) the pending Extend commit for a player. */
+    void StageExtendCommitForPlayer(class APlayerController* PC, const FSFExtendCommitSpec& Spec);
+
+    /** Server: peek the staged Extend commit for a construct instigator if it matches. */
+    bool PeekExtendCommitForInstigator(class APawn* Instigator, UClass* BuildClass, FSFExtendCommitSpec& OutSpec) const;
+
+    /** Server: consume (clear) the staged Extend commit for a construct instigator if it matches. */
+    bool ConsumeExtendCommitForInstigator(class APawn* Instigator, UClass* BuildClass, FSFExtendCommitSpec& OutSpec);
+
 private:
     /** Server-only: pending scaling spec per player controller (transient, never saved). */
     TMap<TWeakObjectPtr<APlayerController>, FSFScalingSpec> StagedScalingSpecs;
+
+    /** Server-only: pending Extend commit per player controller (transient, never saved). */
+    TMap<TWeakObjectPtr<APlayerController>, FSFExtendCommitSpec> StagedExtendCommits;
 
 public:
 

--- a/Source/SmartFoundations/Public/Subsystem/SFSubsystem.h
+++ b/Source/SmartFoundations/Public/Subsystem/SFSubsystem.h
@@ -846,6 +846,11 @@ private:
     /** Server-only: pending Extend commit per player controller (transient, never saved). */
     TMap<TWeakObjectPtr<APlayerController>, FSFExtendCommitSpec> StagedExtendCommits;
 
+    /** Server-only: staging time per commit ([EXTEND-MP] freshness TTL - commits are PRE-staged
+     *  continuously while the preview is active, so a live session refreshes every ~250ms; an
+     *  entry older than the TTL is an abandoned session and must not be consumed). */
+    TMap<TWeakObjectPtr<APlayerController>, double> StagedExtendCommitTimes;
+
 public:
 
 // ========================================

--- a/Source/SmartFoundations/Public/Subsystem/SFSubsystem.h
+++ b/Source/SmartFoundations/Public/Subsystem/SFSubsystem.h
@@ -13,6 +13,7 @@
 #include "Features/Scaling/SFScalingTypes.h"
 #include "Features/Arrows/FSFArrowTypes.h"
 #include "HUD/SFHUDTypes.h"
+#include "Features/Scaling/SFScalingSpec.h"
 #include "Config/Smart_ConfigStruct.h"
 
 // Service includes - needed for FSFBuildingMetadata and FSplinePointData struct members
@@ -808,6 +809,28 @@ public:
 
     /** Reset all counters to defaults and refresh HUD */
     void ResetCounters();
+
+// ========================================
+// MP spec-based scaling construction - SERVER-side per-player spec staging
+// (Client stages via USFRCO::Server_StageScalingSpec at fire time; the AFGBuildableHologram::
+//  Construct hook consumes it, matched by instigator + build class. Overwrite semantics: every
+//  fire stages - an invalid spec when there is no grid - so stale specs cannot leak.)
+// ========================================
+
+    /** Server: stage (or clear, when !Spec.bValid) the pending scaling spec for a player. */
+    void StageScalingSpecForPlayer(class APlayerController* PC, const FSFScalingSpec& Spec);
+
+    /** Server: peek the staged spec for a construct instigator if it matches the build class. */
+    bool PeekScalingSpecForInstigator(class APawn* Instigator, UClass* BuildClass, FSFScalingSpec& OutSpec) const;
+
+    /** Server: consume (clear) the staged spec for a construct instigator if it matches. */
+    bool ConsumeScalingSpecForInstigator(class APawn* Instigator, UClass* BuildClass, FSFScalingSpec& OutSpec);
+
+private:
+    /** Server-only: pending scaling spec per player controller (transient, never saved). */
+    TMap<TWeakObjectPtr<APlayerController>, FSFScalingSpec> StagedScalingSpecs;
+
+public:
 
 // ========================================
 // Scaling Operations (Phase 0: Public for InputHandler access)

--- a/Source/SmartFoundations/Public/UI/SmartUpgradePanel.h
+++ b/Source/SmartFoundations/Public/UI/SmartUpgradePanel.h
@@ -54,6 +54,9 @@ protected:
 	/** Native construct to bind close button click */
 	virtual void NativeConstruct() override;
 
+	/** [UPGRADE-MP] Unbind the static traversal-result delegate */
+	virtual void NativeDestruct() override;
+
 	/** Refresh audit results */
 	UFUNCTION(BlueprintCallable, Category = "SmartFoundations|Upgrade")
 	void RefreshAudit();
@@ -262,6 +265,9 @@ private:
 
 	/** Update traversal UI with results */
 	void UpdateTraversalUI(const FSFTraversalResult& Result);
+
+	/** [UPGRADE-MP] Server-walked traversal result arrived on this client */
+	void OnClientTraversalResult(const FSFTraversalResult& Result);
 
 	/** Current tab state */
 	ESmartUpgradeTab ActiveTab = ESmartUpgradeTab::Radius;

--- a/docs/Features/Multiplayer/DESIGN_MP_ConstructionModel.md
+++ b/docs/Features/Multiplayer/DESIGN_MP_ConstructionModel.md
@@ -1,0 +1,191 @@
+---
+title: Smart Multiplayer — Client/Server Construction Model
+type: DESIGN
+date: 2026-06-09
+status: Draft
+category: Features
+related:
+  - ./PLAN_MultiplayerSupport_Revalidation_1.2.md
+  - ./REF_SMLMultiplayerNotes.md
+  - ../Scaling/IMPL_Scaling_CurrentFlow.md
+  - ../AutoConnect/IMPL_AutoConnect_CurrentFlow.md
+  - ../Extend/IMPL_Extend_CurrentFlow.md
+issues:
+  - 176  # UMBRELLA — multiplayer / dedicated server support
+  - 334  # auto-connect spawns client-only actors
+---
+
+# Smart Multiplayer — Client/Server Construction Model
+
+## Why this doc exists
+
+Slice 0 established that Smart's current multi-buildable construction does not work in
+multiplayer past a hard ceiling, and root-caused why. This doc proposes the **networking model**
+to replace it — derived from how the base game and established SML conventions already do
+MP-safe mass placement — and adapts that model to Smart's harder requirement: every placed
+buildable must remain **individually interactable** and **wired to its neighbours**.
+
+This is a model/architecture doc, not an implementation plan. It defines the boundary and the
+data that crosses it; per-feature implementation slices come after.
+
+## The two problems we must solve together
+
+1. **The construction ceiling (Slice 0).** Smart builds an arrangement as a parent hologram with
+   N child holograms, then commits the whole tree through the vanilla build-gun fire. That fire
+   serializes the entire hologram tree (children included) into a single reliable
+   `Server_ConstructHologram` message. The message is bounded by the engine's reliable-bunch byte
+   ceiling (**65536 bytes**); past ~135 children it fails **all-or-nothing**, and a dropped
+   oversized message never reaches the server, so the orphaned client previews are never cleaned
+   up. The payload is **O(N)** in the number of placed buildables — the architecture scales the
+   wire cost with the build size, which is the root defect.
+
+2. **Authority leakage in post-build wiring (#334).** Auto-connect (power, belts, pipes) defers
+   real wiring to post-build hooks that currently run on **every peer with no authority guard**,
+   so a client's auto-connect spawns actors the server never sees. Construction and wiring are
+   two halves of the same problem: both must be **server-authoritative**.
+
+A correct model has to dissolve **both** at once.
+
+## The proven pattern (engine + SML conventions)
+
+The base game's own multi-placement ("zoop") and the standard SML client/server conventions
+already place many buildables in MP without ever hitting problem (1). The reusable ideas:
+
+- **The boundary is drawn at _intent_, not at _objects_.** The client never ships constructed
+  geometry across the wire. It ships a **compact description** of what to build.
+- **The amount/extent is a compact, replicated property, expanded server-side.** In the engine's
+  zoop, the extent is a single `FIntVector` declared `UPROPERTY(ReplicatedUsing=..., CustomSerialization)`
+  on the buildable hologram; the server reads it during construction and **expands it into N
+  buildables locally**. The wire payload is **O(1)** regardless of N — structurally incapable of
+  hitting the 64 KB ceiling.
+- **Client/server subsystem split.** A server-authoritative subsystem (replicated, spawn-on-server)
+  holds the canonical state and limits; a client-local subsystem (spawn-on-client, never
+  replicated) holds transient preview state. Client→server intent travels through a thin Remote
+  Call Object whose RPCs carry **only small value parameters** (vectors, ints, class refs, bools).
+- **Construction yields real, first-class buildables.** Because the server constructs through the
+  normal buildable path, each result is an independent, replicated `AFGBuildable` — selectable,
+  dismantlable, clipboard-able, and individually addressable. There is no blob to unpack.
+- **The server is the authority.** It clamps requested amounts to its own limits (anti-cheat) and
+  validates cost/placement. Preview-only logic is guarded off on dedicated servers.
+
+The relevant takeaway for us is the **model**, not the tooling. The tooling places dumb copies.
+
+## Why Smart cannot simply reuse that tooling
+
+The engine's mass placement and the mods built on it place **independent, identical copies** with
+**no logistics between them**. Smart's value is precisely the part that pattern omits:
+
+- the **interactions** between placed objects — auto-connect, manifold belts/pipes, power, lift
+  and passthrough stitching;
+- per-object **transforms**, spacing, stepping, rotation, and topology-aware placement;
+- treating each placed buildable as an individually interactable object afterwards.
+
+So we adopt the **transport and authority model**, and supply our **own server-side expansion +
+wiring** for everything the copy-placement path doesn't do.
+
+## The model adapted for Smart
+
+Principle: **the client previews locally and sends a compact reconstruction _spec_; the server
+reconstructs the arrangement, constructs each buildable individually, then wires them — all under
+authority. Everything replicates natively.**
+
+### Components
+
+1. **Preview — client-local (unchanged).** The child holograms, arrows, HUD, and material states
+   stay exactly as they are today. Previews are cosmetic and need no replication. This is already
+   MP-safe.
+
+2. **Reconstruction spec — compact and deterministic.** A small, serializable description from
+   which the server can rebuild the exact arrangement the client previewed:
+   - base build class(es) and the base/anchor transform;
+   - per-axis counts, spacing, stepping, rotation (scaling), and/or
+   - the captured topology + clone plan (Extend: source chains, distributor/manifold plan,
+     belt/pipe/lift roles).
+   Smart already produces almost exactly this today (the JSON spawn data and topology capture used
+   to build the child holograms). The change is to treat that data as the **authoritative spec
+   sent to the server**, rather than as a recipe the client executes into holograms it then ships.
+
+3. **Transport — two viable options.**
+   - **(A) Hologram-carried spec (preferred for placement).** Put the spec on a custom parent
+     hologram as a `CustomSerialization`-replicated property and **expand it in the hologram's
+     server-side `Construct` override** — mirroring how the engine's zoop extent rides the normal
+     build-gun fire. Payload stays O(1); no bespoke chunking; construction still triggers from
+     real player input (which is the only thing that constructs).
+   - **(B) RCO-carried spec.** The client sends the spec through `USFRCO`; the server reconstructs
+     and constructs on receipt. More control and decoupled from the build-gun fire, but the server
+     must drive construction itself. Best where there is no single hologram to ride (e.g. replays,
+     restore, batch operations).
+
+4. **Server construction — individual buildables.** The server reconstructs from the spec and
+   constructs **each buildable on its own** through the normal construct path. Results are real,
+   replicated, individually interactable actors — not a serialized tree. Failure is **per-buildable**,
+   not all-or-nothing, so partial success is recoverable and orphan cleanup is local.
+
+5. **Server-authoritative wiring (this is the #334 fix).** After the buildables exist server-side,
+   the server performs auto-connect / belt / pipe / power construction behind `HasAuthority`. The
+   connections are real and replicate to all clients. Post-build hooks that currently run on every
+   peer get gated to the server.
+
+6. **Authority & validation.** The server validates cost, placement, and limits, and clamps the
+   request to its own bounds before constructing. The client cannot forge state.
+
+### Client/server subsystem split
+
+Mirror the proven split: a **server subsystem** (replicated, authoritative limits + state) and a
+**client subsystem** (local preview state, never replicated). `USFRCO` is already replication-fixed
+(dummy replicated property + `GetLifetimeReplicatedProps`), so the intent channel is ready.
+
+## How today differs from the target
+
+| Layer | Today | Target model |
+|---|---|---|
+| Preview | client-local child holograms | client-local (unchanged) |
+| Wire payload | N serialized child holograms (O(N), 64 KB cap) | compact spec (O(1)) |
+| Construction | one atomic server blob | server constructs each buildable individually |
+| Interactions | implicit in the blob | server-side wiring under `HasAuthority` |
+| Result | all-or-nothing, orphan-prone | N real replicated actors; partial-failure recoverable |
+
+## Mapping to Smart features
+
+- **Scaling (grid).** Spec = base class + base transform + per-axis counts + spacing/stepping +
+  rotation. Strong fit for transport option (A).
+- **Extend.** Spec = server-side topology walk result + clone count + manifold/role plan. The
+  server-side topology-walk RCO already planned for Extend is the front half of this; construction
+  + wiring is the back half. Transport (A) or (B).
+- **Auto-connect / Upgrade / Restore / Dismantle.** Same principle — route the mutation as intent
+  to the server, perform it under authority, let actors replicate. Restore/batch lean toward (B).
+
+## Hard requirements & risks
+
+- **Determinism.** The server's reconstruction from the spec must match the client's preview
+  exactly (same spacing/rotation/topology math, same class resolution). Reuse the existing capture
+  logic on both sides to guarantee this; do not re-derive independently.
+- **Construction trigger.** Only real player input constructs via the build gun. Option (A) rides
+  this naturally; option (B) requires the server to drive construction without a build-gun fire —
+  validate this path early (it is the same wall Slice 0 hit when driving construction manually).
+- **Cost.** Charge cost server-side from the authoritative inventory; preview affordability stays
+  client-side and advisory.
+- **Spec size.** The spec must stay compact (counts/params/topology), never an inline list of N
+  fully-described buildables, or we reintroduce the O(N) payload.
+- **Partial failure.** Define per-buildable failure handling and client preview reconciliation
+  (the absence of this caused the Slice 0 orphan ghosts).
+
+## Suggested incremental slices
+
+1. **Scaling via hologram-carried spec (A)** — prove O(1) construction of a grid of one building
+   type, server-authoritative, individually interactable. Foundations (lightweight) first, then
+   factory machines.
+2. **#334 server-authoritative wiring** — gate auto-connect/power/belt/pipe post-build hooks behind
+   `HasAuthority`; wire server-side; confirm replication.
+3. **Extend** — server topology walk → spec → server construction → server wiring.
+4. Fold remaining features (Upgrade / Restore / Dismantle) onto the same intent→authority model.
+
+Per the workstream rule, none of this ships until **all** features work in MP; the existing
+oversized-grid guard remains the interim safety measure, not a feature.
+
+## Prerequisites already in place
+
+- `USFRCO` replication fix (dummy replicated property + `GetLifetimeReplicatedProps`) — the
+  client→server intent channel works.
+- Existing client-side capture/spawn data (scaling params, Extend topology/JSON) — the raw
+  material for the reconstruction spec.

--- a/docs/Features/Multiplayer/PLAN_MP_AutoConnect_334.md
+++ b/docs/Features/Multiplayer/PLAN_MP_AutoConnect_334.md
@@ -138,17 +138,33 @@ endpoint resolution is implicit in the belt's geometry.
 - Server-side safety nets that also run with authority: deferred belt wiring (next-tick,
   distributor parents), deferred pipe wiring (next-tick), stackable-pipe manual build+connect.
 
-## Live-test checkpoints (increment D, all conduit families)
+## Validation matrix - ALL CONDUIT FAMILIES PASSED (2026-06-10)
 
-Belt checkpoints (merger/splitter rows, manifold lanes, dismantle group, costs) PASSED 2026-06-10.
+| Family | Status | Notes |
+| --- | --- | --- |
+| Distributor belts (mergers + splitters) | PASS | building belts + manifold lanes; chain-verified |
+| Pipe junctions | PASS | recursive capture fix (grid-child previews are grandchildren) |
+| Floor-hole (passthrough) pipes | PASS | bFloorHolePipe replay branch |
+| Power wires | PASS | direct-spawn post-construct (never from holograms) |
+| Stackable conveyor poles | PASS | 0 zombie / 0 orphan chains; #341 in-frame unification |
+| Stackable pipe supports | PASS | |
+| Wall + ceiling conveyor poles | PASS | |
+| Standard conveyor poles | PASS | multi-step fire gate + height sync; chain-verified |
+| Floodlights (angle step) | PASS | multi-step gate + angle sync |
+| Standalone signs (height step) | PASS | sign POLES remain a pre-existing SP limitation (#330) |
+| Conveyor lifts | n/a | auto-connect does not produce lifts (open feature request) |
 
-1. Power-pole grid -> wires appear between grid poles on both sides, charged; check
-   `[MP-334] SpawnConduitPlanChildren` and no "wire entry ... unresolved" warnings.
-2. Pipe junction grid next to fluid buildings -> pipes build + wire (deferred wiring log:
-   "PIPE AUTO-CONNECT DEFERRED WIRING"); floor-hole (passthrough) pipe placement wires through
-   the foundation.
-3. Stackable conveyor pole grid -> run belts build + wire + unify into chains (#341 in-frame log);
-   wall poles / ceiling mounts / standard conveyor poles same.
-4. Stackable pipe support grid -> run pipes build + wire + networks merge.
-5. All conduits join the Smart Dismantle group (post-construct sweep covers every built child).
-6. SP regression sweep: all auto-connect families unchanged (capture/stage is NM_Client-only).
+All conduits join the Smart Dismantle group. Costs charged via ConduitPlanCost.
+
+Fix history for the round-2/3 bugs: recursive descendant capture; pipe junction-branch
+discriminator resolved AFTER FinishSpawning; wires direct-spawned post-construct (hologram-replayed
+wires were unconnected zombies); SetRecipe(null) guard (stackable belt previews carry no recipe -
+dedi assert); multi-step fire gate (step-advance input destroyed previews mid-placement);
+multi-step property sync to spec-expanded children (pole height / floodlight angle / sign step).
+
+**Increment B (settings sync) is OBSOLETE**: it existed for the server-re-derivation model. The
+conduit plan ships the final result - tiers, routing, geometry are baked into the captured classes
+and splines, and the server-side wirers are purely geometric. Client settings honored by construction.
+
+SP regression sweep: DEFERRED by maintainer decision until the full MP feature set (incl. Extend)
+is in place; everything here is gated client-fire/server-spec so SP is expected unchanged.

--- a/docs/Features/Multiplayer/PLAN_MP_AutoConnect_334.md
+++ b/docs/Features/Multiplayer/PLAN_MP_AutoConnect_334.md
@@ -104,17 +104,51 @@ endpoint resolution is implicit in the belt's geometry.
   `out_children` -> the spec group proxy registers them -> Smart Dismantle groups include them.
 - **Cost**: the GetCost hook appends `Spec.BeltPlanCost` after the cell scaling - the staged
   belts are charged with the grid (closes the unpaid-belt interim gap).
-- Same pattern extends to pipes (junction plan) and power (wire endpoint pairs - even simpler:
-  two connection components + wire class). NOT yet implemented - pipes/power previews are still
-  stripped at fire and not rebuilt.
+- Belt-plan live-validated 2026-06-09/10: merger AND splitter rows, building belts + manifold
+  lanes all built/wired/replicated/charged; belts in the Smart Dismantle group (post-construct
+  sweep - spline buildables never reach the ConfigureActor base body the pre-BeginPlay hook
+  patches; safe because conveyors are never lightweight).
 
-## Live-test checkpoints (increment C, belt plan)
+## Increment D (2026-06-10): plan GENERALIZED to all conduit families - awaiting live test
 
-1. Client builds a 1x1 merger next to a factory with auto-connect belt previews -> belts BUILD
-   server-side, wired (check `[MP-334] SpawnBeltPlanChildren` + flow), replicate to the client,
-   and are charged (test with build costs on).
-2. Client builds a merger ROW (the 5-merger manifold case) -> building belts AND merger-to-merger
-   manifold lanes all build + wire.
-3. The built belts are part of the Smart Dismantle group (group-dismantle removes belts too).
-4. SP regression: auto-connect belts wire exactly as before (capture/stage path is NM_Client-only).
-5. Pipes/power: still expected NOT to wire in MP (next increments); no crashes, no ghosts.
+`FSFBeltPlanEntry` -> `FSFConduitPlanEntry` with `ESFConduitPlanKind`
+{Belt, Pipe, StackableBelt, StackablePipe, Wire}; `Spec.ConduitPlan` / `Spec.ConduitPlanCost`.
+
+- **Capture** is now a single uniform walk of the parent's tagged preview children (all families
+  attach to the parent - proven by the fire-hook strip): belt/pipe kinds snapshot the routed
+  spline; wires snapshot the two endpoint connection LOCATIONS (`AFGWireHologram::GetConnection`);
+  pipe entries record `bFloorHolePipe` (registry `PipeAutoConnectConn0 == null`); stackable kinds
+  record their run index.
+- **Replay** mirrors each family's client spawn recipe:
+  - Belt: as before (`SF_BeltAutoConnectChild`, geometric self-wiring in Construct).
+  - StackableBelt: `SF_StackableChild` + registry chain identity (synthetic high-offset
+    StackChainId) -> stack-chain Construct path (coincidence wiring + #341 in-frame chain
+    unification, whose parent hook is also live server-side).
+  - Pipe: `SF_PipeAutoConnectChild` + registry `bIsPipeAutoConnectChild`;
+    `PipeAutoConnectConn0` is ONLY a branch discriminator at the construct seam (never
+    dereferenced) - set to one of the pipe holo's own components for the junction branch
+    (deferred next-tick geometric wiring), left null for the floor-hole branch (passthrough
+    snap registration by proximity).
+  - StackablePipe: `SF_StackableChild` + `bIsStackablePipe` (overlap wiring + network merge in
+    Construct; the OnActorSpawned manual build path dedups via `bHasBeenConstructed`).
+  - Wire: resolve both endpoints by location against the PRE-construct hologram set (parent +
+    grid children; vanilla remaps hologram connections to built poles - the SP mechanism), fall
+    back to built world actors; spawn `ASFWireHologram` + `SetupWirePreview(C0, C1)`; vanilla
+    Construct builds the AFGBuildableWire.
+- Server-side safety nets that also run with authority: deferred belt wiring (next-tick,
+  distributor parents), deferred pipe wiring (next-tick), stackable-pipe manual build+connect.
+
+## Live-test checkpoints (increment D, all conduit families)
+
+Belt checkpoints (merger/splitter rows, manifold lanes, dismantle group, costs) PASSED 2026-06-10.
+
+1. Power-pole grid -> wires appear between grid poles on both sides, charged; check
+   `[MP-334] SpawnConduitPlanChildren` and no "wire entry ... unresolved" warnings.
+2. Pipe junction grid next to fluid buildings -> pipes build + wire (deferred wiring log:
+   "PIPE AUTO-CONNECT DEFERRED WIRING"); floor-hole (passthrough) pipe placement wires through
+   the foundation.
+3. Stackable conveyor pole grid -> run belts build + wire + unify into chains (#341 in-frame log);
+   wall poles / ceiling mounts / standard conveyor poles same.
+4. Stackable pipe support grid -> run pipes build + wire + networks merge.
+5. All conduits join the Smart Dismantle group (post-construct sweep covers every built child).
+6. SP regression sweep: all auto-connect families unchanged (capture/stage is NM_Client-only).

--- a/docs/Features/Multiplayer/PLAN_MP_AutoConnect_334.md
+++ b/docs/Features/Multiplayer/PLAN_MP_AutoConnect_334.md
@@ -1,0 +1,70 @@
+---
+title: Smart Multiplayer - Auto-Connect Server-Authoritative Wiring (#334)
+type: PLAN
+date: 2026-06-09
+status: Active
+category: Features
+branch: feature/mp-server-construction
+related:
+  - ./DESIGN_MP_ConstructionModel.md
+  - ./PLAN_MP_ScalingConstruction_Impl.md
+issues:
+  - 334
+  - 176
+---
+
+# Auto-Connect Server-Authoritative Wiring (#334)
+
+## Grounded findings (2026-06-09 investigation + live crash)
+
+- **The server already runs the auto-connect DECISION pipeline.** The dedi's `USFSubsystem`
+  mirrors the build-gun hologram (same symmetry the spec path relies on) and spawns its own
+  belt preview children against it (live dedi log: `Belt hologram spawned ... (Tier 6)` on the
+  server during a client's merger placement). The "ship the wiring plan to the server" problem
+  largely does not exist - the server derives its own plan.
+- **No post-build mutation path has an authority guard.** `USFSubsystem::OnActorSpawned` belt
+  (~:144) / pipe (~:335) / stackable pipe (~:505) / stackable belt (~:690) sections and
+  `FSFPowerAutoConnectManager::OnPowerPoleBuilt` (wire `SpawnActor` at :1245) run on every peer.
+  In MP the CLIENT runs them against replicated actors and spawns client-only ghosts - the
+  original #334 bug.
+- **Client preview children must never cross the construct message** (server crash deserializing
+  a stripped-spline belt child) - fixed by the fire-hook strip (commit 2f91ccf). Auto-connect in
+  MP currently builds the parent but wires nothing.
+- **The only client-only state the server's pipeline lacks is the runtime settings**
+  (`FAutoConnectRuntimeSettings`: enables, belt/pipe tiers, power axis/range/reserve, routing
+  modes - not replicated; server uses its own config defaults today).
+
+## Architecture
+
+Same intent->authority model as scaling:
+
+1. Client previews locally (unchanged).
+2. Client strips preview children at fire (done) and stages its **auto-connect runtime settings**
+   alongside the scaling spec via the existing `USFRCO` staging channel.
+3. The server's own subsystem - aiming mirror + staged settings - derives the wiring plan
+   server-side and performs ALL post-build wiring under authority.
+4. Clients never mutate: every post-build hook is authority-gated (`!IsClient`). SP standalone
+   and listen-host hold authority, so their behaviour is unchanged.
+
+## Increments
+
+- **A (gates)**: authority-gate every post-build mutation listed above + the legacy blueprint-proxy
+  grouping in OnActorSpawned (client-side ghost proxies for replicated actors). Mechanical; SP
+  unchanged. THEN live-test a client merger+belts build and observe what the server's own pipeline
+  already does - that data drives B/C.
+- **B (settings sync)**: extend the staged intent (RCO) with the client's
+  `FAutoConnectRuntimeSettings` snapshot; server uses the staging player's settings for decisions
+  on that player's builds.
+- **C (deltas)**: fix whatever the live test exposes - candidates: construct-message
+  deserialization clobbering the server hologram's own preview children; connector-pair resolution
+  against built (vs preview) actors; manufacturer production-recipe application for spec children;
+  per-family verification (belts, pipes, power, stackables).
+
+## Live-test checkpoints (after A)
+
+1. Client builds a merger with auto-connect belts -> server log: does the server's
+   OnActorSpawned belt section run? Do server-derived belts get BUILT and wired? Do they
+   replicate to the client?
+2. Client builds a power-pole grid -> do wires appear (server-spawned) on both sides? No ghost
+   client wires?
+3. SP regression: belts/pipes/power wire exactly as before (authority held locally).

--- a/docs/Features/Multiplayer/PLAN_MP_AutoConnect_334.md
+++ b/docs/Features/Multiplayer/PLAN_MP_AutoConnect_334.md
@@ -76,26 +76,45 @@ fixes the design:
 3. **The CLIENT is the only party with the complete, real plan at fire time** (its preview belts
    are full holograms with routed splines + snapped connectors; we strip them at fire anyway).
 
-**REVISED increment C: ship the explicit belt plan in the staged intent.**
-- At the client fire hook, before stripping, capture per auto-connect belt:
-  `{ DistributorCellIndex (grid linear index or parent=-1), DistributorConnectorName,
-     TargetBuildable (replicated AFGBuildable* - serializes via the package map),
-     TargetConnectorName, BeltRecipe, SplinePoints }`.
-- Stage it with the scaling spec via `USFRCO` (extend the staged struct).
-- Server, AFTER the grid constructs (out_children known): resolve each entry - cell index ->
-  built distributor, connector by NAME on the built actor, target connector by name on the
-  replicated buildable - then build each belt directly with the proven primitive
-  (`ASFConveyorBeltHologram` + `SetSplineDataAndUpdate` + `SetSnappedConnections` + `Construct`),
-  the same mechanism the Extend clone spawner uses. No preview machinery involved.
-- Same pattern then extends to pipes (junction plan) and power (wire endpoint pairs - even
-  simpler: two connection components + wire class).
-- Charge the belts as part of the staged plan's cost (closes the unpaid-belt interim gap).
+**REVISED increment C: ship the explicit belt plan in the staged intent. IMPLEMENTED 2026-06-09.**
 
-## Live-test checkpoints (after A)
+The implementation simplified the sketched design in one important way: NO connector names, cell
+indices, or replicated component refs cross the wire. `ASFConveyorBeltHologram::Construct`'s
+`SF_BeltAutoConnectChild` path already wires a freshly built belt GEOMETRICALLY - each free end
+connects to the nearest free, direction-compatible connector within 50cm among BUILT actors only
+(the same mechanism SP uses for every auto-connect belt today). So the plan per belt is just
+`{ BeltClass, Recipe, Location, Rotation, SplinePoints (local) }` (`FSFBeltPlanEntry`), and
+endpoint resolution is implicit in the belt's geometry.
 
-1. Client builds a merger with auto-connect belts -> server log: does the server's
-   OnActorSpawned belt section run? Do server-derived belts get BUILT and wired? Do they
-   replicate to the client?
-2. Client builds a power-pole grid -> do wires appear (server-spawned) on both sides? No ghost
-   client wires?
-3. SP regression: belts/pipes/power wire exactly as before (authority held locally).
+- **Capture** (`SFScalingSpecExpansion::CaptureBeltPlan`, client fire hook): BEFORE the strip
+  destroys the previews, walk the service's stored previews for the parent + every child
+  distributor and snapshot each belt preview's class/recipe/transform/routed spline into
+  `Spec.BeltPlan`, plus its exact vanilla length-based `GetCost(false)` into `Spec.BeltPlanCost`
+  (merged per item class).
+- **Stage**: part of `FSFScalingSpec` via the existing `USFRCO::Server_StageScalingSpec` -
+  overwrite semantics carry over, so a stale plan can't leak. Validation bounds: <=4096 belts,
+  <=64 spline points each. A reliable-RPC ceiling guard at the fire hook refuses the fire
+  (~>45KB estimated plan) BEFORE the previews are destroyed, keeping the grid live.
+- **Replay** (`SFScalingSpecExpansion::SpawnBeltPlanChildren`, server Construct hook): after
+  `ExpandScalingSpecIntoChildren`, spawn each plan belt as a fresh `ASFConveyorBeltHologram`
+  child (Extend clone-spawner recipe: deferred spawn, `SetBuildClass`/`SetRecipe`,
+  `SF_BeltAutoConnectChild` tag, `DisableValidation`, `SetSplineDataAndUpdate` before AND after
+  `AddChild`). Appended AFTER the grid cells in `mChildren`, so the vanilla child-construct loop
+  builds the distributors first and each belt then self-wires against built actors. Belts join
+  `out_children` -> the spec group proxy registers them -> Smart Dismantle groups include them.
+- **Cost**: the GetCost hook appends `Spec.BeltPlanCost` after the cell scaling - the staged
+  belts are charged with the grid (closes the unpaid-belt interim gap).
+- Same pattern extends to pipes (junction plan) and power (wire endpoint pairs - even simpler:
+  two connection components + wire class). NOT yet implemented - pipes/power previews are still
+  stripped at fire and not rebuilt.
+
+## Live-test checkpoints (increment C, belt plan)
+
+1. Client builds a 1x1 merger next to a factory with auto-connect belt previews -> belts BUILD
+   server-side, wired (check `[MP-334] SpawnBeltPlanChildren` + flow), replicate to the client,
+   and are charged (test with build costs on).
+2. Client builds a merger ROW (the 5-merger manifold case) -> building belts AND merger-to-merger
+   manifold lanes all build + wire.
+3. The built belts are part of the Smart Dismantle group (group-dismantle removes belts too).
+4. SP regression: auto-connect belts wire exactly as before (capture/stage path is NM_Client-only).
+5. Pipes/power: still expected NOT to wire in MP (next increments); no crashes, no ghosts.

--- a/docs/Features/Multiplayer/PLAN_MP_AutoConnect_334.md
+++ b/docs/Features/Multiplayer/PLAN_MP_AutoConnect_334.md
@@ -60,6 +60,37 @@ Same intent->authority model as scaling:
   against built (vs preview) actors; manufacturer production-recipe application for spec children;
   per-family verification (belts, pipes, power, stackables).
 
+## Increment C live findings (2026-06-09 evening, three rounds) - REVISED DESIGN
+
+Three approaches to belt wiring at the server construct seam were tried live; the evidence now
+fixes the design:
+
+1. **Re-derivation fails in that context**: `ProcessSingleDistributor` returns 0 previews for
+   every distributor at the construct seam even with sane positions and 20+ nearby buildings
+   found by the physics scan (the failure is deeper in the pair logic, context-dependent).
+2. **Reusing the server's aim-time previews fails on timing**: `GetBeltPreviews(constructHolo)`
+   is empty at the seam, then repopulates DURING the construct (the deserialize moves the
+   hologram, retriggering the preview pipeline) - always one step behind the child-list
+   enumeration. Maintainer also notes distributor belt previews are not construct-grade the way
+   e.g. stackable-pole belt holograms are.
+3. **The CLIENT is the only party with the complete, real plan at fire time** (its preview belts
+   are full holograms with routed splines + snapped connectors; we strip them at fire anyway).
+
+**REVISED increment C: ship the explicit belt plan in the staged intent.**
+- At the client fire hook, before stripping, capture per auto-connect belt:
+  `{ DistributorCellIndex (grid linear index or parent=-1), DistributorConnectorName,
+     TargetBuildable (replicated AFGBuildable* - serializes via the package map),
+     TargetConnectorName, BeltRecipe, SplinePoints }`.
+- Stage it with the scaling spec via `USFRCO` (extend the staged struct).
+- Server, AFTER the grid constructs (out_children known): resolve each entry - cell index ->
+  built distributor, connector by NAME on the built actor, target connector by name on the
+  replicated buildable - then build each belt directly with the proven primitive
+  (`ASFConveyorBeltHologram` + `SetSplineDataAndUpdate` + `SetSnappedConnections` + `Construct`),
+  the same mechanism the Extend clone spawner uses. No preview machinery involved.
+- Same pattern then extends to pipes (junction plan) and power (wire endpoint pairs - even
+  simpler: two connection components + wire class).
+- Charge the belts as part of the staged plan's cost (closes the unpaid-belt interim gap).
+
 ## Live-test checkpoints (after A)
 
 1. Client builds a merger with auto-connect belts -> server log: does the server's

--- a/docs/Features/Multiplayer/PLAN_MP_ExtendConstruction_Strategy.md
+++ b/docs/Features/Multiplayer/PLAN_MP_ExtendConstruction_Strategy.md
@@ -47,11 +47,15 @@ GetLastCloneTopology prefers it on clients.
 Three identical dedi crashes (TickFactoryActors lambda_31, FGBuildableSubsystem.cpp:644,
 ParallelFor worker calling through freed heap — cdb-symbolized, rip in zeroed heap), each
 ~2 min after building/dismantling 1x1 auto-connect distributor+belt groups; the third followed a
-Smart Dismantle directly (GC-latency timing). Working theory: stale mConveyorBucketID makes
-vanilla RemoveConveyor silently no-op in shipping → dismantled belt stays in another tick group's
-array → freed → ticked. GUARD DEPLOYED (ab02ab5): RemoveConveyor after-hook force-removes the
-belt from every TG and logs [CHAIN-DIAG] when it catches one — next dismantle either names the
-leak in one log line or the theory is wrong (dumps + cdb workflow in AGENTS.md). Related fixes
+Smart Dismantle directly (GC-latency timing). A 4TH repro killed the dismantle theory: NO
+dismantle, NO build — just hover-extend → look away → re-aim — with the RemoveConveyor guard
+(ab02ab5) silent. So some conveyor destruction path never calls RemoveConveyor at all; the
+trigger correlates with the EXTEND AIM/TEARDOWN cycle on the dedi (its mirror runs aim-time
+pipelines). SECOND GUARD DEPLOYED (5257f00): AFGBuildableConveyorBase::EndPlay before-hook —
+the destruction chokepoint — sweeps every tick group while the object is alive and logs which
+belt died, why (EEndPlayReason), and how many stale entries it left. The next repro attempt
+either prints the leak's name or survives silently; either way it cannot AV from this class
+anymore (dumps + cdb workflow in AGENTS.md). Related fixes
 same session: chain-hygiene sweep after every spec/extend construct + always-on sweep summary
 (06694cf), chainless-belt heal (7649aec), detached-chain force-destroy + member-belt re-register
 (0b9c87c). Separate closed item: a wild-pointer walk crash was a STALE-OBJECT-FILE layout

--- a/docs/Features/Multiplayer/PLAN_MP_ExtendConstruction_Strategy.md
+++ b/docs/Features/Multiplayer/PLAN_MP_ExtendConstruction_Strategy.md
@@ -1,0 +1,125 @@
+---
+title: Smart Multiplayer — Extend Construction Strategy
+type: PLAN
+date: 2026-06-09
+status: Draft
+category: Features
+branch: feature/mp-server-construction
+related:
+  - ./DESIGN_MP_ConstructionModel.md
+  - ./PLAN_MP_ScalingConstruction_Impl.md
+  - ../Extend/IMPL_Extend_CurrentFlow.md
+issues:
+  - 176
+  - 334
+  - 309
+---
+
+# Smart Multiplayer — Extend Construction Strategy
+
+How to bring Extend onto the same client/server construction model as scaling
+(`DESIGN_MP_ConstructionModel.md`). Strategy only — sequenced after the scaling slice validates the
+core mechanics.
+
+## Why Extend is the harder case
+
+Scaling places a **uniform** grid (one build class + one recipe), so its spec is tiny and the
+server expansion is a single loop. Extend is **heterogeneous and relational**:
+
+- It clones a captured subgraph: factory building(s) + their **distributors** + **belts**
+  (`belt_segment`, factory↔distributor), **pipes** (`pipe_segment`), **lifts** (`lift_segment`),
+  and the between-distributor **manifold lanes**.
+- The clones must be **wired to each other** (auto-connect belts/pipes/power) — the inter-object
+  logistics that scaling has none of. This is the part copy-placement can never do and the reason
+  Extend is Smart's signature feature.
+- Placement is **topology-aware**: it depends on walking the source building's connection graph.
+
+So Extend needs (a) a richer spec, (b) a server-side topology walk, and (c) server-authoritative
+**wiring** after construction.
+
+## Two advantages Extend already has
+
+1. **The parent is already swapped.** Extend already swaps the active hologram to
+   `ASFFactoryHologram` via the proven `USFExtendService::SwapToSmartFactoryHologram`. So the
+   risky "swap the plain-scaling parent + re-register" step that blocks the scaling slice **does
+   not exist for Extend** — the custom parent (with `CustomSerialization` + `Construct` overrides)
+   is already in place.
+2. **The spec already exists in all but name.** `SFExtendCloneSpawner` already builds the clones
+   from a JSON-ish description (the captured topology + per-role clone data, `FSFExtendTopology`,
+   `JsonCloneId`, the role tags `belt_segment`/`pipe_segment`/`lift_segment`/lanes). That captured
+   description **is** the reconstruction spec; today it is executed client-side into child
+   holograms that are then serialized. The model change is to ship the description and execute it
+   server-side.
+
+## The blocker Extend must solve first (already planned)
+
+`USFExtendTopologyService::WalkTopology` follows `UFGFactoryConnectionComponent::GetConnection()`,
+but `mConnectedComponent` is `UPROPERTY(SaveGame)` — **server-only, not replicated**. On a client
+`GetConnection()` is null, so the topology walk finds no chains and Extend never activates. The
+already-chosen fix (unblocked by the `USFRCO` replication fix) is a **server-side topology walk via
+RCO**: the client asks the server to `WalkTopology` once on activation; the server returns the
+topology; the client caches it and builds the local preview. This is the front half of the model
+for Extend and must land before Extend construction can be ported.
+
+## Target flow (mirrors scaling, with topology + wiring)
+
+1. **Activation / topology** — client aims at a building → RCO `Server_WalkExtendTopology(building)`
+   → server walks the connection graph (it has the authoritative `mConnectedComponent`) → returns a
+   compact `FSFExtendTopology` (distributors, chains, roles, counts). Client caches it.
+2. **Preview — client-local.** Client builds the clone/belt/pipe preview from the cached topology
+   exactly as today (`SFExtendCloneSpawner`), purely cosmetic.
+3. **Spec.** The Extend spec = `{ cached FSFExtendTopology, clone count, direction/spacing/rotation,
+   per-role plan }`. Compact relative to N serialized child holograms (it is counts + topology, not
+   geometry-per-cell). Rides the already-swapped `ASFFactoryHologram` (Option A) or the RCO
+   (Option B) — prefer the RCO here since activation already round-trips to the server.
+4. **Server construction.** On commit, the server reconstructs from the spec:
+   - construct the clone factory building(s) individually (real replicated buildables);
+   - construct the per-role logistics (distributors, `belt_segment`, `pipe_segment`,
+     `lift_segment`, lanes) individually via the same vanilla spawn path scaling uses
+     (`SpawnChildHologramFromRecipe` per element, transforms reconstructed deterministically).
+5. **Server-authoritative wiring (#334).** After the elements exist server-side, the server runs
+   auto-connect / belt / pipe / power connection **behind `HasAuthority`** — the post-build hooks
+   that today run on every peer get gated to the server. Connections are real and replicate.
+6. **Cost / validation / failure** — as scaling: spec-based server cost (the depot-aware
+   `CanAffordExtendCost` already exists), per-element failure isolation, no oversized blob.
+
+## What to reuse vs build
+
+| Need | Reuse | Build |
+|---|---|---|
+| Custom parent hologram | `ASFFactoryHologram` (already swapped for Extend) + the scaling spec hooks | An Extend spec variant (topology-bearing) |
+| Topology | `FSFExtendTopology`, `WalkTopology` | `Server_WalkExtendTopology` RCO (client→server walk) |
+| Per-element construction | The scaling server-expansion pattern (`SpawnChildHologramFromRecipe` + position math) | Per-role transform reconstruction from topology (vs grid counters) |
+| Wiring | Existing auto-connect / chain-rebuild services | `HasAuthority` gating on the post-build hooks (#334) |
+| Cost | `CanAffordExtendCost` | — |
+
+## Determinism requirement
+
+The server must reconstruct the same clone arrangement + topology the client previewed. Because the
+topology now originates **on the server** (step 1), determinism is easier than scaling: the server
+is the source of truth for the graph, and the client preview is built from the server-returned
+topology. Spacing/direction/rotation math must match (reuse the same calculators on both sides).
+
+## Slice order (after the scaling slice validates the core)
+
+1. **Server-side topology walk RCO** — `Server_WalkExtendTopology`; client builds preview from the
+   returned topology. (Already the chosen Extend-MP fix; unblocks activation on clients.)
+2. **Extend spec + server reconstruction** — ship the topology+clone spec; server constructs the
+   clone factory + per-role elements individually (reusing the scaling expansion pattern).
+3. **Server-authoritative wiring (#334)** — gate auto-connect/belt/pipe/power post-build hooks
+   behind `HasAuthority`; wire server-side; confirm replication.
+4. **Heterogeneous role coverage** — belts, pipes, lifts, lanes, passthroughs, distributors,
+   power poles — each reconstructed + wired server-side; per-role failure isolation.
+
+## Dependencies / ordering
+
+- Depends on the **scaling slice** proving the spec round-trip + server expansion + (for Option A)
+  the swap/re-registration mechanics in a live MP session.
+- Depends on the **`USFRCO` replication fix** (done) for both the topology-walk RCO and any
+  spec-bearing RCO.
+- #334 (server-authoritative wiring) is shared infrastructure between scaling's "no inter-object
+  logistics" case and Extend's manifolds; doing it for Extend also hardens any future scaling
+  auto-connect.
+
+Per the workstream rule, nothing ships until **all** features work in MP; the oversized-grid guard
+remains the interim safety measure.

--- a/docs/Features/Multiplayer/PLAN_MP_ExtendConstruction_Strategy.md
+++ b/docs/Features/Multiplayer/PLAN_MP_ExtendConstruction_Strategy.md
@@ -185,12 +185,14 @@ Cost, SourceBuilding, ScaledClones[]}; the server derives the topology at the co
 SP bug in the scaled clone wiring loop (prefix-stripped map keys vs prefixed connection targets =
 empty per-clone manifests; now generated from the prefixed topology against the global id map).
 
-Remaining for Extend-MP hardening: daisy power continuation along scaled chains, Restore, costs
-in non-creative, diagnostics strip.
+Remaining for Extend-MP hardening: Restore, costs in non-creative, diagnostics strip.
 VALIDATED 2026-06-10: rotated scaled extend (maintainer's post-fix build had rotation; built,
 chained, and carried live item flow — 62 chains / 917 items / 0 zombie / 0 orphan under load);
 lifts in the manifold (same run: ConveyorLiftMk5 segments in the wiring pass, uniform flow
-through every chain); heterogeneous topologies (blender 7-clone set, belts+pipes+lifts, every
+through every chain); daisy power along the scaled chain (same run: power poles + Build_PowerLine
+actors along the run, mid-chain Pipeline Pump Mk.2 hasPower=true, producing factories powered
+end to end — note: pipeline junctions report idleReason=no_power as a SENSOR ARTIFACT, they have
+no power connector); heterogeneous topologies (blender 7-clone set, belts+pipes+lifts, every
 clone wired 23/23).
 
 ## Dependencies / ordering

--- a/docs/Features/Multiplayer/PLAN_MP_ExtendConstruction_Strategy.md
+++ b/docs/Features/Multiplayer/PLAN_MP_ExtendConstruction_Strategy.md
@@ -97,8 +97,16 @@ same session: chain-hygiene sweep after every spec/extend construct + always-on 
 (0b9c87c). Separate closed item: a wild-pointer walk crash was a STALE-OBJECT-FILE layout
 mismatch — clean module rebuild fixed it (rule + cdb recipe added to AGENTS.md).
 
-**Remaining for complete MP support (workstream rule: CANNOT SHIP PARTIAL):**
-1. Extend costs in NON-CREATIVE — STILL UNTESTED (two attempts ended in the tick crash above
+**✅ MP FEATURE SURFACE COMPLETE (2026-06-10 end of day): Extend costs in NON-CREATIVE
+LIVE-VALIDATED** — after the GetCost-hook wild-free fix (b3acba5), the killer repro (costs-ON
+hover/re-aim, 13 walks) ran clean and a costs-on SCALED extend (6/6 children + 4 clone sets,
+34 children) built with the inventory deduction EXACTLY matching the preview quote (maintainer
+confirmed). Every feature in the maintainer rule is now live-validated in MP: scaling,
+auto-connect (all conduit families), Extend, Scaled Extend, Restore, Upgrade, Dismantle,
+non-creative costs.
+
+**Remaining before release (cleanup only):**
+1. [DONE — see above] Extend costs in NON-CREATIVE — was: STILL UNTESTED (two attempts ended in the tick crash above
    before the fire; the staged commit carried the 6-type cost array correctly both times).
    Re-test: extend with costs on, verify inventory deduction matches the preview quote.
 1b. Validate the RemoveConveyor guard: build + Smart Dismantle an auto-connect group, watch for

--- a/docs/Features/Multiplayer/PLAN_MP_ExtendConstruction_Strategy.md
+++ b/docs/Features/Multiplayer/PLAN_MP_ExtendConstruction_Strategy.md
@@ -167,6 +167,27 @@ Scaled Extend rides the same commit (it already builds per-clone `FSFCloneTopolo
 `SFExtendScaledService.cpp:698`). Restore replays captured clone topologies through the same
 spawner, so it inherits the ported commit too.
 
+## Slice 2 LIVE-VALIDATED (2026-06-10, commits d61c7b1..68ba8d5)
+
+Normal Extend AND Scaled Extend work end-to-end in MP: 21-clone scaled constructor chain built,
+every clone set wired 8/8 manifest connections, daisy power, dismantle groups, and EXTENDING OFF
+the built chain's end clone works (topology walk valid on built clones). Five root causes fixed
+en route - see the workstream memory / commit log: (1) wiring anchors lived in the client-only
+swapped hologram class; (2) the large commit RPC lost the cross-channel race (fix: parameters-only
+spec + continuous pre-staging + TTL); (3) deferred wiring races the post-construct cleanup (fix:
+synchronous pass at the Construct seam with the built parent); (4) server vanilla clearance
+rejects Extend placement (fix: CheckValidPlacement leniency hook - on the AFGBuildableHologram
+OVERRIDE, the base member pointer is an unhookable thunk); (5) THE ROOT: the commit's clone
+topology was client-captured and CaptureBeltChain/CapturePipeChain read GetConnection() (null on
+clients) - every MP Extend built unwired. Fix: the spec carries ONLY parameters {ParentOffset,
+Cost, SourceBuilding, ScaledClones[]}; the server derives the topology at the construct seam
+(walk -> CaptureFromTopology -> FromSource -> ReconstructCommitOnServer). BONUS: fixed a latent
+SP bug in the scaled clone wiring loop (prefix-stripped map keys vs prefixed connection targets =
+empty per-clone manifests; now generated from the prefixed topology against the global id map).
+
+Remaining for Extend-MP hardening: rotated scaled extend (clearance leniency untested), pipe/lift
+heterogeneous topologies (refineries), Restore, costs in non-creative, diagnostics strip.
+
 ## Dependencies / ordering
 
 - Depends on the **scaling slice** proving the spec round-trip + server expansion + (for Option A)

--- a/docs/Features/Multiplayer/PLAN_MP_ExtendConstruction_Strategy.md
+++ b/docs/Features/Multiplayer/PLAN_MP_ExtendConstruction_Strategy.md
@@ -43,8 +43,26 @@ connections (GetConnection() null); FIX: server pushes its authoritatively deriv
 topology to the building client after every commit (Client_ReceiveServerCloneTopology);
 GetLastCloneTopology prefers it on clients.
 
+**OPEN INVESTIGATION (2026-06-10 end of session): freed-pointer factory-tick AV.**
+Three identical dedi crashes (TickFactoryActors lambda_31, FGBuildableSubsystem.cpp:644,
+ParallelFor worker calling through freed heap — cdb-symbolized, rip in zeroed heap), each
+~2 min after building/dismantling 1x1 auto-connect distributor+belt groups; the third followed a
+Smart Dismantle directly (GC-latency timing). Working theory: stale mConveyorBucketID makes
+vanilla RemoveConveyor silently no-op in shipping → dismantled belt stays in another tick group's
+array → freed → ticked. GUARD DEPLOYED (ab02ab5): RemoveConveyor after-hook force-removes the
+belt from every TG and logs [CHAIN-DIAG] when it catches one — next dismantle either names the
+leak in one log line or the theory is wrong (dumps + cdb workflow in AGENTS.md). Related fixes
+same session: chain-hygiene sweep after every spec/extend construct + always-on sweep summary
+(06694cf), chainless-belt heal (7649aec), detached-chain force-destroy + member-belt re-register
+(0b9c87c). Separate closed item: a wild-pointer walk crash was a STALE-OBJECT-FILE layout
+mismatch — clean module rebuild fixed it (rule + cdb recipe added to AGENTS.md).
+
 **Remaining for complete MP support (workstream rule: CANNOT SHIP PARTIAL):**
-1. Extend costs in NON-CREATIVE (GetCost hook charges the staged preview-exact array — untested).
+1. Extend costs in NON-CREATIVE — STILL UNTESTED (two attempts ended in the tick crash above
+   before the fire; the staged commit carried the 6-type cost array correctly both times).
+   Re-test: extend with costs on, verify inventory deduction matches the preview quote.
+1b. Validate the RemoveConveyor guard: build + Smart Dismantle an auto-connect group, watch for
+   the [CHAIN-DIAG] guard line, confirm no crash within ~5 min after.
 2. **Restore MP — IMPLEMENTED 2026-06-10, awaiting live test.** A restore commit rides the
    EXISTING extend-commit machinery end to end: `FSFExtendCommitSpec` gained
    `{bIsRestore, RestoreTemplate (the preset's value-only FSFCloneTopology), RestoreCounterState,

--- a/docs/Features/Multiplayer/PLAN_MP_ExtendConstruction_Strategy.md
+++ b/docs/Features/Multiplayer/PLAN_MP_ExtendConstruction_Strategy.md
@@ -201,7 +201,30 @@ heterogeneous topologies (refineries), Restore, costs in non-creative, diagnosti
 Per the workstream rule, nothing ships until **all** features work in MP; the oversized-grid guard
 remains the interim safety measure.
 
-## OPEN: dedi factory-tick crash after blender scaled extend (2026-06-10 07:22)
+## ROOT-CAUSED (fix pending live re-test): dedi factory-tick crash after blender scaled extend (2026-06-10 07:22)
+
+**Root cause (found 2026-06-10 by code inspection, no dump needed):**
+`FSFWiringManifest::CreateChainActors` collected conveyors from the `AdditionalActors` map by KEY
+role prefix (`StartsWith("lane_segment"/"belt_segment"/"lift_segment")`). The prefixed-key wiring
+fix (68ba8d5) switched the per-clone maps to `sc{i}_`-prefixed keys, so the filter matched NOTHING:
+`AllConveyors == 0`, early-return 0 — the literal `chains=0` in every clone log line. Meanwhile
+extend belts deliberately SKIP `AddConveyor` in `ConfigureComponents`
+(SFConveyorBeltHologram.cpp:1757, "CreateChainActors will handle it"), so every scaled-clone belt
+was connection-wired but NEVER registered with the conveyor subsystem — the exact
+connected-but-unchained THESIS hazard class → factory-tick AV ~2.5 min later. (A regression
+introduced BY 68ba8d5; affects SP scaled extend identically. `RebuildPipeNetworks` was immune
+because it collects by `Cast<AFGBuildablePipeline>` regardless of key — which is why pipes worked.)
+
+**Fix:** collect conveyors by TYPE (`Cast<AFGBuildableConveyorBase>` over all `AdditionalActors`
+values), mirroring the pipe pass. Per-clone neighbor chains exist by pass order (parent set rebuilt
+first with unprefixed keys), so `InvalidateAndRebuildChains` ingests the fresh belts via the proven
+orphan re-registration (SFChainActorService.cpp:1572).
+
+**Re-test gate:** rebuild the blender scaled extend on the dedi, confirm per-clone `chains>0` in
+the wiring log + WiringManifest.json, verify chain integrity via SmartMCP (0 zombie / 0 orphan),
+and let it tick well past the ~2.5 min crash window.
+
+### Original crash record (pre-diagnosis)
 
 Repro context: blender scaled extend (7 clone sets, 151 children, every clone wired 23 incl.
 12 pipe connections) built clean at 07:20:10 and ticked for ~2.5 minutes. At 07:22:42 the player

--- a/docs/Features/Multiplayer/PLAN_MP_ExtendConstruction_Strategy.md
+++ b/docs/Features/Multiplayer/PLAN_MP_ExtendConstruction_Strategy.md
@@ -68,8 +68,18 @@ log named the corruptor: the ARROW module on the dedi (readiness checks can neve
 null renderer -> every aim cycle deferred attach, armed a 5s raw-this lambda timer on a
 non-UObject module whose Cleanup clear was silently skipped when the hologram died first, and
 re-ran failing /Engine/BasicShapes async loads). FIX 052f728: arrows fully no-op on dedicated
-servers + timer world cached at arm and cleared unconditionally. VALIDATE: costs-ON
-hover->away->re-aim repro; if stable, this investigation closes (cdb workflow in AGENTS.md). Related fixes
+servers + timer world cached at arm and cleared unconditionally. Repros 7-9 falsified arrows AND the dead-entry model entirely: the pre-tick scrub (623832c)
+found every entry VALID on the crashing tick, and the mid-tick AddBuildable detector (18f26f8)
+stayed silent - the mutation happens DURING the ParallelFor by something other than
+registration. Current build (d993fcc) adds the symmetric RemoveBuildable mid-tick detector
+(shrink-realloc frees the buffer under the workers). IF THAT IS ALSO SILENT, the next-session
+DEFINITIVE move is interactive: attach cdb to the LIVE dedi (cdbX64 -p <pid>), resolve the
+subsystem ptr (captured in any dump or via SmartMCP), set a hardware write breakpoint on the
+array pointer field - `ba w8 <subsystem>+0x3C0` - and run the costs-ON hover repro: the break
+fires at the exact corrupting instruction. Known facts for whoever continues: crash = vtable
+call on garbage entry of mFactoryBuildings (+0x3C0, PDB-named) inside TickFactoryActors
+lambda_31; Num=1843 stable; crash index varies (1824, 1841-1843); entries valid at tick start;
+costs-ON correlates, costs-OFF never crashes; client aim/walk/stage cycle is the trigger window. Related fixes
 same session: chain-hygiene sweep after every spec/extend construct + always-on sweep summary
 (06694cf), chainless-belt heal (7649aec), detached-chain force-destroy + member-belt re-register
 (0b9c87c). Separate closed item: a wild-pointer walk crash was a STALE-OBJECT-FILE layout

--- a/docs/Features/Multiplayer/PLAN_MP_ExtendConstruction_Strategy.md
+++ b/docs/Features/Multiplayer/PLAN_MP_ExtendConstruction_Strategy.md
@@ -29,8 +29,24 @@ is RESOLVED (chain registration by type, d79e19b — see the resolved section be
 
 **Remaining for complete MP support (workstream rule: CANNOT SHIP PARTIAL):**
 1. Extend costs in NON-CREATIVE (GetCost hook charges the staged preview-exact array — untested).
-2. **Restore MP** — replays captured clone topologies through the same spawner; expected to be
-   fire-path hookup onto the existing commit machinery.
+2. **Restore MP — IMPLEMENTED 2026-06-10, awaiting live test.** A restore commit rides the
+   EXISTING extend-commit machinery end to end: `FSFExtendCommitSpec` gained
+   `{bIsRestore, RestoreTemplate (the preset's value-only FSFCloneTopology), RestoreCounterState,
+   RestoreProductionRecipe}`; `BuildCommitSpecForMP` builds the restore variant whenever the
+   replay session is active (so the fire hook, GetCost hook, clearance hook, Hook B and the
+   pre-stage/clear flows all work UNCHANGED); `ReconstructCommitOnServer` branches on
+   `bIsRestore`: installs counter state + production recipe, then runs the SAME SP replay
+   pipeline (`ReplayRestoreCloneTopology`) against the constructing parent — no source-building
+   walk needed, and the GetConnection() poisoning rule doesn't apply because the connections are
+   preset-sourced values. Pre-staging added to `TickRestoredCloneTopology`; clear staged on
+   session teardown; RCO validation bounds the template (≤4096 children, ≤64 spline points each);
+   client-side ~45KB byte guard refuses oversized templates before previews are destroyed.
+   Caveats for the live test: (a) a preset whose Extend topology was SAVED on an MP client may
+   carry empty CloneConnections (client-side capture poisoning at save time) — test with a preset
+   saved in SP or by the host; (b) the server-side replay runs KickRestoredPreviewParent at the
+   construct seam (synthetic-hit SetHologramLocationAndRotation) — watch for preview-pipeline
+   re-trigger artifacts on the dedi; (c) counter state is installed into the dedi's GLOBAL
+   subsystem state at the construct seam (accepted single-frame race with other players).
 3. **Smart Upgrade MP** — the last feature; not yet analyzed for MP.
 4. Cleanup before release: strip [MP-SLICE0]/[EXTEND-MP]/[MP-334]/[MP-SPEC] Display diagnostics +
    dedi HintBarService spam; S4 time-sliced construction queue (thousands-scale) still unbuilt.

--- a/docs/Features/Multiplayer/PLAN_MP_ExtendConstruction_Strategy.md
+++ b/docs/Features/Multiplayer/PLAN_MP_ExtendConstruction_Strategy.md
@@ -51,11 +51,19 @@ Smart Dismantle directly (GC-latency timing). A 4TH repro killed the dismantle t
 dismantle, NO build — just hover-extend → look away → re-aim — with the RemoveConveyor guard
 (ab02ab5) silent. So some conveyor destruction path never calls RemoveConveyor at all; the
 trigger correlates with the EXTEND AIM/TEARDOWN cycle on the dedi (its mirror runs aim-time
-pipelines). SECOND GUARD DEPLOYED (5257f00): AFGBuildableConveyorBase::EndPlay before-hook —
-the destruction chokepoint — sweeps every tick group while the object is alive and logs which
-belt died, why (EEndPlayReason), and how many stale entries it left. The next repro attempt
-either prints the leak's name or survives silently; either way it cannot AV from this class
-anymore (dumps + cdb workflow in AGENTS.md). Related fixes
+pipelines). A 5TH repro (costs ON, hover→away→re-aim, conveyor guards silent) was cracked with cdb:
+disassembling the crashing lambda showed it walking **mFactoryBuildings** (subsystem +0x3C0,
+member named via PDB `dt`) virtual-calling each entry; the freed entry sat at the array END =
+most recently registered buildables. So a NON-conveyor factory buildable (constructor/merger/
+splitter class) is destroyed by a path that skips vanilla RemoveBuildable. MAINTAINER
+CORRELATION: every costs-ON session crashed, every costs-OFF session was clean — and the preview
+materials have cost-conditional logic (maintainer hint, unexplored). Code suspect found but not
+yet confirmed: SFExtendWiringService_Manifold.cpp spawns REAL belts then
+AFGBuildableConveyorBelt::Respline (destroy+recreate). CURRENT GUARD (4c7f5ec, supersedes
+5257f00): AFGBuildable::EndPlay AFTER-hook (scope first, so only true leaks remain) force-removes
+the dying buildable from mFactoryBuildings + mFactoryBuildingGroups + conveyor tick groups and
+logs name/class/reason. Next repro names the leaking path; the AV is structurally prevented
+either way (dumps + cdb workflow in AGENTS.md; `dt` against the dedi PDB names subsystem members). Related fixes
 same session: chain-hygiene sweep after every spec/extend construct + always-on sweep summary
 (06694cf), chainless-belt heal (7649aec), detached-chain force-destroy + member-belt re-register
 (0b9c87c). Separate closed item: a wild-pointer walk crash was a STALE-OBJECT-FILE layout

--- a/docs/Features/Multiplayer/PLAN_MP_ExtendConstruction_Strategy.md
+++ b/docs/Features/Multiplayer/PLAN_MP_ExtendConstruction_Strategy.md
@@ -47,7 +47,25 @@ is RESOLVED (chain registration by type, d79e19b — see the resolved section be
    construct seam (synthetic-hit SetHologramLocationAndRotation) — watch for preview-pipeline
    re-trigger artifacts on the dedi; (c) counter state is installed into the dedi's GLOBAL
    subsystem state at the construct seam (accepted single-frame race with other players).
-3. **Smart Upgrade MP** — the last feature; not yet analyzed for MP.
+3. **Smart Upgrade MP — IMPLEMENTED 2026-06-10, awaiting live test.** Analysis: the AUDIT path was
+   already MP-ported (Server_StartUpgradeAudit / Client_ReceiveAuditResult, panel routes on
+   NM_Client); EXECUTION and TRAVERSAL were not — a client StartUpgrade would run the whole
+   world-mutation pipeline client-side (client-only actors, no-authority destroys, local-only
+   costs: the #334 hazard class), and a client traversal walks GetConnection()=null so the
+   Traversal tab was structurally empty on clients. Port mirrors the audit pattern exactly:
+   `USFRCO::Server_StartUpgrade` (PlayerController overridden server-side from the RCO owner) +
+   `Client_ReceiveUpgradeResult` → `InjectUpgradeResult` broadcasts the local service delegate;
+   `Server_StartUpgradeTraversal` (server walk, synchronous) + `Client_ReceiveTraversalResult` →
+   static `USFUpgradeTraversalService::InjectTraversalResult` → panel
+   `OnClientTraversalResult` → the same `UpdateTraversalUI`. Also fixed the
+   `GetFirstPlayerController` build-gun hazard in `ProcessSingleUpgrade` (now the requesting
+   player's PC). UHT gotcha: TMaps are forbidden in RPC structs — `FSFTraversalResult.CountByTier`
+   is `UPROPERTY(NotReplicated)` and recomputed from Entries client-side. Execution runs the
+   UNCHANGED server-side pipeline incl. the two-phase chain-actor rebuild (the SFChainActorService
+   rules) — same code as an SP/host run; new belts/chains replicate. Live-test focus: client-
+   triggered belt upgrade across a live chain (chain registration on the dedi + client visual),
+   traversal-mode upgrade (SpecificBuildables resolve via package map), cost deduction from the
+   requesting client's inventory, result text on the client panel.
 4. Cleanup before release: strip [MP-SLICE0]/[EXTEND-MP]/[MP-334]/[MP-SPEC] Display diagnostics +
    dedi HintBarService spam; S4 time-sliced construction queue (thousands-scale) still unbuilt.
 5. SP regression sweep (maintainer-deferred until all MP features work).

--- a/docs/Features/Multiplayer/PLAN_MP_ExtendConstruction_Strategy.md
+++ b/docs/Features/Multiplayer/PLAN_MP_ExtendConstruction_Strategy.md
@@ -26,6 +26,22 @@ Smart Dismantle groups, normal Extend (build + wiring + daisy power + dismantle)
 (rotated, heterogeneous blender sets, lifts in the manifold, daisy power, extend-off-built-chain,
 live item flow under load — 62 chains / 917 items / 0 zombie / 0 orphan). The factory-tick crash
 is RESOLVED (chain registration by type, d79e19b — see the resolved section below).
+**LIVE-VALIDATED 2026-06-10 (later session): Restore MP** (client preset replay → staged restore
+commit → server ReplayRestoreCloneTopology; 4x1/5x1 blender grids built, wired, recipes applied,
+items flowing through every clone) **and Smart Upgrade MP** (client-routed save-wide belt/lift
+upgrade, Success=19, result echo to the client panel). Three same-day root causes fixed en route:
+(1) RCO resolution — RCOs are NOT actors; GetAllActorsOfClass(USFRCO) never finds one; all six
+sites now use PC->GetRemoteCallObjectOfClass (the audit RCO port had NEVER worked on clients);
+(2) detached-but-segmented chain actors — upgrade/extend chain rebuilds left old chains alive
+WITH segments → escaped the 0-seg purge → unconditionally saved → reload found belts in two
+chains → vanilla's worker-thread recovery assert (the boot crash), and at runtime imprisoned
+in-flight items (frozen manifolds); FIX: deferred purge force-destroys them via vanilla's
+ForceDestroyChainActor from the game-thread timer window + a 15s post-load sweep self-repairs
+already-poisoned saves (both live-validated);
+(3) preset capture poisoning — Import-from-Last-Extend on a client saved empty segment
+connections (GetConnection() null); FIX: server pushes its authoritatively derived clone
+topology to the building client after every commit (Client_ReceiveServerCloneTopology);
+GetLastCloneTopology prefers it on clients.
 
 **Remaining for complete MP support (workstream rule: CANNOT SHIP PARTIAL):**
 1. Extend costs in NON-CREATIVE (GetCost hook charges the staged preview-exact array — untested).

--- a/docs/Features/Multiplayer/PLAN_MP_ExtendConstruction_Strategy.md
+++ b/docs/Features/Multiplayer/PLAN_MP_ExtendConstruction_Strategy.md
@@ -185,8 +185,11 @@ Cost, SourceBuilding, ScaledClones[]}; the server derives the topology at the co
 SP bug in the scaled clone wiring loop (prefix-stripped map keys vs prefixed connection targets =
 empty per-clone manifests; now generated from the prefixed topology against the global id map).
 
-Remaining for Extend-MP hardening: rotated scaled extend (clearance leniency untested), pipe/lift
-heterogeneous topologies (refineries), Restore, costs in non-creative, diagnostics strip.
+Remaining for Extend-MP hardening: lifts as primary conduits (vertical manifolds), daisy power
+continuation along scaled chains, Restore, costs in non-creative, diagnostics strip.
+VALIDATED 2026-06-10: rotated scaled extend (maintainer's post-fix build had rotation; built,
+chained, and carried live item flow — 62 chains / 917 items / 0 zombie / 0 orphan under load);
+heterogeneous topologies (blender 7-clone set, belts+pipes+lifts, every clone wired 23/23).
 
 ## Dependencies / ordering
 

--- a/docs/Features/Multiplayer/PLAN_MP_ExtendConstruction_Strategy.md
+++ b/docs/Features/Multiplayer/PLAN_MP_ExtendConstruction_Strategy.md
@@ -200,3 +200,29 @@ heterogeneous topologies (refineries), Restore, costs in non-creative, diagnosti
 
 Per the workstream rule, nothing ships until **all** features work in MP; the oversized-grid guard
 remains the interim safety measure.
+
+## OPEN: dedi factory-tick crash after blender scaled extend (2026-06-10 07:22)
+
+Repro context: blender scaled extend (7 clone sets, 151 children, every clone wired 23 incl.
+12 pipe connections) built clean at 07:20:10 and ticked for ~2.5 minutes. At 07:22:42 the player
+aimed at the END clone (walk valid=1 - extend-off-chain ACTIVATED, the feature works) and fired a
+normal extend off it at 07:22:43. One frame later: EXCEPTION_ACCESS_VIOLATION on a heap address in
+`AFGBuildableSubsystem::TickFactoryActors` (FGBuildableSubsystem.cpp:644, ParallelFor lambda) -
+a freed/garbage actor in the factory tick arrays. NO Smart logs in the crash frame: the new fire's
+construct RPC had NOT yet been processed (staged-commit log only), so the leading hypothesis is a
+TIMEBOMB from the blender build (poisoned factory-tick entry) rather than the new construct.
+
+Evidence preserved: crash folder UECC-Windows-B806A0C64D3B58734FC0E38F04B60288_0000 (UEMinidump.dmp
++ log), WiringManifest.json from the build. No cdb/windbg installed yet - install Windows
+Debugging Tools and open the dump with the FactoryServer-SmartFoundations PDB to identify the
+faulting actor type.
+
+Diagnosis plan: (1) dump analysis; (2) repro the blender chain and observe WHEN it dies (idle vs
+production start vs player action) - if reproducible, bisect the commit wiring pass by disabling
+CreateChainActors / RebuildPipeNetworks for the commit path (the manifest reported chains=0,
+suggesting the connected belts may lack unified chain registration - the THESIS hazard class);
+(3) compare against an identical SP blender scaled extend for baseline.
+
+Also pending from the same round: end-blender showed 2/6 factory connections (1 belt in, 1 pipe
+in) - CONFIRM whether the source blender had only those connected (Extend mirrors the source's
+chains; partial source = partial clone is correct behavior).

--- a/docs/Features/Multiplayer/PLAN_MP_ExtendConstruction_Strategy.md
+++ b/docs/Features/Multiplayer/PLAN_MP_ExtendConstruction_Strategy.md
@@ -43,7 +43,19 @@ connections (GetConnection() null); FIX: server pushes its authoritatively deriv
 topology to the building client after every commit (Client_ReceiveServerCloneTopology);
 GetLastCloneTopology prefers it on clients.
 
-**OPEN INVESTIGATION (2026-06-10 end of session): freed-pointer factory-tick AV.**
+**RESOLVED (2026-06-10, 12 repros, b3acba5): the freed-pointer factory-tick AV was OUR GetCost
+hook calling scope.Override(Cost) WITHOUT invoking scope() first.** For a hooked method
+returning TArray BY VALUE, SML's ApplyCallUserTypeByValue move-assigns the override into an
+UNINITIALIZED return slot when the original was never invoked - the move-assign wild-frees the
+slot's stack-garbage Data pointer, which in CheckCanAfford's frame (dedi mirror build gun,
+costs ON, ticking while a client aims) held the AIMED-AT BUILDING's address. Wild
+FMemory::Free(liveActor) -> allocator freelist scribble over its vtable -> ParallelFor tick AV
+minutes later. Convicted via hardware write watchpoint on the victim's vtable slot (address
+boot-logged by the one-shot identity table). Rule added to AGENTS.md: never Override a by-value
+return without invoking scope() first. The investigation history below is retained for the
+debugging-workflow lessons (cdb live attach, watchpoints, detector layering).
+
+**INVESTIGATION HISTORY (resolved above): freed-pointer factory-tick AV.**
 Three identical dedi crashes (TickFactoryActors lambda_31, FGBuildableSubsystem.cpp:644,
 ParallelFor worker calling through freed heap — cdb-symbolized, rip in zeroed heap), each
 ~2 min after building/dismantling 1x1 auto-connect distributor+belt groups; the third followed a

--- a/docs/Features/Multiplayer/PLAN_MP_ExtendConstruction_Strategy.md
+++ b/docs/Features/Multiplayer/PLAN_MP_ExtendConstruction_Strategy.md
@@ -86,7 +86,7 @@ stayed silent - the mutation happens DURING the ParallelFor by something other t
 registration. Current build (d993fcc) adds the symmetric RemoveBuildable mid-tick detector
 (shrink-realloc frees the buffer under the workers). IF THAT IS ALSO SILENT, the next-session
 DEFINITIVE move is interactive: attach cdb to the LIVE dedi (cdbX64 -p <pid>), resolve the
-subsystem ptr (captured in any dump or via SmartMCP), set a hardware write breakpoint on the
+subsystem ptr (captured in any dump or via live server-state inspection), set a hardware write breakpoint on the
 array pointer field - `ba w8 <subsystem>+0x3C0` - and run the costs-ON hover repro: the break
 fires at the exact corrupting instruction. Known facts for whoever continues: crash = vtable
 call on garbage entry of mFactoryBuildings (+0x3C0, PDB-named) inside TickFactoryActors
@@ -370,7 +370,7 @@ remains the interim safety measure.
 ## RESOLVED (fix d79e19b, live re-test PASSED 2026-06-10 07:48): dedi factory-tick crash after blender scaled extend
 
 **Re-test result:** blender scaled extend rebuilt on the dedi post-fix (07:48:33, 1 clone set,
-jsonBuilt=43, every connection wired 23/23). SmartMCP chain scan: both new sets carry REAL chain
+jsonBuilt=43, every connection wired 23/23). Live chain scan: both new sets carry REAL chain
 actors (mirrored shapes — 3-segment lane chain + building-belt singles per set), 0 zombie /
 0 orphan. Server ticked >5 minutes past build (old timebomb fired at ~2.5 min) with no crash and
 no new crash folder. The per-clone log still prints `chains=0` — now the BENIGN early-out
@@ -399,7 +399,7 @@ first with unprefixed keys), so `InvalidateAndRebuildChains` ingests the fresh b
 orphan re-registration (SFChainActorService.cpp:1572).
 
 **Re-test gate:** rebuild the blender scaled extend on the dedi, confirm per-clone `chains>0` in
-the wiring log + WiringManifest.json, verify chain integrity via SmartMCP (0 zombie / 0 orphan),
+the wiring log + WiringManifest.json, verify chain integrity via a live chain scan (0 zombie / 0 orphan),
 and let it tick well past the ~2.5 min crash window.
 
 ### Original crash record (pre-diagnosis)

--- a/docs/Features/Multiplayer/PLAN_MP_ExtendConstruction_Strategy.md
+++ b/docs/Features/Multiplayer/PLAN_MP_ExtendConstruction_Strategy.md
@@ -201,7 +201,19 @@ heterogeneous topologies (refineries), Restore, costs in non-creative, diagnosti
 Per the workstream rule, nothing ships until **all** features work in MP; the oversized-grid guard
 remains the interim safety measure.
 
-## ROOT-CAUSED (fix pending live re-test): dedi factory-tick crash after blender scaled extend (2026-06-10 07:22)
+## RESOLVED (fix d79e19b, live re-test PASSED 2026-06-10 07:48): dedi factory-tick crash after blender scaled extend
+
+**Re-test result:** blender scaled extend rebuilt on the dedi post-fix (07:48:33, 1 clone set,
+jsonBuilt=43, every connection wired 23/23). SmartMCP chain scan: both new sets carry REAL chain
+actors (mirrored shapes — 3-segment lane chain + building-belt singles per set), 0 zombie /
+0 orphan. Server ticked >5 minutes past build (old timebomb fired at ~2.5 min) with no crash and
+no new crash folder. The per-clone log still prints `chains=0` — now the BENIGN early-out
+(fresh belts with no pre-existing neighbor chains to migrate; vanilla's pending-chain path
+registers them), not the silent conveyor-collection no-op.
+
+Note: `Failed to connect conveyor components ... snap only (or any)` LogGame errors at the build
+frame are PRE-EXISTING noise (also present in all previously-validated runs, 72-252 per session);
+the Any-direction components get connected by a later pass.
 
 **Root cause (found 2026-06-10 by code inspection, no dump needed):**
 `FSFWiringManifest::CreateChainActors` collected conveyors from the `AdditionalActors` map by KEY

--- a/docs/Features/Multiplayer/PLAN_MP_ExtendConstruction_Strategy.md
+++ b/docs/Features/Multiplayer/PLAN_MP_ExtendConstruction_Strategy.md
@@ -2,7 +2,8 @@
 title: Smart Multiplayer — Extend Construction Strategy
 type: PLAN
 date: 2026-06-09
-status: Draft
+updated: 2026-06-10
+status: Implemented — Extend + Scaled Extend live-validated in MP; Restore/Upgrade remain
 category: Features
 branch: feature/mp-server-construction
 related:
@@ -16,6 +17,35 @@ issues:
 ---
 
 # Smart Multiplayer — Extend Construction Strategy
+
+## STATUS SNAPSHOT (2026-06-10, end of session)
+
+**Working in MP, live-validated on the dedi:** scaling (all families, real costs), #334
+auto-connect (ALL conduit families incl. stackables/poles/floodlights/signs/floor holes),
+Smart Dismantle groups, normal Extend (build + wiring + daisy power + dismantle), Scaled Extend
+(rotated, heterogeneous blender sets, lifts in the manifold, daisy power, extend-off-built-chain,
+live item flow under load — 62 chains / 917 items / 0 zombie / 0 orphan). The factory-tick crash
+is RESOLVED (chain registration by type, d79e19b — see the resolved section below).
+
+**Remaining for complete MP support (workstream rule: CANNOT SHIP PARTIAL):**
+1. Extend costs in NON-CREATIVE (GetCost hook charges the staged preview-exact array — untested).
+2. **Restore MP** — replays captured clone topologies through the same spawner; expected to be
+   fire-path hookup onto the existing commit machinery.
+3. **Smart Upgrade MP** — the last feature; not yet analyzed for MP.
+4. Cleanup before release: strip [MP-SLICE0]/[EXTEND-MP]/[MP-334]/[MP-SPEC] Display diagnostics +
+   dedi HintBarService spam; S4 time-sliced construction queue (thousands-scale) still unbuilt.
+5. SP regression sweep (maintainer-deferred until all MP features work).
+6. Confirm end-blender 2/6 connections mirror its source (partial source = partial clone correct).
+
+Key seams for whoever continues: client fire hook + server Hook A/B/C/D live in
+`SFGameInstanceModule.cpp` (RegisterClientGridChunkFireHook / RegisterSpecConstructionHooks);
+staging in USFRCO + USFSubsystem; Extend server derivation in `SFExtendService.cpp`
+(ReconstructCommitOnServer / ReconstructScaledCommitOnServer); wiring in
+`SFExtendWiringService_Json.cpp` + `SFWiringManifest.cpp`. DEBUG GOLD: the wiring pass writes
+`WiringManifest.json` to the dedi's Saved/Logs every run. Deploy = BOTH targets (AGENTS.md golden
+path). Memory file `multiplayer-workstream.md` carries the full debugging arc + 7 root causes.
+
+---
 
 How to bring Extend onto the same client/server construction model as scaling
 (`DESIGN_MP_ConstructionModel.md`). Strategy only — sequenced after the scaling slice validates the

--- a/docs/Features/Multiplayer/PLAN_MP_ExtendConstruction_Strategy.md
+++ b/docs/Features/Multiplayer/PLAN_MP_ExtendConstruction_Strategy.md
@@ -62,8 +62,14 @@ yet confirmed: SFExtendWiringService_Manifold.cpp spawns REAL belts then
 AFGBuildableConveyorBelt::Respline (destroy+recreate). CURRENT GUARD (4c7f5ec, supersedes
 5257f00): AFGBuildable::EndPlay AFTER-hook (scope first, so only true leaks remain) force-removes
 the dying buildable from mFactoryBuildings + mFactoryBuildingGroups + conveyor tick groups and
-logs name/class/reason. Next repro names the leaking path; the AV is structurally prevented
-either way (dumps + cdb workflow in AGENTS.md; `dt` against the dedi PDB names subsystem members). Related fixes
+logs name/class/reason. A 6TH repro with the AFGBuildable guard SILENT reframed it: not a dead-listed actor but HEAP
+CORRUPTION (loop bound constant 0x733 across all dumps = corrupted Num/capture). Crash-adjacent
+log named the corruptor: the ARROW module on the dedi (readiness checks can never pass under the
+null renderer -> every aim cycle deferred attach, armed a 5s raw-this lambda timer on a
+non-UObject module whose Cleanup clear was silently skipped when the hologram died first, and
+re-ran failing /Engine/BasicShapes async loads). FIX 052f728: arrows fully no-op on dedicated
+servers + timer world cached at arm and cleared unconditionally. VALIDATE: costs-ON
+hover->away->re-aim repro; if stable, this investigation closes (cdb workflow in AGENTS.md). Related fixes
 same session: chain-hygiene sweep after every spec/extend construct + always-on sweep summary
 (06694cf), chainless-belt heal (7649aec), detached-chain force-destroy + member-belt re-register
 (0b9c87c). Separate closed item: a wild-pointer walk crash was a STALE-OBJECT-FILE layout

--- a/docs/Features/Multiplayer/PLAN_MP_ExtendConstruction_Strategy.md
+++ b/docs/Features/Multiplayer/PLAN_MP_ExtendConstruction_Strategy.md
@@ -105,7 +105,20 @@ confirmed). Every feature in the maintainer rule is now live-validated in MP: sc
 auto-connect (all conduit families), Extend, Scaled Extend, Restore, Upgrade, Dismantle,
 non-creative costs.
 
-**Remaining before release (cleanup only):**
+**Diagnostics strip DONE (1f7ba64):** investigation scaffolding deleted (mid-tick detectors,
+identity table); permanent safety nets KEPT (pre-tick factory-array scrub, EndPlay +
+RemoveConveyor destruction sweeps, chain-hygiene + post-load sweeps) with catch-lines at
+Warning; 52 routine Display diagnostics demoted to Verbose; HintBarService dedi spam silenced.
+Issues updated with the campaign results: #309 (milestone), #334 (resolution), #356 (Smart
+Walking SP/MP analysis + path forward).
+
+**Remaining before release:**
+0. Maintainer SP regression sweep (the final gate), then merge feature/mp-server-construction.
+   Consider: upstream SML report for the Override-without-invoke by-value footgun; the SP/MP
+   path unification (Phase 1: always-RCO panel call sites; Phase 2: spec-path-only construction,
+   piloted by Smart Walking #356).
+
+**Original cleanup list (superseded by the above):**
 1. [DONE — see above] Extend costs in NON-CREATIVE — was: STILL UNTESTED (two attempts ended in the tick crash above
    before the fire; the staged commit carried the 6-type cost array correctly both times).
    Re-test: extend with costs on, verify inventory deduction matches the preview quote.

--- a/docs/Features/Multiplayer/PLAN_MP_ExtendConstruction_Strategy.md
+++ b/docs/Features/Multiplayer/PLAN_MP_ExtendConstruction_Strategy.md
@@ -185,11 +185,13 @@ Cost, SourceBuilding, ScaledClones[]}; the server derives the topology at the co
 SP bug in the scaled clone wiring loop (prefix-stripped map keys vs prefixed connection targets =
 empty per-clone manifests; now generated from the prefixed topology against the global id map).
 
-Remaining for Extend-MP hardening: lifts as primary conduits (vertical manifolds), daisy power
-continuation along scaled chains, Restore, costs in non-creative, diagnostics strip.
+Remaining for Extend-MP hardening: daisy power continuation along scaled chains, Restore, costs
+in non-creative, diagnostics strip.
 VALIDATED 2026-06-10: rotated scaled extend (maintainer's post-fix build had rotation; built,
 chained, and carried live item flow — 62 chains / 917 items / 0 zombie / 0 orphan under load);
-heterogeneous topologies (blender 7-clone set, belts+pipes+lifts, every clone wired 23/23).
+lifts in the manifold (same run: ConveyorLiftMk5 segments in the wiring pass, uniform flow
+through every chain); heterogeneous topologies (blender 7-clone set, belts+pipes+lifts, every
+clone wired 23/23).
 
 ## Dependencies / ordering
 

--- a/docs/Features/Multiplayer/PLAN_MP_ExtendConstruction_Strategy.md
+++ b/docs/Features/Multiplayer/PLAN_MP_ExtendConstruction_Strategy.md
@@ -111,6 +111,62 @@ topology. Spacing/direction/rotation math must match (reuse the same calculators
 4. **Heterogeneous role coverage** — belts, pipes, lifts, lanes, passthroughs, distributors,
    power poles — each reconstructed + wired server-side; per-role failure isolation.
 
+## Status 2026-06-10
+
+**Slice 1 DONE (commit eebc0ac): client Extend previews work in MP for the first time.**
+`USFRCO::Server_RequestExtendTopology` / `Client_ReceiveExtendTopology`; WalkTopology's client
+branch fires a throttled request and returns false - activation's per-tick retry makes the flow
+async with zero restructuring. `FSFExtendTopology` crosses the wire as-is: it references
+replicated actors + their default-subobject components, which resolve against client proxies
+(only the `mConnectedComponent` VALUES needed to DISCOVER the graph are server-only).
+`FSFPowerChainNode`'s four naked members gained UPROPERTY() to actually serialize. Negative
+replies cached briefly. Live-validated: previews show on a client.
+
+**Slice 3 ALREADY DONE** by the #334 conduit-plan work (see PLAN_MP_AutoConnect_334.md): the
+post-build wiring paths run server-side with authority and are live-validated across all families.
+
+**Interim guard (commit 914bcee):** a client Extend FIRE is refused with an on-screen notice.
+Firing the unported commit serializes the clone children into the construct message and the
+recipe-less belt/lift clones assert the CLIENT in `SerializeConstructMessage` (live crash
+2026-06-10: "Assertion failed: hologramRecipe" via `SetupPendingConstructionHologram`'s
+pending-ghost path - SP never runs that path, which is why SP Extend fires fine). The guard is
+removed by slice 2.
+
+### Slice 2 concrete design (the remaining work)
+
+**Key discovery: the clone description is wire-safe by construction.** `FSFSourceTopology` and
+`FSFCloneTopology` (SFExtendCloneTopology.h) are fully reflected, VALUE-ONLY structs - strings,
+floats, transforms, spline points, zero object pointers (designed as a JSON-ish schema). And
+`FSFCloneTopology` carries its own executor: `SpawnChildHolograms(Parent, ExtendService, Out)` +
+`WireChildHologramConnections`. The pipeline `CaptureFromTopology(topology) -> FromSource(source,
+offset) -> SpawnChildHolograms` is deterministic given (topology, offset).
+
+Flow (mirrors the scaling/conduit commit exactly):
+1. Client fire with Extend active: capture the staged Extend commit, destroy the preview children,
+   fire the childless parent (replaces the interim guard).
+2. Stage via a new `USFRCO::Server_StageExtendCommit` into the subsystem per-player map (overwrite
+   semantics like the scaling spec).
+3. Server `Construct` hook (the existing seam): consume by instigator+BuildClass; per clone run
+   `SpawnChildHolograms` + `WireChildHologramConnections` PRE-scope(); the vanilla child loop
+   constructs everything; the Extend built-child registries + post-build wiring run server-side
+   with authority (slice 3, already validated).
+4. Cost: staged cost array captured client-side from the preview (the ConduitPlanCost pattern) -
+   the GetCost hook appends it.
+
+**Payload decision** (make at implementation time):
+- Option 1: ship `TArray<FSFCloneTopology>` (one per clone, as the preview emitted them -
+  includes Scaled Extend's post-FromSource rotation fix-ups). Faithful but O(clones) bytes;
+  large manifolds x many clones can approach the reliable-RPC ceiling - needs the byte-estimate
+  refusal guard like the conduit plan.
+- Option 2: ship ONE `FSFSourceTopology` + clone offsets/rotations and re-run
+  `FromSource` (+ the Scaled Extend fix-ups, which are plain code) server-side. O(1) in clone
+  count; requires the fix-up code to be callable server-side deterministically.
+Start with Option 1 + the guard (simplest, most faithful); fall back to Option 2 if sizes bite.
+
+Scaled Extend rides the same commit (it already builds per-clone `FSFCloneTopology` instances -
+`SFExtendScaledService.cpp:698`). Restore replays captured clone topologies through the same
+spawner, so it inherits the ported commit too.
+
 ## Dependencies / ordering
 
 - Depends on the **scaling slice** proving the spec round-trip + server expansion + (for Option A)

--- a/docs/Features/Multiplayer/PLAN_MP_ScalingConstruction_Impl.md
+++ b/docs/Features/Multiplayer/PLAN_MP_ScalingConstruction_Impl.md
@@ -118,10 +118,13 @@ These cannot be verified without an in-game MP session; they are the points to t
 
 ## Live-test status (2026-06-09) + known gaps
 
-**MILESTONE: the model works end-to-end for factory machines.** Live on the dedicated server: a
-175-cell constructor grid committed via the O(1) spec, the server expanded 174/174 children inside
-`Construct` (post-validation), built all of them (`out_children=174`, zero disqualifiers), and each
-is individually dismantlable. Key findings baked into the implementation:
+**MILESTONE: the model works end-to-end for BOTH families.** Live on the dedicated server: a
+175-cell constructor grid AND >130-cell flat-foundation grids committed via the O(1) spec, the
+server expanded all children inside `Construct` (post-validation), built all of them
+(`out_children=N`, zero disqualifiers), each individually dismantlable. Foundations confirmed
+working as expected by the maintainer (lightweight-instance path included). Swap eligibility is
+now gated on `USFBuildableSizeRegistry.bSupportsScaling` (the existing per-buildable source of
+truth). Key findings baked into the implementation:
 
 - Expansion MUST run inside `Construct` (post-validation): freshly spawned vanilla holograms cannot
   pass vanilla placement validation (`FGCDInitializing`/`FGCDInvalidFloor`/`FGCDInvalidAimLocation`).

--- a/docs/Features/Multiplayer/PLAN_MP_ScalingConstruction_Impl.md
+++ b/docs/Features/Multiplayer/PLAN_MP_ScalingConstruction_Impl.md
@@ -1,0 +1,125 @@
+---
+title: Smart Multiplayer — Scaling Construction Implementation Plan
+type: PLAN
+date: 2026-06-09
+status: Draft (in progress)
+category: Features
+branch: feature/mp-server-construction
+related:
+  - ./DESIGN_MP_ConstructionModel.md
+  - ../Scaling/IMPL_Scaling_CurrentFlow.md
+issues:
+  - 176
+---
+
+# Smart Multiplayer — Scaling Construction Implementation Plan
+
+Concrete implementation of the spec-based construction model (see `DESIGN_MP_ConstructionModel.md`)
+for the **scaling** feature. Extend is planned separately (`PLAN_MP_ExtendConstruction_Strategy.md`).
+
+## Grounded current-state facts (verified in code)
+
+- Plain scaling parent = the **vanilla** build-gun hologram (`USFSubsystem::RegisterActiveHologram`
+  sets `ActiveHologram = Hologram`, no swap). The `ASFFactoryHologram` swap
+  (`USFExtendService::SwapToSmartFactoryHologram`, proven working) only runs in the Extend path.
+- Grid children are real holograms (`ASFSmartChildHologram` / `ASFBuildableChildHologram` / logistics
+  variants), tagged `SF_GridChild`, `AddChild`'d onto the parent (`SFHologramHelperService`).
+- Commit rides the vanilla build-gun fire → `UFGBuildGunStateBuild::Server_ConstructHologram`, which
+  serializes the parent **plus `mChildren`** into one reliable message → 64 KB ceiling (~135 cells).
+- Existing safety: `RegisterClientGridChunkFireHook` cancels a client fire when a `SF_GridChild`
+  grid exceeds `SF_MP_OVERSIZED_CELLS` (130).
+- Per-cell transforms are computed by `USFPositionCalculator::CalculateChildPosition(X,Y,Z, parentLoc,
+  parentRot, itemSize, FSFCounterState, gridIndex, anchorOffset)` — **deterministic** from
+  `FSFCounterState` + parent transform + item size. This is reproducible server-side.
+- **Scaling grids are uniform** — one build class + one recipe for the whole grid. The spec is small
+  regardless of cell count.
+- Cost today = vanilla `AFGHologram::GetCost(includeChildren=true)` over `mChildren`. With children
+  off the wire we must compute cost from the spec (the `CanAffordExtendCost` pattern already does
+  per-item availability checks).
+
+## Chosen approach: ride the natural fire + compact spec + server expansion (Option A)
+
+Rationale: keep construction on the **proven rails** (the build-gun fire *does* construct — verified
+to ~135 cells; the failure was payload size, not the fire). Slice 0 proved that *re-driving*
+construction off the natural fire is treacherous (sync/deferred re-fire never construct;
+hand-serialized `Server_ConstructHologram` crashed the dedicated server). So we keep the single
+natural fire and shrink the payload to O(1), letting the server expand.
+
+RCO transport (Option B) remains the fallback / the path for Extend and batch ops (Restore), where
+there is no single hologram to ride.
+
+### Flow
+
+1. **Preview — unchanged.** Client builds the `SF_GridChild` preview grid locally exactly as today.
+2. **Swap the scaling parent to `ASFFactoryHologram`** (reuse the proven Extend swap) so the parent
+   can carry a spec and override `Construct`. Done at grid-activation time, before any fire.
+3. **Spec capture.** `ASFFactoryHologram` holds an `FSFScalingSpec` (below). It is populated from the
+   authoritative `FSFCounterState` + base transform + build class + recipe + item size + anchor
+   offset whenever the grid changes.
+4. **Strip children from the wire.** Just before the fire serializes, the grid children are **not**
+   part of the serialized `mChildren` (kept as a client-local preview list). The serialized message
+   is parent + `FSFScalingSpec` only (O(1)).
+5. **Spec serialization.** `ASFFactoryHologram` overrides `SerializeConstructMessage` (the
+   `IFGConstructionMessageInterface` hook vanilla uses for `mDesiredZoop`-style custom fields) to
+   write/read `FSFScalingSpec` alongside the base hologram data.
+6. **Server expansion.** `ASFFactoryHologram::Construct` (server, `HasAuthority`) reads the spec,
+   reconstructs each cell transform via `USFPositionCalculator`, and constructs one buildable per
+   cell — appending each to `out_children`. Results are real, replicated, individually-interactable
+   buildables. Recipe applied per the uniform spec.
+7. **Cost.** Server validates total cost = per-building cost x cell count against the instigator's
+   inventory + Dimensional Depot (generalize `CanAffordExtendCost`); charge server-side.
+8. **Time-slicing (scale slice).** For large N, `Construct` enqueues the spec into a server
+   tick-driven construction queue (build K cells/frame) instead of building all in one frame; the
+   first buildable returns immediately so the build registers, the rest stream in. (Implemented as a
+   second slice; synchronous construct first to validate the model.)
+9. **Failure / reconciliation.** Per-cell construction failure is isolated (skip that cell, continue).
+   No oversized-blob all-or-nothing; the Slice 0 orphan-ghost class of bug cannot occur because the
+   client never shipped N objects.
+
+## FSFScalingSpec (data model)
+
+```
+USTRUCT()
+struct FSFScalingSpec
+{
+    TSubclassOf<class UFGRecipe>     Recipe;        // uniform recipe for the grid (drives build class + cost)
+    FTransform                       BaseTransform; // parent/origin cell world transform
+    FSFCounterState                  Counters;      // grid counts + spacing/steps/stagger/rotation
+    FVector                          ItemSize;      // cell size used by the position calculator
+    FVector                          AnchorOffset;  // attachment anchor compensation
+    bool                             bValid = false;
+};
+```
+
+Compact and fixed-size (no per-cell data). Serializes in a handful of bytes + the recipe class ref.
+
+## Files to change
+
+| File | Change |
+|---|---|
+| `Holograms/Core/SFFactoryHologram.h/.cpp` | Add `FSFScalingSpec mScalingSpec`; override `SerializeConstructMessage`; expand spec in `Construct` (server); spec-based cost in `CheckCanAfford` |
+| `Features/Scaling/SFScalingTypes.h` (or new) | `FSFScalingSpec` |
+| Scaling activation (`SFSubsystem` lifecycle) | Swap plain-scaling parent to `ASFFactoryHologram`; populate `mScalingSpec` on grid change |
+| `Services/SFGridSpawnerService` / `SFHologramHelperService` | Keep preview children off the serialized `mChildren` (client-local preview list) |
+| `Module/SFGameInstanceModule.cpp` | Replace the oversized-grid *refusal* guard with the spec path once validated (keep guard as fallback while gated) |
+| `Subsystem/SFPositionCalculator` | Reused as-is server-side (no change; ensure determinism) |
+
+## Validation gates (require the user's MP test — the testing blocker)
+
+1. Does a client build-gun fire deliver the spec-carrying `ASFFactoryHologram` (children stripped) to
+   the server and run `Construct` server-side? (Expected yes — small payload on the proven fire.)
+2. Does `SerializeConstructMessage` round-trip `FSFScalingSpec` correctly client->server?
+3. Does server-side per-cell construction produce correctly-placed, replicated, interactable
+   buildables on all clients?
+4. Cost charged once, correctly, server-side.
+5. Large-N time-slicing does not hitch the server.
+
+These cannot be verified without an in-game MP session; they are the points to test when available.
+
+## Slice order
+
+- **S1** swap scaling parent + `FSFScalingSpec` + capture + serialize override (compile-clean).
+- **S2** server `Construct` expansion (synchronous) + spec-based cost. *Validation gate 1-4.*
+- **S3** strip children from wire + retire the oversized refusal guard behind the new path.
+- **S4** server-side time-sliced construction queue. *Validation gate 5.*
+- **S5** failure isolation + preview reconciliation polish.

--- a/docs/Features/Multiplayer/PLAN_MP_ScalingConstruction_Impl.md
+++ b/docs/Features/Multiplayer/PLAN_MP_ScalingConstruction_Impl.md
@@ -116,6 +116,33 @@ Compact and fixed-size (no per-cell data). Serializes in a handful of bytes + th
 
 These cannot be verified without an in-game MP session; they are the points to test when available.
 
+## Live-test status (2026-06-09) + known gaps
+
+**MILESTONE: the model works end-to-end for factory machines.** Live on the dedicated server: a
+175-cell constructor grid committed via the O(1) spec, the server expanded 174/174 children inside
+`Construct` (post-validation), built all of them (`out_children=174`, zero disqualifiers), and each
+is individually dismantlable. Key findings baked into the implementation:
+
+- Expansion MUST run inside `Construct` (post-validation): freshly spawned vanilla holograms cannot
+  pass vanilla placement validation (`FGCDInitializing`/`FGCDInvalidFloor`/`FGCDInvalidAimLocation`).
+  Cost correctness restored via `GetCost` cell-count scaling on the spec parents.
+- The stripped preview children must be restored into `mChildren` right after the message bytes are
+  written (`SerializeConstructMessage`, saving side) or they leak as orphans.
+- Vanilla flat foundations use a BP hologram subclass (`Holo_Foundation_C`) - gate on the hologram
+  FAMILY (excluding `AFGRampHologram`), not exact class.
+- The toggle ships ON inside the mod (`sf.MP.SpecConstruction`, developer escape hatch only):
+  players must never configure anything externally, and Saved/Engine.ini is rewritten by the game.
+
+**Known gaps (parked, tracked here):**
+- **Cost validation untested** - the test server runs creative/No Build Cost; the `GetCost`
+  cell-scaling needs a real-inventory MP test (charge exactly N x per-cell, no double-charge).
+- **Smart Dismantle groups**: spec-built children skip the client-side group bookkeeping the legacy
+  path performs, so group dismantle shows the group but cannot dismantle spec-built buildables.
+  Same family as the other post-build bookkeeping that must move server-side or replicate (#334
+  wiring, production-recipe application for manufacturer children). Address with that slice.
+- **Ramp/inclined foundation family** stays on the legacy path (guard still active for it).
+- **Foundations (flat)** gate widened to the family; awaiting live retest.
+
 ## Slice order
 
 - **S1** swap scaling parent + `FSFScalingSpec` + capture + serialize override (compile-clean).

--- a/docs/Features/Multiplayer/PLAN_MP_ScalingConstruction_Impl.md
+++ b/docs/Features/Multiplayer/PLAN_MP_ScalingConstruction_Impl.md
@@ -136,15 +136,29 @@ truth). Key findings baked into the implementation:
 - The toggle ships ON inside the mod (`sf.MP.SpecConstruction`, developer escape hatch only):
   players must never configure anything externally, and Saved/Engine.ini is rewritten by the game.
 
+**Final architecture (2026-06-09 evening, live-validated): class-agnostic hooks + RCO staging.**
+The subclass/swap implementation was replaced by three seams that cover EVERY scalable buildable
+(registry-gated) with no hologram swap: the client fire hook captures the spec + stages it via
+`USFRCO::Server_StageScalingSpec` + destroys the local preview (sticky counters regenerate it);
+the server `Construct` hook (primary virtual, CDO-resolved) consumes the staged spec
+post-validation and expands; the `GetCost` hook scales by cell count pre-charge. Two hard rules
+learned by live crash: SML hooks need `SUBSCRIBE_METHOD_VIRTUAL`+CDO for virtuals, and
+INTERFACE-inherited virtuals (SerializeConstructMessage et al.) must never be hooked (interface-
+adjusted `this`). LIVE-VALIDATED on the dedi: constructors (175), foundations, 414-cell ramps,
+224-cell stairs (`Holo_RampDouble_C`/`Holo_Ramp_C` - families the swap explicitly excluded),
+**with real-inventory cost deduction confirmed** (No Build Cost off, materials charged).
+
 **Known gaps (parked, tracked here):**
-- **Cost validation untested** - the test server runs creative/No Build Cost; the `GetCost`
-  cell-scaling needs a real-inventory MP test (charge exactly N x per-cell, no double-charge).
 - **Smart Dismantle groups**: spec-built children skip the client-side group bookkeeping the legacy
   path performs, so group dismantle shows the group but cannot dismantle spec-built buildables.
   Same family as the other post-build bookkeeping that must move server-side or replicate (#334
   wiring, production-recipe application for manufacturer children). Address with that slice.
-- **Ramp/inclined foundation family** stays on the legacy path (guard still active for it).
-- **Foundations (flat)** gate widened to the family; awaiting live retest.
+- **Auto-connect children** (belts/wires attached to grid previews) are not part of the spec; they
+  are destroyed with the preview at fire time and not built server-side. Part of the #334 slice.
+- **RPC ordering race** (spec stage vs construct, different actor channels): never observed losing
+  in testing; a lost race builds the parent only (benign, logged).
+- **Single-frame expansion**: the server constructs all N children inside one Construct call;
+  fine at ~400, unmeasured at thousands - the time-sliced queue (S4) remains future work.
 
 ## Slice order
 

--- a/docs/Features/Multiplayer/PLAN_MultiplayerSupport_Revalidation_1.2.md
+++ b/docs/Features/Multiplayer/PLAN_MultiplayerSupport_Revalidation_1.2.md
@@ -211,6 +211,57 @@ auto-connect hooks.
   save/reload. **Diagnostics:** temporary `UE_LOG(LogSmartFoundations, Display, …)` at the RPC entry, the
   authority branch, and the per-child construct — `Display`, not `VeryVerbose` (won't show in-game).
 
+### Slice 0 — EMPIRICAL RESULT (2026-06-08, live dedicated-server test)
+
+Run against a **claimed Windows dedicated server** (CL491125) with a game client joined via
+`open 127.0.0.1`, observing the **server's authoritative state live** through the SmartMCP dedi API
+(port 51096). This is Approach B — stricter than a listen server (no PC index 0 on the dedi).
+
+**Headline: client-originated scaled placement WORKS in MP — for normal grid sizes, for both buildable
+kinds.** The core Slice 0 parity question is **YES**. Above a count threshold it fails in a bounded,
+reproducible, fixable way.
+
+Data (cumulative server-side count via `nearby_buildings`; foundations confirmed visually + persist-through-
+reconnect since they are lightweight instances invisible to the actor scan):
+- Foundation tower (~10) + 3×3 (9) → built and persisted. ✅
+- Constructors: 3 → 3; +25 → 28; +100 → **128** — every one a valid replicated actor on the correct grid. ✅
+- Constructors **144 (12×12) → 0 persisted** (server stayed at 128). ✗
+- Foundations **256 (16×16) → 0**; Constructors **256 → 0**; Foundations **1250 → 0**. ✗
+- **All-or-nothing:** on failure, *zero* of the batch persists (not truncated).
+
+Diagnosis (what each observation rules in/out):
+- **COUNT-based, not payload-based.** Lightweight foundations (tiny per-child data) and heavy factory actors
+  fail at the *same* ~100–144 threshold. A byte/bunch-size limit would let foundations go far higher.
+- **NOT a preview-positioning timing bug.** Smart spawns children into `mChildren` synchronously but
+  *positions* them via a progressive batch (~200/frame, ticked by `USFSubsystem::Tick()`), designed for
+  single-player FPS (`SFGridSpawnerService.cpp`, `SFHologramHelperService*`). Hypothesis was that the client
+  fires before the batch settles — **disproven live**: waiting ~10 s for the preview to fully settle before
+  placing still failed.
+- **Not a Smart hard cap.** `GRID_CHILDREN_HARD_CAP = 2000`, `LARGE_GRID_WARNING_THRESHOLD = 100`
+  (`SFHologramHelperService.h`). The 100 warning matches the observed boundary but only warns.
+- **Single-player is unaffected** — large grids (historically 3000+ children) build fine in SP, where the
+  construct is local and never serialized. The limit is specific to the **client→server networked construct**.
+
+**Root cause (leading):** a single client→server construct carrying N child holograms is rejected wholesale
+above ~100–144 children — a **count limit in the networked construction path** (candidate: net-construction-ID
+pool / reliable-bunch / sub-object cap). The parent hologram's vanilla `Construct` serializes `mChildren` to
+the server; beyond the limit the whole construct fails atomically. Two distinct **client-side cleanup**
+failure modes layer on top: at moderate over-cap (256) the orphaned previews self-clean after ~1 min; at very
+large counts (1250) they persist as walk-through ghosts with the build gun consumed.
+
+**Fix direction:**
+1. **Chunk** client-originated scaled placement into sub-batches of ≤~64–100 children, each committed as its
+   own construct, so each stays under the net limit. Single-player can keep the single-construct path.
+2. **Reconcile** local preview holograms when the server does not confirm the build (destroy orphans) — fixes
+   the ghost-cleanup bug; degrades worse with size.
+3. **Confirm the exact constant** via a code review of the build-gun / hologram net-construct path (the
+   maintainer flagged the 30.1.0 "smoother grid scaling / children-at-higher-counts" rework as related).
+
+**Significance for the matrix:** scaling's MP risk is **lower than the 2026-05-20 matrix assumed** — the
+commit path is the safe vanilla server-authoritative path and it works for both lightweight and actor
+buildables at normal scale. The only defect is the large-batch ceiling + preview cleanup, both bounded and
+fixable. This is the first concrete MP work item (ahead of, or alongside, #334).
+
 ### After Slice 0 — Slice 1: fix #334 power (smallest real bug)
 Gate `OnPowerPoleBuilt` behind authority; for client builds, route the pole-to-pole wire request through
 `USFRCO` so the server spawns the `AFGBuildableWire` and it replicates. Same host+client harness, asserting

--- a/docs/Features/Multiplayer/PLAN_MultiplayerSupport_Revalidation_1.2.md
+++ b/docs/Features/Multiplayer/PLAN_MultiplayerSupport_Revalidation_1.2.md
@@ -248,11 +248,18 @@ RPC** — `UFGBuildGunStateBuild::Server_ConstructHologram(FNetConstructionID, F
 `FConstructHologramMessage.SerializedHologramData`, a single `TArray<uint8>` holding the entire hologram tree
 serialized via `IFGConstructionMessageInterface::SerializeConstructMessage` (`FGConstructionMessageInterface.h`;
 `mChildren` serialized with the parent — `Hologram/FGHologram.h:126,729`). So the construct is **inherently
-all-or-nothing** (one RPC, one blob), and above ~100–144 children the serialized blob exceeds UE's
-**reliable-bunch / packet size ceiling** (an *engine-level* limit, not a FactoryGame constant — which is why
-it never appears in a Smart/FactoryGame grep, and the modding docs don't mention it). "Count-based vs
-byte-based" reconciles: each child serializes to a roughly constant size, so the byte ceiling ≈ count ×
-constant and foundations vs actors hit the same threshold (their child-hologram serialization is similar).
+all-or-nothing** (one RPC, one blob), and past a threshold the serialized blob exceeds UE's **reliable
+partial-bunch byte ceiling** (an *engine-level* limit, not a FactoryGame constant — which is why it never
+appears in a Smart/FactoryGame grep, and the modding docs don't mention it).
+
+**Measured boundaries (hard, reproducible, single 1×N lines):** foundations **136 OK / 137 fail**;
+constructors **135 OK / 136 fail**. The **off-by-one between building types is the proof it is byte-based,
+not a count cap**: a fixed byte ceiling ÷ a near-constant per-child serialized size. Each child's payload is
+dominated by **common hologram fields** (transform, `FNetConstructionID`, build-class ref, hologram state) —
+identical in size regardless of building — so the boundary barely moves; the constructor carries a hair more
+(recipe/class-path) and so crosses the ceiling one child sooner. Back-of-envelope: ~64 KB ceiling ÷ ~480
+bytes/child ≈ 136. There is **no "136/137" constant anywhere in code** — it is `floor((ceiling − overhead) /
+bytes_per_child)`.
 
 **Why previews orphan:** vanilla has a failure callback `Client_OnBuildableFailedConstruction(FNetConstructionID)`
 (`FGBuildGunBuild.h:328`) — but it only fires if the **server processes** the message. An oversized RPC

--- a/docs/Features/Multiplayer/PLAN_MultiplayerSupport_Revalidation_1.2.md
+++ b/docs/Features/Multiplayer/PLAN_MultiplayerSupport_Revalidation_1.2.md
@@ -1,0 +1,243 @@
+---
+title: Smart Multiplayer Support — 1.2 Re-Validation + First Slice
+type: PLAN
+date: 2026-06-08
+status: Active
+category: Features
+supersedes_assumptions_in: ./PLAN_MultiplayerSupport_Matrix.md
+related:
+  - ./PLAN_MultiplayerSupport_Matrix.md
+  - ../Scaling/IMPL_Scaling_CurrentFlow.md
+  - ../AutoConnect/IMPL_AutoConnect_CurrentFlow.md
+  - ../Extend/IMPL_Extend_CurrentFlow.md
+  - ../SmartUpgrade/IMPL_SmartUpgrade_CurrentFlow.md
+  - ../SmartDismantle/IMPL_SmartDismantle_CurrentFlow.md
+issues:
+  - 176  # UMBRELLA — multiplayer / dedicated server support (other MP issues link here)
+  - 309  # Multiplayer support — Extend with friends (links to #176)
+  - 334  # Power-wire + belt auto-connect broken across client (first concrete bug; links to #176)
+---
+
+# Smart Multiplayer Support — 1.2 Re-Validation + First Slice
+
+## Why this doc exists
+
+The original risk matrix (`PLAN_MultiplayerSupport_Matrix.md`) was written **2026-05-20**, before the
+1.2/CL-83 port and before the belt work (#341 chain-actor unification, #354 standard pole auto-connect).
+The 1.2 "defer broad rewrites" hold it imposed is now **lifted**. This doc re-validates every feature's
+authority story against the **current** code, folds the new belt/pole paths into the matrix, and defines a
+**narrow, testable first slice**.
+
+The original matrix's *structure and design rules remain correct* — what changed is that we now have
+concrete file:line authority hazards and a confirmed root cause for the first bug (#334). Where this doc and
+the old matrix disagree, **this doc wins**.
+
+---
+
+## Headline conclusions
+
+1. **Scaling is genuinely MP-safe by construction** and is the correct first slice. Scaled placement commits
+   purely through vanilla parent→child `Construct()` / `AddChild()` cost aggregation — **no direct
+   `SpawnActor` of buildables, no manual cost charging** in the scaling path. The only scaling RCO gaps are
+   *cosmetic state echo* to other clients (TODO #21), not build correctness.
+
+2. **#334 has a confirmed, concrete root cause** and it is the cleanest first *bug* to fix after the parity
+   slice: **power, belt, and pipe auto-connect all defer their real connection wiring to post-build hooks
+   (`OnActorSpawned` / parent `Construct`) that run on every peer with no authority guard.** On a client
+   those hooks spawn/wire **client-only** actors the server never sees → "built but no power / no items."
+
+3. **The new belt (#341) and pole (#354) paths did NOT regress scaling**, but they **widened the
+   auto-connect authority surface**: the matrix's old note that "only Power directly spawns actors" is now
+   **stale** — stackable belt runs and pipes also commit real connections through post-build hooks.
+
+4. **Extend and SmartUpgrade remain Very High** and stay last. Both have a `GetFirstPlayerController()`
+   build-path hazard (wrong player's tier/inventory/build-gun in a client or non-host listen-server build).
+
+---
+
+## Confirmed authority infrastructure (current code)
+
+| Surface | File | State |
+|---|---|---|
+| `USFRCO` | `Public/SFRCO.h` / `Private/SFRCO.cpp` | 5 Server RPCs: `Server_ApplyScaling`, `Server_ResetScaling`, `Server_SetSpacingMode`, `Server_ToggleArrows`, `Server_StartUpgradeAudit` (+`Server_CancelUpgradeAudit`, `Client_ReceiveAuditResult`). Registered unconditionally (`ShouldRegisterRemoteCallObject()` → true). |
+| `HasHologramAuthority()` | `SFRCO.cpp:302` | **Placeholder returning true** (TODO #22) — no ownership check on the target hologram. |
+| `CheckRateLimit()` | `SFRCO.cpp:318` | **Placeholder returning true.** |
+| Result echo to other clients | `SFSubsystem_Config.cpp:84,102,122` | **TODO #21** — scaling/spacing/arrow results apply server-side but are not replicated to other clients (cosmetic, not build-correctness). |
+| `FSFNetworkHelper` | `Public/Core/Helpers/SFNetworkHelper.h` | **Policy/detection only** — `IsMultiplayer/IsClient/IsListenServer/IsDedicatedServer/ShouldEnableFeature`. No RPC routing, no `HasAuthority`. Conservative default-deny on unknown netmode. |
+| Audit per-player routing | `SFRCO.cpp:218,249` | **Correct** — `RequestingPlayer = Cast<AFGPlayerController>(GetOuter())`, result returned via `Client_ReceiveAuditResult` to the caller only. |
+
+**`GetFirstPlayerController()` audit (18 sites):** 10 are **MP-safe** (local input, HUD, arrows, radar,
+diagnostics, hologram-poll cache, pipe preview — all legitimately the local player). **8 are hazards** —
+all in *tier-config resolution* or *build-gun/inventory* paths where the code wants the **requesting builder**,
+not the world's first PC:
+
+| Site | Hazard |
+|---|---|
+| `SFUpgradeExecutionService.cpp:670` | **Critical** — build-gun/inventory for actual upgrade construction. |
+| `SFRestoreService.cpp:460,823` | **Critical** — build-gun/inventory in restore build-commit. |
+| `SFExtendCloneSpawner.cpp:958` | Lane/belt tier from first PC, not builder. |
+| `SFExtendWiringService_Manifold.cpp:580` | Manifold belt tier from first PC. |
+| `SFAutoConnectService_Belt.cpp:987,1048` | Belt tier from first PC. |
+| `SFPipeAutoConnectManager.cpp:874,1171` + `_Spawn.cpp:165,686,901` | Pipe tier from first PC. |
+| `SFPowerAutoConnectManager.cpp:1799` | Cable-cost inventory from first PC. |
+| `SFSubsystem.cpp:810` | Scaling RPC fallback uses world first PC instead of RCO `GetOuter()`. |
+
+---
+
+## Re-validated feature matrix (current code)
+
+Columns: **Preview** = local client preview only · **Commit path** = how the real build happens ·
+**Authority hazard** = the concrete MP failure · **Risk** · **Δ since 2026-05-20**.
+
+### Scaling — Risk: LOW-MED (was High) ✅ first slice
+- **Preview:** child holograms via `AddChild()`, client-side only; counters in `SFGridStateService`.
+- **Commit path:** vanilla parent `Construct()` traverses children; **cost auto-aggregated by vanilla
+  `GetCost()`** — DeferredCostService/RecipeCostInjector were **removed** (`SFSubsystem.cpp:74`). No direct
+  `SpawnActor`, no manual `Construct()`, no manual cost charging in the scaling path.
+- **Authority hazard:** only the *client→server scale-change RPC* (`Server_ApplyScaling`) and its missing
+  echo to other clients (TODO #21). Build correctness is sound because the parent hologram build is already
+  the vanilla server-authoritative path.
+- **Δ:** matrix rated this High out of caution; current code shows the commit path is the safe vanilla path.
+  #341/#354 add an *in-frame chain rebuild* only when the grid contains belt poles — irrelevant to plain
+  foundation/factory scaling.
+
+### AutoConnect — Risk: HIGH (belts/pipes), CRITICAL (power) — this is #334
+Root cause is shared across all three: **real connections are wired in post-build hooks that run on every
+peer with no `HasAuthority()` guard.**
+- **Power (CRITICAL):** `SFPowerAutoConnectManager::OnPowerPoleBuilt` (`SFPowerAutoConnectManager.cpp:1029`)
+  → direct `SpawnActor<AFGBuildableWire>` + `NewWire->Connect()` (`:1245`,`:1248`). **Zero authority guard
+  in the whole manager.** Child wire holograms are cost-only (Issue #244 comment at `:1235`). On a client
+  this spawns a **client-only wire** → server's pole has no connection → power never transmits. *Confirmed.*
+- **Belts (HIGH):** stackable runs register their chain in-frame during the parent pole `Construct` hook
+  (`SFGameInstanceModule.cpp`, the #341 path) → `USFChainActorService::InvalidateAndRebuildChains`. If this
+  runs on a client (or before child belts replicate), the client's chain is incomplete → items don't move.
+- **Pipes (HIGH):** post-build `SetConnection()` + `MergeNetworks()` via deferred-wiring `OnActorSpawned`
+  hook (`SFPipeAutoConnectManager*`). Same peer/ordering hazard → no fluid.
+- **Δ:** matrix said "Power is the exception that directly spawns actors." **Now stale** — stackable belts
+  (#341) and pipes also commit real connections off the hologram-child path. The IMPL doc
+  (`IMPL_AutoConnect_CurrentFlow.md:24-25`) needs the same correction.
+
+### Extend — Risk: VERY HIGH (unchanged)
+- **Preview:** clone child holograms via direct `SpawnActor<ASF…Hologram>(bDeferConstruction=true)` with
+  `SetReplicates(false)` — explicitly client-only preview (`SFExtendCloneSpawner.cpp`).
+- **Commit path:** built children come through vanilla `AddChild()`→`Construct()`; **but** post-build
+  manifold wiring spawns **real** `AFGBuildableConveyorBelt/Lift/Wire` directly
+  (`SFExtendWiringService_BuiltChild.cpp` ~470/495, `_Json.cpp` wires) and then
+  `RebuildConveyorChains`/`RebuildPipeNetworks` (`SFWiringManifest.cpp:846,907`).
+- **Authority hazard:** tier selection via `GetFirstPlayerController` (`:958`, manifold `:580`) → non-host
+  builder gets wrong tier; post-build buildable spawns have no explicit authority guard.
+- **Δ:** none structural; #341 chain path is what the manifold rebuild already calls.
+
+### SmartUpgrade — Risk: MED (audit) / VERY HIGH (execution)
+- **Audit:** RCO route is **correct per-player** (`SFRCO.cpp:218`), but the scan is a **world-wide
+  `TActorIterator`** then radius-filtered (`SFUpgradeAuditService.cpp:297,323,356`) — safe (read-only) but
+  broad, as the matrix flagged.
+- **Execution:** server-side, no client hologram spawn; cost charged per-item server-side. **Hazards:**
+  `GetFirstPlayerController()` fallback for build-gun/inventory (`SFUpgradeExecutionService.cpp:670`) and
+  **no unlock/recipe revalidation at execute time** (audit-time availability is trusted).
+- **Δ:** chain rebuild uses the two-phase vanilla queue (`:1608`,`:1629`), **not** changed by #341 — doc
+  stays accurate.
+
+### SmartDismantle — Risk: MED (raise to HIGH for grouping correctness)
+- **Commit path:** `AFGBlueprintProxy` is spawned in `OnActorSpawned`
+  (`SFSubsystem_OnActorSpawned.cpp:61`) with **no `HasAuthority()` guard**, then `SetBlueprintProxy()` /
+  `RegisterBuildable()` (`:90`,`:91`). Fires on **all peers** → client and server spawn independent
+  proxies, last-write-wins → split/inconsistent grouping.
+- **Δ:** IMPL doc is silent on MP; add the authority caveat.
+
+---
+
+## Cross-cutting root-cause pattern (the thing to fix)
+
+Smart! deliberately defers "real" connection/chain/proxy wiring to **post-build hooks** (`OnActorSpawned`,
+parent `Construct`) to dodge vanilla ordering issues. That pattern is correct in single-player but
+**unguarded for authority**: the hooks run on every connected peer. The MP fix is *not* a rewrite — it is to
+**gate every world-mutating post-build hook behind a server-authority check and route the client's intent
+through an RCO**, letting the resulting vanilla actors replicate down normally.
+
+Concretely, the recurring fix shape:
+- Add `if (!Buildable->HasAuthority()) return;` (or world-netmode guard) at the top of `OnPowerPoleBuilt`,
+  the pipe deferred-wiring hook, the stackable-belt chain registration, and the dismantle proxy spawn.
+- For client-originated builds, the client sends a validated request via `USFRCO`; the **server** runs the
+  hook and the built wire/belt/pipe/proxy replicates to all clients through vanilla replication.
+- Replace build-path `GetFirstPlayerController()` with the **requesting** PC (from the RCO `GetOuter()` or a
+  threaded request context — see Slice "Per-Player Request Context" in the original matrix).
+
+---
+
+## First slice (narrow, testable)
+
+### Slice 0 — Parity proof: client-originated **scaled foundation/factory placement** on a listen server
+
+**Goal:** prove that a *client* (not the host) can place a scaled grid of plain foundations / a simple
+factory building and have every cell appear, correctly costed, on **both** host and client — with **no
+AutoConnect, no Extend, no Upgrade** involved. This validates the core authority pipeline (client scale
+intent → server-authoritative vanilla child construct → replication) on the simplest buildable family.
+
+**Why this first:** scaling's commit path is already the vanilla server-authoritative build path, so Slice 0
+is mostly *verification*, not new construction code. It gives us a green baseline before we touch the #334
+auto-connect hooks.
+
+**Code-level state established this session (2026-06-08, static trace):**
+1. **The scaling RCO is dead code on the build path.** The input path
+   `USFSubsystem::ApplyAxisScaling` (`SFSubsystem.cpp:938`) mutates **local** counter state
+   (`GridStateService`) and scales the **local preview hologram** directly. It **never calls**
+   `USFRCO::Server_ApplyScaling` — that RPC has no caller anywhere outside `SFRCO.cpp/.h`. So scaling is a
+   purely local-preview operation; closing TODO #22 (`HasHologramAuthority`) is **NOT** what Slice 0 needs.
+2. **Commit happens through the vanilla build-gun fire, not a Smart RPC.** Scaled cells are vanilla
+   `AFGHologram` child holograms added via `AddChild()`; the parent's vanilla `Construct()` traverses them,
+   and each child (`ASFBuildableChildHologram::Construct`, `SFBuildableChildHologram.cpp:36`) is built with a
+   vanilla `FNetConstructionID`. No direct `SpawnActor`, no manual cost — confirmed.
+3. **Therefore the real Slice 0 question is a vanilla-replication question:** when a *client* fires the build
+   gun on a scaled grid, does Satisfactory's build-gun construct path **serialize/replicate the custom SF
+   child holograms to the server** so the server reconstructs all cells? Vanilla supports nested child
+   holograms (blueprints, poles), but SF's children are custom `AFGHologram` subclasses — whether they
+   round-trip the client→server construct message is exactly what the live test proves. This is the gate; no
+   feature code to write before we have the test result.
+4. Cosmetic other-client preview echo (TODO #21) is explicitly **out of scope** for parity.
+
+**Host + client test setup (maintainer-driven build, per AGENTS.md):**
+- Build the Shipping DLL via the golden path; deploy to the game dir.
+- **Host:** launch Satisfactory, load a flat test save, **Open to LAN / listen server**.
+- **Client:** second machine (or second Steam account / second instance) joins the listen server.
+- **Test A (baseline, host):** host equips build gun, scales a 3×3×1 foundation grid, places. Expect 9
+  foundations, correct total cost. (Sanity that the slice didn't regress SP/host.)
+- **Test B (the actual proof, client):** **client** does the same 3×3×1 scaled placement. Expect: all 9
+  foundations visible on **both** host and client; cost deducted from the **client's** inventory only;
+  nothing duplicated/ghosted on either side; save → reload → still 9.
+- **Test C (factory family):** repeat Test B with a simple factory building (e.g. a 2×1 of Constructors) to
+  cover a non-foundation buildable.
+- **Pass criteria:** host and client agree on count, position, and cost; no client-only ghost actors; clean
+  save/reload. **Diagnostics:** temporary `UE_LOG(LogSmartFoundations, Display, …)` at the RPC entry, the
+  authority branch, and the per-child construct — `Display`, not `VeryVerbose` (won't show in-game).
+
+### After Slice 0 — Slice 1: fix #334 power (smallest real bug)
+Gate `OnPowerPoleBuilt` behind authority; for client builds, route the pole-to-pole wire request through
+`USFRCO` so the server spawns the `AFGBuildableWire` and it replicates. Same host+client harness, asserting
+power actually transmits on the client. Belts and pipes follow with the identical pattern.
+
+---
+
+## Sequencing (updated)
+
+1. **Slice 0** — client scaled placement parity (this slice).
+2. **Slice 1** — #334 power wire authority + RCO route.
+3. **Slice 2** — #334 belt chain + pipe network authority (same pattern).
+4. **Slice 3** — per-player request context; replace build-path `GetFirstPlayerController` (8 sites).
+5. **Slice 4** — Extend (#309) authority + tier-by-builder.
+6. **Slice 5** — SmartUpgrade execution authority + execute-time unlock revalidation.
+7. **Dismantle proxy** authority guard — fold in opportunistically (small, `SFSubsystem_OnActorSpawned.cpp:61`).
+8. **#176 dedicated server** — certify after listen-server parity holds (packaging already shipped 31.0.2).
+
+## Open questions (carried forward, now answerable)
+- **Listen server first** — yes; dedicated (#176) after parity. Confirmed by the deferred-hook pattern: a
+  listen server exercises both host-authority and client-request paths.
+- **Do other players see preview grids?** Out of scope for parity; keep preview local (TODO #21 cosmetic).
+- **Experimental MP toggle?** Worth adding so high-risk features (Extend/Upgrade) can be disabled per-session
+  while Slices 0–2 stabilize — decide before Slice 4.
+
+## Doc-hygiene follow-ups (not this session)
+- Correct `IMPL_AutoConnect_CurrentFlow.md:24-25` ("Power is the only direct-spawn") — belts/pipes now also
+  commit via post-build hooks.
+- Add MP authority caveats to `IMPL_SmartDismantle_CurrentFlow.md` (proxy spawn) and note #341/#354 in the
+  Scaling and AutoConnect current-flow docs.

--- a/docs/Features/Multiplayer/PLAN_MultiplayerSupport_Revalidation_1.2.md
+++ b/docs/Features/Multiplayer/PLAN_MultiplayerSupport_Revalidation_1.2.md
@@ -242,20 +242,37 @@ Diagnosis (what each observation rules in/out):
 - **Single-player is unaffected** — large grids (historically 3000+ children) build fine in SP, where the
   construct is local and never serialized. The limit is specific to the **client→server networked construct**.
 
-**Root cause (leading):** a single client→server construct carrying N child holograms is rejected wholesale
-above ~100–144 children — a **count limit in the networked construction path** (candidate: net-construction-ID
-pool / reliable-bunch / sub-object cap). The parent hologram's vanilla `Construct` serializes `mChildren` to
-the server; beyond the limit the whole construct fails atomically. Two distinct **client-side cleanup**
-failure modes layer on top: at moderate over-cap (256) the orphaned previews self-clean after ~1 min; at very
-large counts (1250) they persist as walk-through ghosts with the build gun consumed.
+**Root cause (CONFIRMED from vanilla headers, 2026-06-08):** the whole scaled grid commits as **one reliable
+RPC** — `UFGBuildGunStateBuild::Server_ConstructHologram(FNetConstructionID, FConstructHologramMessage)`
+(`Equipment/FGBuildGunBuild.h:208-209`, `Server, Reliable`). Every child rides inside
+`FConstructHologramMessage.SerializedHologramData`, a single `TArray<uint8>` holding the entire hologram tree
+serialized via `IFGConstructionMessageInterface::SerializeConstructMessage` (`FGConstructionMessageInterface.h`;
+`mChildren` serialized with the parent — `Hologram/FGHologram.h:126,729`). So the construct is **inherently
+all-or-nothing** (one RPC, one blob), and above ~100–144 children the serialized blob exceeds UE's
+**reliable-bunch / packet size ceiling** (an *engine-level* limit, not a FactoryGame constant — which is why
+it never appears in a Smart/FactoryGame grep, and the modding docs don't mention it). "Count-based vs
+byte-based" reconciles: each child serializes to a roughly constant size, so the byte ceiling ≈ count ×
+constant and foundations vs actors hit the same threshold (their child-hologram serialization is similar).
 
-**Fix direction:**
+**Why previews orphan:** vanilla has a failure callback `Client_OnBuildableFailedConstruction(FNetConstructionID)`
+(`FGBuildGunBuild.h:328`) — but it only fires if the **server processes** the message. An oversized RPC
+dropped at the net layer **never reaches the server**, so the callback never fires and the client never learns
+it failed → orphaned previews. The two observed cleanup modes (256 → self-clean ~1 min; 1250 → persistent
+walk-through ghosts, build gun consumed) are downstream of this missing-ack path.
+
+**Fix direction (grounded in the vanilla path above):**
 1. **Chunk** client-originated scaled placement into sub-batches of ≤~64–100 children, each committed as its
-   own construct, so each stays under the net limit. Single-player can keep the single-construct path.
-2. **Reconcile** local preview holograms when the server does not confirm the build (destroy orphans) — fixes
-   the ghost-cleanup bug; degrades worse with size.
-3. **Confirm the exact constant** via a code review of the build-gun / hologram net-construct path (the
-   maintainer flagged the 30.1.0 "smoother grid scaling / children-at-higher-counts" rework as related).
+   own `Server_ConstructHologram` call, so each serialized blob stays under the reliable-bunch ceiling.
+   Single-player can keep the one-shot path. (Lever: Smart already owns the multi-child hologram; the chunking
+   happens at the commit seam, not in `SerializeConstructMessage`.)
+2. **Reconcile** orphaned previews two-pronged: hook `Client_OnBuildableFailedConstruction` for the
+   server-rejected (deliverable-but-refused) case, **plus** a client-side timeout/ack for the dropped-RPC case
+   where that callback never fires (the oversized-blob case). Without the timeout, the ghost cleanup stays
+   broken for exactly the failure we hit.
+3. **Exact constant is engine-level** (UE reliable bunch / packet size), not a FactoryGame/Smart constant — so
+   the chunk size is chosen empirically (≤100 proven safe here) rather than read from a header. The modding
+   docs do not cover this; the vanilla headers (`FGBuildGunBuild.h`, `FGConstructionMessageInterface.h`,
+   `FGHologram.h`) are the authority.
 
 **Significance for the matrix:** scaling's MP risk is **lower than the 2026-05-20 matrix assumed** — the
 commit path is the safe vanilla server-authoritative path and it works for both lightweight and actor

--- a/docs/Features/Multiplayer/PLAN_MultiplayerSupport_Revalidation_1.2.md
+++ b/docs/Features/Multiplayer/PLAN_MultiplayerSupport_Revalidation_1.2.md
@@ -214,7 +214,7 @@ auto-connect hooks.
 ### Slice 0 — EMPIRICAL RESULT (2026-06-08, live dedicated-server test)
 
 Run against a **claimed Windows dedicated server** (CL491125) with a game client joined via
-`open 127.0.0.1`, observing the **server's authoritative state live** through the SmartMCP dedi API
+`open 127.0.0.1`, observing the **server's authoritative state live** through live server-state inspection
 (port 51096). This is Approach B — stricter than a listen server (no PC index 0 on the dedi).
 
 **Headline: client-originated scaled placement WORKS in MP — for normal grid sizes, for both buildable

--- a/docs/Features/Multiplayer/PLAN_MultiplayerSupport_Revalidation_1.2.md
+++ b/docs/Features/Multiplayer/PLAN_MultiplayerSupport_Revalidation_1.2.md
@@ -281,6 +281,20 @@ walk-through ghosts, build gun consumed) are downstream of this missing-ack path
    docs do not cover this; the vanilla headers (`FGBuildGunBuild.h`, `FGConstructionMessageInterface.h`,
    `FGHologram.h`) are the authority.
 
+**RESULT (live testing, 2026-06-08) — chunking is NOT viable; shipped a safety guard instead.**
+The ceiling is exactly **65536 bytes** (foundations 136 OK/137 fail, constructors 135/136 — off-by-one proves
+byte-based). A *single* chunk built cleanly via the natural player fire (shrink `mChildren` before vanilla
+serializes → 65536→32768 bytes, builds). But building the *remaining* chunks requires driving extra constructs,
+and all three mechanisms failed: (1) synchronous build-gun re-fire never constructs (single-construct-per-fire
+state machine); (2) deferred per-frame re-fire never constructs either (build gun only constructs on real
+input); (3) hand-building `FConstructHologramMessage` + calling `Server_ConstructHologram` directly **crashes
+the dedicated server** (`UNetDriver::InternalTickDispatch`), despite the client side fully working (package map
+resolves, blob serializes, derived `FNetConstructionID` Client_IDs send). **Conclusion: full-auto large-grid
+MP placement is not safely achievable with available APIs.** Current code: a **safety guard** at the client
+fire handler refuses an oversized grid (>130 cells) before any send — no crash, no orphan, grid stays live to
+scale down. Large-grid MP placement is parked for the *complete* MP solution (which cannot ship partially);
+revisit only if vanilla exposes the construct sequencing.
+
 **Significance for the matrix:** scaling's MP risk is **lower than the 2026-05-20 matrix assumed** — the
 commit path is the safe vanilla server-authoritative path and it works for both lightweight and actor
 buildables at normal scale. The only defect is the large-batch ceiling + preview cleanup, both bounded and

--- a/docs/Features/Multiplayer/REF_DedicatedServerSetup.md
+++ b/docs/Features/Multiplayer/REF_DedicatedServerSetup.md
@@ -1,0 +1,121 @@
+---
+title: Dedicated Server Setup (Windows + Linux) — for #176 certification
+type: REFERENCE
+date: 2026-06-08
+status: Active
+category: Features
+related:
+  - ./PLAN_MultiplayerSupport_Revalidation_1.2.md
+  - ./REF_SMLMultiplayerNotes.md
+issues:
+  - 176  # Dedicated server support (umbrella)
+---
+
+# Dedicated Server Setup (Windows + Linux)
+
+Grounded in the official Satisfactory modding docs (`ForUsers/DedicatedServerSetup.adoc`,
+`Development/TestingResources.adoc`, `Development/UpdatingToDedi.adoc`) and the Satisfactory wiki
+dedicated-server guide. This is the reference for standing up a dedi to certify Smart! on dedicated servers
+(#176).
+
+## Read this first — sequencing
+
+- **Slice 0 (client scaled-placement parity) does NOT need a dedicated server.** It uses **Approach A**: two
+  game clients, one hosting a **listen server** (host sets Session Type = `IP`, client runs `open
+  127.0.0.1`). See `REF_SMLMultiplayerNotes.md`. Run Slice 0 first on a listen server; it exercises both
+  host-authority and client-request paths.
+- A dedicated server is **Approach B**, needed to *certify* #176. A dedi has **no player controller index 0**
+  at all — so it is the strict test for our `GetFirstPlayerController` build-path hazards (they don't just
+  pick the wrong player on a dedi, they have no PC to pick). Do this **after** listen-server parity holds.
+
+## Hard prerequisite: Smart! must be compiled for the SERVER target
+
+> "Do NOT naively copy-paste your client's mods folder to a server — this will not work. The compiled files
+> used by the game client will not work on dedicated servers."
+
+- The client Shipping DLL from the AGENTS.md golden path is **client-only**. A dedi needs the mod built and
+  packaged for the **server platform target** (Windows Server and/or Linux Server).
+- 31.0.2 shipped a **Windows dedicated-server package** (so the mod can be version-matched on a Windows
+  dedi) but it is **uncertified**. **Linux server is a separate target compile** and is not yet produced —
+  standing up a Linux dedi will surface whether the Linux server target even builds/cooks cleanly (likely the
+  first concrete #176 work item on the Linux side).
+- Packaging the server targets is an Alpakit step (maintainer-driven, like the client package). Confirm
+  Alpakit's server-platform options are enabled for SmartFoundations before attempting a dedi install.
+
+## A. Windows self-hosted dedicated server (SteamCMD)
+
+1. **Install SteamCMD.** Download `steamcmd.zip`, extract to e.g. `C:\steamcmd`, run `steamcmd.exe` once to
+   self-update.
+2. **Install the dedicated server** (Steam app **1690800**, separate from the game app 526870):
+   ```
+   steamcmd +force_install_dir C:\SatisfactoryDedicatedServer +login anonymous +app_update 1690800 validate +quit
+   ```
+   For the experimental branch: `+app_update 1690800 -beta experimental validate`.
+3. **Launch** (minimum args from the docs):
+   ```
+   FactoryServer.exe -log -EpicPortal -NoSteamClient
+   ```
+   A local dedi doesn't need Steam/Epic auth to be reachable on the LAN.
+4. **Claim + load a save.** Use a normally-launched client (Steam/Epic) for the one-time claim. A locally
+   installed dedi shares your personal save folder, so *uploading* a save fails — instead select a save by
+   editing the server's **session name** (Satisfactory wiki: "Loading a save file").
+5. **Connect** via the server browser or `open 127.0.0.1` (or `open <LAN-IP>` from another machine).
+6. **Firewall:** default game/query/beacon ports `7777/15777/15000` UDP (plus the Steam range) if joining
+   from another box.
+
+## B. Linux self-hosted dedicated server (SteamCMD)
+
+1. **Install SteamCMD** (Debian/Ubuntu example):
+   ```
+   sudo apt update && sudo apt install -y steamcmd      # or the distro's package / the tarball
+   ```
+2. **Install the dedicated server:**
+   ```
+   steamcmd +force_install_dir ~/SatisfactoryDedicatedServer +login anonymous +app_update 1690800 validate +quit
+   ```
+3. **Launch:**
+   ```
+   ~/SatisfactoryDedicatedServer/FactoryServer.sh -log
+   ```
+   Run under `systemd` (or `tmux`/`screen`) for persistence. A minimal unit:
+   ```ini
+   [Unit]
+   Description=Satisfactory Dedicated Server
+   After=network.target
+   [Service]
+   ExecStart=/home/<user>/SatisfactoryDedicatedServer/FactoryServer.sh -log
+   User=<user>
+   Restart=on-failure
+   [Install]
+   WantedBy=multi-user.target
+   ```
+4. **Claim + connect** the same way (claim from a normal client, then `open <server-ip>`).
+5. **Ports:** same `7777/15777/15000` UDP; open them in `ufw`/firewalld if remote.
+
+## C. Installing Smart! on the dedi (after the server target is packaged)
+
+Use **Satisfactory Mod Manager (SMM ≥ 3.0)** or **ficsit-cli** — never hand-copy client mod files.
+- **Shut the server down first** (running server locks mod files).
+- **Local install:** SMM/ficsit-cli often auto-detect a Steam/Epic dedi and tag it `DS` in the dropdown;
+  otherwise point the tool at the folder containing `FactoryServer.exe`/`FactoryServer.sh` (local path on the
+  same machine, or SFTP/SMB for a remote box — SFTP preferred).
+- **Server↔client version consistency is mandatory** — clients must run the exact same mod set/version or the
+  join is rejected. Manage client + server from the **same SMM/ficsit-cli profile** to avoid drift.
+- **Mod config:** no remote config UI on dedis — configure Smart! client-side and copy the config files to the
+  server; mismatched configs can misbehave. (Relevant for Smart!'s `Smart_Config`.)
+- Restart the server after any mod change.
+
+## D. Local test loop for #176 (Approach B)
+
+Per `Development/TestingResources.adoc`: run the dedi locally (`FactoryServer.exe -log -EpicPortal
+-NoSteamClient`), claim once with a normal client, then connect the launch-script client via `open
+127.0.0.1`. Every iteration needs the **server-target** mod recompiled and redeployed (Alpakit can copy to a
+network path like `//host/share/satisfactory` for a remote box), and the server restarted to reload files.
+
+## Open setup decisions (to confirm before standing one up)
+
+- **Where:** local Windows box (same machine as dev), a separate Linux box/VM, or both? (Both eventually, for
+  target coverage; pick the first to certify.)
+- **Branch:** stable vs experimental dedi (must match the client branch we test against).
+- **Server-target packaging:** confirm Alpakit produces the Windows *and* Linux server packages for
+  SmartFoundations; if Linux doesn't build/cook, that's the first Linux #176 task.

--- a/docs/Features/Multiplayer/REF_DedicatedServerSetup.md
+++ b/docs/Features/Multiplayer/REF_DedicatedServerSetup.md
@@ -147,6 +147,37 @@ Sequence to a working modded Windows dedi:
 3. Apply the **SmartFoundations server package** at the version matching the client under test.
 4. Connect client via `open 127.0.0.1`; run the MP tests.
 
+### Update (2026-06-08, second boot) — SML fixed; real blocker is SmartFoundations not deployed for the server target
+
+After updating SML to 3.12.0 via SMM, the **PSAPI/SML crash is gone** — SML 3.12.0 and a SmartCamera
+WindowsServer rebuild both load. The server now aborts at a **different, later** point:
+
+```
+Unable to load plugin 'SmartFoundations'. Aborting.   (PluginManager ConfigureEnabledPlugins)
+```
+
+Root cause: **`SmartCamera.uplugin` hard-declares a dependency on SmartFoundations**
+(`"Plugins": [ { "Name": "SmartFoundations", "Enabled": true, "SemVersion": ">=25.0.0" }, ... ]`), but
+**SmartFoundations is not deployed for the WindowsServer target** — there is no
+`Mods/GameFeatures/SmartFoundations/` on the server. SmartCamera can't satisfy its dependency → fatal abort.
+(Renaming the SmartCamera folder in place does **not** disable it: UE plugin discovery scans for the
+`.uplugin` file regardless of folder name; to truly disable a GameFeature, move it out of the server tree.)
+
+Dev-env state: a current **SF server DLL** (`Binaries/Win64/FactoryServer-SmartFoundations-Win64-Shipping.dll`,
+2026-06-08) and cooked `Saved/Cooked/WindowsServer/` content exist, but **no packaged WindowsServer pak**
+and nothing deployed. SmartCamera, by contrast, has the full deployed set on the server:
+`FactoryServer-SmartCamera-Win64-Shipping.dll` + `.modules` + `Content/Paks/WindowsServer/*.pak/.ucas/.utoc`
++ `.uplugin` + `Resources/Icon128.png`. That set is the **template** for what a complete SF server deploy
+needs.
+
+**Fix (maintainer / Alpakit, do NOT hand-mix DLL+pak — BuildId trap):** run Alpakit with the **WindowsServer**
+target for SmartFoundations (the same step that produced the working SmartCamera server package) and deploy
+to `Mods/GameFeatures/SmartFoundations/`. Then re-boot; SmartCamera's dependency resolves and the server
+should reach a ready state, after which it can be claimed.
+
+Verified-good so far: server core (CL491125), SML 3.12.0, SmartCamera WindowsServer build. Outstanding:
+SmartFoundations WindowsServer package + deploy, then claim.
+
 ## Open setup decisions (to confirm before standing one up)
 
 - **Where:** local Windows box (same machine as dev), a separate Linux box/VM, or both? (Both eventually, for

--- a/docs/Features/Multiplayer/REF_DedicatedServerSetup.md
+++ b/docs/Features/Multiplayer/REF_DedicatedServerSetup.md
@@ -178,6 +178,37 @@ should reach a ready state, after which it can be claimed.
 Verified-good so far: server core (CL491125), SML 3.12.0, SmartCamera WindowsServer build. Outstanding:
 SmartFoundations WindowsServer package + deploy, then claim.
 
+### RESOLVED (2026-06-08, third boot) — modded dedi boots clean
+
+The real blocker turned out to be the **SML server binary**: the active SMM profile pinned **SML 3.11.3**
+and the deployed `FactoryServer-SML-Win64-Shipping.dll` was the **Jan-2 pre-1.2 build** that fails the
+`PSAPI.DLL` import (GetLastError=127). Once SmartFoundations was deployed and plugin-*configure* passed, the
+engine reached module-*load* and the stale SML surfaced — with SmartFoundations (126: `Missing import:
+FactoryServer-SML-Win64-Shipping.dll`) and SmartCamera cascading off it. The "SML fixed" read from the
+second boot was a false positive: that boot aborted earlier (SF missing at configure) before any module DLL
+loaded.
+
+Fix applied by the maintainer: rebuilt **SML + SmartFoundations + SmartCamera** for the WindowsServer target
+to both the game and the dedi (SML server DLL now 3.12.0, 2026-06-07). Result — **clean boot**:
+
+```
+LogServer: Server API listening on [::]:7777 Dedicated Server
+LogNet:    GameNetDriver ... IpNetDriver listening on port 7777
+LogGame:   Discovered 1 Remote Call Objects on AFGGameMode::InitGame   <-- USFRCO registers server-side
+LogSmartFoundations: ClearRegistry: Cleared 0 hologram entries          <-- SF module live
+LogSmartCamera: Subscribed to SFSubsystem ... (IsBound: YES)            <-- dependency chain OK
+LogServer: Server startup time elapsed and saving/level loading is done
+```
+
+Process `FactoryServer-Win64-Shipping-Cmd` healthy (~308 MB). Loads `DedicatedserverEntry` (unclaimed).
+**Lesson:** SMM "looks up to date" can be misleading — verify the on-disk server **binary date/version**, not
+just the profile lock. The dedi needs the SML *server* binaries actually replaced, which here required a
+local server-target rebuild because the dev env is ahead of (or differs from) the SMR-pinned 3.11.3.
+
+**Remaining to a usable test server:** claim it from a normal game client (admin password + server name +
+create/select a save); the entry map is expected until a save is loaded. Then connect via `open 127.0.0.1`.
+Infrastructure (SML + SF + SmartCamera + RCO) is validated.
+
 ## Open setup decisions (to confirm before standing one up)
 
 - **Where:** local Windows box (same machine as dev), a separate Linux box/VM, or both? (Both eventually, for

--- a/docs/Features/Multiplayer/REF_DedicatedServerSetup.md
+++ b/docs/Features/Multiplayer/REF_DedicatedServerSetup.md
@@ -112,6 +112,41 @@ Per `Development/TestingResources.adoc`: run the dedi locally (`FactoryServer.ex
 127.0.0.1`. Every iteration needs the **server-target** mod recompiled and redeployed (Alpakit can copy to a
 network path like `//host/share/satisfactory` for a remote box), and the server restarted to reload files.
 
+## Current state (2026-06-08) — Windows dedi already installed, first blocker found
+
+A Windows dedicated server is **already installed** at
+`<SteamLibrary>\steamapps\common\SatisfactoryDedicatedServer` and is **version-matched to the client**:
+`CL491125 / GameVersion 1.2.2.2 / branch rel-main-1.2.0` (Steam app 1690800, buildid 23300422). It is
+**unclaimed** (no SaveGames, no Session/Admin config yet).
+
+**First concrete #176 blocker — stale server-side SML.** Launching the vanilla server
+(`FactoryServer.exe -log -unattended -NoSteamClient`) **crashes on boot**:
+
+```
+Failed to load '...\Mods\SML\Binaries\Win64\FactoryServer-SML-Win64-Shipping.dll' (GetLastError=127)
+  Missing import: PSAPI.DLL
+Plugin 'SML' failed to load because module 'SML' could not be loaded.
+```
+
+Cause: the server has **SML 3.11.3 (DLL dated 2026-01-02, `GameVersion ">=416835"` = pre-1.2)** installed,
+but the server binaries are the **June 1.2 build (CL491125)**. `GetLastError=127` is ERROR_PROC_NOT_FOUND —
+PSAPI.DLL *is* present on the system, so this is the stale pre-1.2 SML DLL being ABI-incompatible with the
+1.2 engine (export mismatch), not a missing system file. The client/dev env is on **SML 3.12.0** (and the
+dev env already has a current server-target SML DLL dated 2026-06-07).
+
+**Fix (mod-manager, maintainer-driven — do NOT hand-copy binaries):** update the server install's SML to the
+**3.12.0 / 1.2 server target** via SMM or ficsit-cli pointed at the server folder. Re-applying the managed
+profile should pull the correct `WindowsServer` (and later `LinuxServer`) target binaries. Do **not** copy
+the dev-env `FactoryServer-SML-Win64-Shipping.dll` over the stale one by hand — the cooked pak/BuildId must
+match (same trap as the content-cook BuildId rule in AGENTS.md). After SML 3.12.0 loads cleanly (vanilla-ish
+boot), the SmartFoundations **server target** (31.0.2 Windows server package) can be applied on top.
+
+Sequence to a working modded Windows dedi:
+1. Mod manager → server install → update **SML → 3.12.0** (server target). Boot vanilla-clean.
+2. Claim the server from a normal game client (set admin password + server name, create/select a save).
+3. Apply the **SmartFoundations server package** at the version matching the client under test.
+4. Connect client via `open 127.0.0.1`; run the MP tests.
+
 ## Open setup decisions (to confirm before standing one up)
 
 - **Where:** local Windows box (same machine as dev), a separate Linux box/VM, or both? (Both eventually, for

--- a/docs/Features/Multiplayer/REF_SMLMultiplayerNotes.md
+++ b/docs/Features/Multiplayer/REF_SMLMultiplayerNotes.md
@@ -1,0 +1,136 @@
+---
+title: SML / Satisfactory Multiplayer — Grounded Reference Notes
+type: REFERENCE
+date: 2026-06-08
+status: Active
+category: Features
+related:
+  - ./PLAN_MultiplayerSupport_Revalidation_1.2.md
+  - ./PLAN_MultiplayerSupport_Matrix.md
+---
+
+# SML / Satisfactory Multiplayer — Grounded Reference Notes
+
+Distilled from the official Satisfactory modding documentation
+(`satisfactorymodding/Documentation`, cloned locally for grounding; HEAD `ea7cc38` as of 2026-06-08).
+Source `.adoc` pages live under the cloned repo's `modules/ROOT/pages/Development/Satisfactory/` and
+`.../Development/` trees. This file is the on-our-side summary so MP work stays grounded in real CSS/SML
+guidance rather than assumptions. Where this and our own planning docs agree, that agreement is now
+*sourced*; where vanilla behavior is uncertain, the docs say "test it" — which is why Slice 0 is a live test.
+
+## Core principle (matches our approach)
+
+> "Mods coded properly for multiplayer will also work in singleplayer — no additional code paths are
+> required specifically for singleplayer."
+
+So: no SP-only branches where a server-authoritative path exists. As soon as a mod **handles user input or
+uses custom logic to modify game state** (exactly what Smart! does), it needs MP consideration.
+
+## Authority
+
+- Check authority with `AActor::HasAuthority()`. If you lack an actor, use the **GameState** as the actor to
+  check against (`UGameplayStatics::GetGameState`).
+- **This is the fix shape for #334**: our post-build hooks (`OnPowerPoleBuilt`, pipe deferred-wiring,
+  stackable-belt chain registration, dismantle proxy spawn) currently run on every peer with no
+  `HasAuthority()` gate — see `PLAN_MultiplayerSupport_Revalidation_1.2.md`.
+
+## Avoid Player Controller index 0 (validates our GetFirstPlayerController audit)
+
+> "Dedicated servers have no player controller, so you should generally avoid using Get Player Controller
+> with index 0… it will break if the game ever implements local splitscreen support."
+
+- This is the official basis for our 8 build-path `GetFirstPlayerController()` hazards. UI-only use on a side
+  that *has* a valid PC0 can work, but build/authority logic must not depend on PC0.
+- **Dedicated-server (#176) consequence:** any path that assumes a local PC0 is outright broken on a dedi
+  (no PC0 at all), not merely "wrong player." Our 8 hazard sites must route the requesting PC through the RCO.
+
+## RCO vs Replicated Subsystem (the routing rule)
+
+| Use an **RCO** when… | Use a **Replicated Mod Subsystem** when… |
+|---|---|
+| RPC goes client → server | RPC goes server → one/more clients |
+| Triggered by a client action | Triggered automatically / without client action |
+| — | The RPC is **Multicast** |
+
+- **Never multicast on an RCO** — RCOs are owned per-player-controller and don't exist on every connection;
+  multicasting one will **softlock and crash** clients. Multicast belongs on a replicated subsystem.
+- RCOs are spawned by the server per player controller and network-owned by that controller (that ownership
+  is what lets client→server RPCs fire at all).
+- Retrieve at runtime: `AFGPlayerController::GetRemoteCallObjectByClass(UMyRCO::StaticClass())`. Can return
+  **nullptr** (e.g. before registration completes) — client code needs null-checks + fallback logging.
+- Register via the Game Instance Module's `Remote Call Objects` array (Smart! registers `USFRCO` in
+  `SmartFoundations.cpp:73`).
+
+### RCO C++ gotcha (we must verify USFRCO complies)
+
+An RCO **must have at least one replicated `UPROPERTY`** and must add it to `GetLifetimeReplicatedProps`,
+or Unreal won't replicate the RCO and RPCs silently won't work:
+
+```cpp
+UCLASS()
+class UDocModRCO : public UFGRemoteCallObject {
+    GENERATED_BODY()
+public:
+    UFUNCTION(Server, WithValidation, Reliable)
+    void DoThingRPC(ADocMachine* context, bool bData);
+
+    UPROPERTY(Replicated)
+    bool bDummy = true;          // must exist
+};
+
+void UDocModRCO::GetLifetimeReplicatedProps(TArray<FLifetimeProperty>& Out) const {
+    Super::GetLifetimeReplicatedProps(Out);
+    DOREPLIFETIME(UDocModRCO, bDummy);   // must be registered
+}
+```
+
+> **CONFIRMED GAP (2026-06-08):** `USFRCO` (`Public/SFRCO.h`) has **no replicated `UPROPERTY` and no
+> `GetLifetimeReplicatedProps` override**. Per the official guidance above, this means the RCO does not
+> replicate and **its client→server RPCs do not actually work in MP** — almost certainly why the scaling
+> input path mutates local state directly (`SFSubsystem.cpp:938`) and never calls `Server_ApplyScaling`.
+> This is a real, concrete fix item, not just a planning note: add a `UPROPERTY(Replicated) bool bDummy`
+> and register it in `GetLifetimeReplicatedProps`. Sequence it into Slice 1 (it's a prerequisite for *any*
+> Smart RCO route working, including the #334 power-wire request).
+
+- Pass **one context parameter** so the server knows which object to act on, and **revalidate on the server**
+  (treat client input as proposed). `Server, WithValidation, Reliable` is the standard signature.
+
+## Inventory / property replication
+
+- Replication Detail Components are **gone** as of 1.0 — replaced by **Conditional Property Replication**
+  (CSS-custom, reduces data sent to clients). See `ConditionalPropertyReplication.adoc` for inventory
+  components. Relevant if Smart! ever needs to read/replicate inventory state for cost validation.
+- **TMaps don't replicate** — replicate an array of structs (or array of values when keys are derivable) and
+  rebuild the map in an `OnRep`. Avoid two parallel key/value arrays (arrival not synchronized).
+
+## Local multiplayer test harness (grounds Slice 0)
+
+**Approach A — two game clients (fastest iteration, our default):**
+1. Launch two copies of the Steam client detached from the launcher (the docs' Quick Launch Script does this;
+   normally Steam blocks a second copy). Flags of note: `-Multiprocess` (don't clobber shared .ini),
+   `-CustomConfig=` (more consistent MP GUIDs), `-log -NewConsole`.
+2. **Host copy:** load a save; before loading, **Load Settings → Session Type = `IP`**.
+3. **Client copy:** Join Game → `127.0.0.1`, or run the `open 127.0.0.1` console command (or
+   `-clientAutoJoin` in the script).
+- Caveat: this approach yields **inconsistent player GUIDs** across launches. If a stable GUID is needed,
+  use a real Epic/Steam copy for one side (requires compiling for both targets).
+
+**Approach B — local dedicated server + client (required to certify #176):**
+- Install a local dedi (`FactoryServer.exe -log -EpicPortal -NoSteamClient`), claim it once with a normally
+  launched client, then connect via `open 127.0.0.1`. Requires compiling the mod for the **server target**
+  too. This is the path for dedicated-server certification (#176), to run **after** listen-server parity holds.
+
+**For our build flow:** Smart! ships a Shipping client DLL via the AGENTS.md golden path. Approach A only
+needs the client target, so it fits the existing build loop; Approach B (dedi) adds a server-target compile —
+defer until the dedicated-server slice.
+
+## Where the full source pages live (cloned, for deeper reading)
+
+- `Development/Satisfactory/Multiplayer.adoc` — the canonical page (authority, RCO, subsystems, replication).
+- `Development/Satisfactory/ConditionalPropertyReplication.adoc` — inventory replication (1.0+).
+- `Development/Satisfactory/DedicatedServerAPIDocs.adoc` + `Development/UpdatingToDedi.adoc` — dedi specifics (#176).
+- `Development/TestingResources.adoc` — the launch script + MP test approaches above.
+- `Development/ModLoader/Subsystems.adoc` — replicated mod subsystem replication-policy field.
+- ExampleMod (`Mods/GameFeatures/ExampleMod/` in the SML monorepo) — `Widget_MultiplayerDemoBuilding`,
+  `Build_MultiplayerDemoBuilding` (replicated property + RepNotify), `ReplicationExampleSubsystem`
+  (multicast), and the `CC_ExampleReplication` chat command (the "don't multicast on an RCO" demo).

--- a/docs/Reference/FicsitApp/ficsit.app.SmartFoundations.md
+++ b/docs/Reference/FicsitApp/ficsit.app.SmartFoundations.md
@@ -1,8 +1,8 @@
 # <img src="https://github.com/majormer/SmartFoundations/blob/main/images/Smart-Logo.png?raw=true" width="150" alt="Smart! Logo"> Smart! Mod
 
-![Status](https://img.shields.io/badge/Status-Released-brightgreen) ![Version](https://img.shields.io/badge/Version-31.1.0-blue) ![Satisfactory](https://img.shields.io/badge/Satisfactory-1.2-blue) ![Engine](https://img.shields.io/badge/Engine-UE%205.6-blue) ![SML](https://img.shields.io/badge/SML-3.11.x-blue) ![Multiplayer](https://img.shields.io/badge/Multiplayer-Testing-orange) ![AI Assisted Development Used](https://img.shields.io/badge/AI%20Assisted%20Development%20Used-Disclosure%20Below-blue)
+![Status](https://img.shields.io/badge/Status-Released-brightgreen) ![Version](https://img.shields.io/badge/Version-32.0.0-blue) ![Satisfactory](https://img.shields.io/badge/Satisfactory-1.2-blue) ![Engine](https://img.shields.io/badge/Engine-UE%205.6-blue) ![SML](https://img.shields.io/badge/SML-3.12-blue) ![Multiplayer](https://img.shields.io/badge/Multiplayer-Supported-brightgreen) ![AI Assisted Development Used](https://img.shields.io/badge/AI%20Assisted%20Development%20Used-Disclosure%20Below-blue)
 
-> **Multiplayer note:** Smart! is primarily developed for single-player. Multiplayer is under active testing with partial success, but is not currently considered fully supported.
+> **Multiplayer note:** As of v32.0.0, every Smart! feature works in multiplayer on dedicated servers (Windows and Linux). Multiplayer support is new in this release — if you hit something odd in a multiplayer session, please report it on [GitHub](https://github.com/majormer/SmartFoundations/issues) or [Discord](https://discord.gg/SgXY4CwXYw).
 
 **Quick links:** [Watch videos](#-watch-smart-in-action) • [First-time setup](#-first-time-setup) • [Extend explained](#-extend-explained-copy-an-existing-manifold) • [Supported buildings](#-supported-buildings) • [Wiki](https://github.com/majormer/SmartFoundations/wiki) • [Discord](https://discord.gg/SgXY4CwXYw) • [Report bugs](https://github.com/majormer/SmartFoundations/issues) • [Source](https://github.com/majormer/SmartFoundations)
 
@@ -65,12 +65,12 @@ Smart! is useful if you enjoy designing factories but do not enjoy repeating the
 - Copy a working production block and repeat it somewhere else.
 - Batch-upgrade belts, lifts, pipes, and power infrastructure after unlocking better tiers.
 - Keep a vanilla-like save: Smart! places standard Satisfactory buildings.
+- Build together: Smart! works in multiplayer on dedicated servers (Windows and Linux).
 
 ### Smart! may not be what you want if you expect:
 
 - Free buildings or free resources.
 - A creative-mode replacement.
-- A fully supported multiplayer experience today.
 - Perfect compatibility with every modded buildable or every other building-assist mod.
 
 ### Source Availability
@@ -101,44 +101,28 @@ See [LICENSE.md](https://github.com/majormer/SmartFoundations/blob/main/LICENSE.
 
 ---
 
-## 📰 What's New in v31.1.0
+## 📰 What's New in v32.0.0: Multiplayer
 
-**Current Release:** v31.1.0 — a belt-focused update on the Satisfactory **1.2** line. See the [full changelog](https://github.com/majormer/SmartFoundations/blob/main/CHANGELOG.md) for all release details.
+**Current Release:** v32.0.0 — the multiplayer release. See the [full changelog](https://github.com/majormer/SmartFoundations/blob/main/CHANGELOG.md) for all release details.
 
-### Highlights in v31.1.0
+### Smart! now works in multiplayer
 
-- **Standard conveyor pole auto-connect (new)** — scaling a standard Conveyor Pole now works like the Stackable pole: place one, scale out a line, and Smart! auto-connects belts between the poles at the height you set, with the whole line following as you raise or lower the height. (Tip: size the line first, then set the height.)
-- **Auto-connected belts between poles no longer stall or crash** — runs of auto-connected belts across Stackable / Wall / Ceiling conveyor poles used to fragment into disconnected pieces that could stop moving items after a reload, or even crash the game when items flowed through them. Smart! now stitches each pole run into one proper conveyor line as it's built, so it transports correctly and survives save/reload. A long-standing risk (present since around v29), now fixed.
+Every Smart! feature now works when you play as a client on a dedicated server: grid scaling, belt/pipe/power auto-connect, Extend and Scaled Extend, Smart Upgrade, Smart Restore presets, and Smart Dismantle — with normal build costs charged exactly as the preview shows. Everything Smart! places is a standard, fully replicated game building: other players see it, can use it, and can dismantle it, just as if it were built by hand.
 
-### Also in v31.0.2
+- **Windows and Linux dedicated servers** — the release includes server builds for both platforms, so Smart! runs on most hosted-server providers.
+- **For server admins** — install the same Smart! version on the server and on every client; the mod manager keeps these paired on update.
+- Multiplayer support is new in this release. If something behaves differently in a multiplayer session than in single-player, that's a bug — please report it on [GitHub](https://github.com/majormer/SmartFoundations/issues) or [Discord](https://discord.gg/SgXY4CwXYw).
 
-- **Packaged for Windows dedicated servers** — the release now includes a server build so the mod can be installed on a dedicated server and its version lines up with clients on update. Packaging only — multiplayer and dedicated servers are still **not officially supported** (full multiplayer support is planned for a future update).
-- **Smart! builds free in Creative Mode** — with No Build Cost on (now under Creative Mode in 1.2), auto-connect and Extend / Scaled Extend no longer ask for materials or block as "unaffordable"; they build for free, the same as base-game building.
-- **Power cable previews are back for Extend and Scaled Extend** — when you Extend a building that carries power, the preview again shows the cables (with droop) running between the source and each copy, sitting on the connectors and following each copy's rotation and chaining.
-- **Smart! Panel Routing dropdown opens on Stackable Conveyor Poles** — the Belt Auto-Connect *Routing* dropdown now lists Default / Curve / Straight and applies your choice; dragging the panel also closes any open dropdown.
+This release also fixes one-click Smart Dismantle for restored single modules, and adds belt repairs while building and on save load (including saves made on earlier versions) — see the [changelog](https://github.com/majormer/SmartFoundations/blob/main/CHANGELOG.md) for details.
 
-### Also in v31.0.1
+### Earlier in the 31.x line: Satisfactory 1.2
 
-- **Settings for Extend daisy-chain power** — the building-to-building power chaining now has its own controls under Options > Mods > Smart! > Building Behavior: turn it on or off, and choose whether Extending a pole-less machine starts a fresh daisy chain. Defaults match 31.0.0.
-- **Auto-connect conveyors and pipes no longer charge double** — an auto-connected belt or pipe used to preview at twice its real cost on the build gun; the preview now matches what the segment actually costs and refunds.
-- **Smart! Panel arrow keys fixed** — stepping a value with the Up/Down arrow keys no longer snaps back when the field loses focus.
-
-### Also in v31.0.0: Satisfactory 1.2
-
-> **One-time settings reset:** the Smart! settings menu was reorganized in 31.0.0, so your saved Smart! settings reset to their defaults the first time you load a 31.x build. Set them once and they'll stick from then on.
-
-- **Rebuilt for Satisfactory 1.2** — Smart! was migrated to the engine (UE 5.6) and the "Game Feature" plugin model that 1.2 uses. Every Smart! feature carries over with no intended gameplay change: grid building, Extend and Scaled Extend, belt/pipe/power auto-connect, Smart Upgrade, Restore presets, the Smart Panel, and all keybinds.
-- **Pipeline T-Junction support** — Satisfactory 1.2's new 3-way Pipeline T-Junction now works everywhere Smart! handles pipes (scaling, Extend, Scaled Extend, pipe auto-connect, and Restore presets), the same as the existing 4-way junction.
-- **Extend can daisy-chain building power** — once you research **Upgraded Power Connectors**, Extending a row of buildings wires their power directly building-to-building along the lane (one chain per row) instead of needing a power pole to each one. It only makes connections you could make by hand.
-- **More reliable stacked-pole belt auto-connect** — auto-connected belts between stackable conveyor poles, including across stacked levels and long runs, now carry items and stay correct after saving and reloading.
-- **Settings menu reorganized into labeled sections**, with a plain-language tooltip on every option.
-
-### Also in version 30: Smart Restore Enhanced
-
-Version 30 introduced **Smart Restore Enhanced** — a preset system for saving, applying, sharing, and replaying Smart Panel setups. Presets can capture grid size, spacing, steps, stagger, rotation, production recipe, auto-connect settings, and restored Extend topology. Use the Smart Panel's `Presets >>` button to save your current setup, apply a saved setup later, export or import a shared preset, or turn the last Extend layout you built into a reusable preset. Shared presets are checked against your current unlocks before they can be imported or applied.
+- **Rebuilt for Satisfactory 1.2** (v31.0.0) — Smart! was migrated to Unreal Engine 5.6 and the plugin model that 1.2 uses. Every Smart! feature carried over, and 1.2's new Pipeline T-Junction works everywhere Smart! handles pipes. (One-time note: settings were reorganized in 31.0.0, so saved Smart! settings reset to defaults the first time you load a 31.x-or-later build from 30.x or earlier.)
+- **Extend can daisy-chain building power** (v31.0.0) — once you research Upgraded Power Connectors, Extending a row of buildings wires power directly building-to-building along the lane, with settings to control it under Options > Mods > Smart!.
+- **Rock-solid belt runs between conveyor poles** (v31.1.0) — standard Conveyor Poles joined the auto-connect family, and auto-connected belt runs across pole lines were rebuilt to transport correctly and survive save/reload, fixing a long-standing stall/crash risk.
+- Plus a series of quality fixes across 31.0.1–31.1.0: free building in Creative Mode, power-cable previews for Extend, corrected auto-connect costs, and Smart! Panel fixes — all in the [changelog](https://github.com/majormer/SmartFoundations/blob/main/CHANGELOG.md).
 
 ---
-
 ## 🛠️ First-Time Setup
 
 Smart! has many keybinds, but you do not need to learn them all immediately.
@@ -234,6 +218,12 @@ Supported upgrade families include:
 - Conveyor belts and lifts.
 - Pipelines.
 - Power poles and wall outlets.
+
+### 6. Smart Restore Presets
+
+Smart Restore is a preset system for saving, applying, sharing, and replaying Smart Panel setups.
+
+Presets can capture grid size, spacing, steps, stagger, rotation, production recipe, auto-connect settings, and a restored Extend topology — a whole factory module layout. Use the Smart Panel's `Presets >>` button to save your current setup, apply a saved setup later, export or import a shared preset, or turn the last Extend layout you built into a reusable preset. Shared presets are checked against your current unlocks before they can be imported or applied.
 
 ---
 
@@ -662,7 +652,7 @@ No. Smart! is a different system. It can place grids and factory modules in ways
 
 ### Does Smart! work in multiplayer?
 
-Multiplayer is under active testing with partial success, but is not fully supported. If you play multiplayer, expect edge cases and report issues with clear reproduction steps.
+Yes — as of v32.0.0, every Smart! feature works in multiplayer on dedicated servers (Windows and Linux). Install the same Smart! version on the server and on every client. Multiplayer support is new, so if something behaves differently in a multiplayer session than in single-player, that's a bug — please report it with clear reproduction steps.
 
 ### Why did Extend not copy my layout?
 


### PR DESCRIPTION
## Summary

The multiplayer release. Every Smart! feature now works in multiplayer on dedicated servers — Windows **and** Linux — with normal build costs charged exactly as previewed:

- Grid scaling (factories and foundations)
- Belt / pipe / power auto-connect
- Extend and Scaled Extend
- Smart Upgrade (scan, audit, traversal, execution)
- Smart Restore presets
- Smart Dismantle

Architecture: client previews locally and ships a compact parameters-only spec; the server reconstructs and constructs each buildable individually under authority, so everything placed is a standard, fully replicated game building. This dissolves both the oversized-construct ceiling and the client-only ghost-actor class of bugs (#334).

## Closes

Closes #309, closes #334, closes #176, closes #359, closes #360.

## Also in this PR

- Linux dedicated server support: LinuxServer packaging targets, clang/SysV portability fixes, int-overflow fix in grid validation
- Smart Dismantle fix for restored single modules (#359, found in the SP regression sweep)
- Conveyor-chain hygiene: cleanup during build/upgrade plus a load-time repair sweep that also heals saves from earlier versions (#360)
- Release docs: CHANGELOG 32.0.0 (new Multiplayer section convention), version bump to 32.0.0, ficsit.app page refresh (MP badge flip, What''s New restructure, Restore presets documented under Core Features)

## Validation

- Full MP feature matrix live-validated on Windows AND Linux dedicated servers (client CL-493833, servers matched)
- Non-creative costs validated: deduction exactly matches preview
- SP regression sweep passed (one find, fixed: #359)
- Save/reload boot regression clean on both server platforms

## Note for the merge

Builds from this tree carry a required local SML header fix for Linux servers (SysV sret parameter order in the native hook invoker); an upstream SML report/PR is being filed separately. Windows builds are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)